### PR TITLE
Feature/lwe discarding encryption for views

### DIFF
--- a/concrete-core-bench/src/core.rs
+++ b/concrete-core-bench/src/core.rs
@@ -75,6 +75,7 @@ bench! {
     (LweCiphertextVectorZeroEncryptionFixture, (LweSecretKey, LweCiphertextVector)),
     (LweCiphertextDecryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
     (LweCiphertextDiscardingEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
+    (LweCiphertextDiscardingEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertextMutView)),
     (LweCiphertextVectorDecryptionFixture, (PlaintextVector, LweSecretKey, LweCiphertextVector)),
     (LweCiphertextVectorEncryptionFixture, (PlaintextVector, LweSecretKey, LweCiphertextVector)),
     (LweCiphertextVectorDiscardingEncryptionFixture, (PlaintextVector, LweSecretKey,

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -80,6 +80,7 @@ test! {
     (LweCiphertextVectorZeroEncryptionFixture, (LweSecretKey, LweCiphertextVector)),
     (LweCiphertextDecryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
     (LweCiphertextDiscardingEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
+    (LweCiphertextDiscardingEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertextMutView)),
     (LweCiphertextVectorDecryptionFixture, (PlaintextVector, LweSecretKey, LweCiphertextVector)),
     (LweCiphertextVectorEncryptionFixture, (PlaintextVector, LweSecretKey, LweCiphertextVector)),
     (LweCiphertextVectorDiscardingEncryptionFixture, (PlaintextVector, LweSecretKey,

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_encryption.rs
@@ -2,7 +2,8 @@ use concrete_commons::dispersion::Variance;
 
 use crate::backends::core::implementation::engines::CoreEngine;
 use crate::backends::core::implementation::entities::{
-    LweCiphertext32, LweCiphertext64, LweSecretKey32, LweSecretKey64, Plaintext32, Plaintext64,
+    LweCiphertext32, LweCiphertext64, LweCiphertextMutView32, LweCiphertextMutView64,
+    LweSecretKey32, LweSecretKey64, Plaintext32, Plaintext64,
 };
 use crate::specification::engines::{
     LweCiphertextDiscardingEncryptionEngine, LweCiphertextDiscardingEncryptionError,
@@ -124,6 +125,142 @@ impl LweCiphertextDiscardingEncryptionEngine<LweSecretKey64, Plaintext64, LweCip
         &mut self,
         key: &LweSecretKey64,
         output: &mut LweCiphertext64,
+        input: &Plaintext64,
+        noise: Variance,
+    ) {
+        key.0.encrypt_lwe(
+            &mut output.0,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextDiscardingEncryptionEngine`] for [`CoreEngine`] that operates
+/// on 32 bits integers.
+impl
+    LweCiphertextDiscardingEncryptionEngine<LweSecretKey32, Plaintext32, LweCiphertextMutView32<'_>>
+    for CoreEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u32 << 20;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// let mut engine = CoreEngine::new(())?;
+    /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let plaintext = engine.create_plaintext(&input)?;
+    ///
+    /// let mut output_cipertext_container = vec![0_32; lwe_dimension.to_lwe_size().0];
+    /// let mut output_ciphertext: LweCiphertextMutView32 =
+    ///     engine.create_lwe_ciphertext(&mut output_cipertext_container[..])?;
+    ///
+    /// engine.discard_encrypt_lwe_ciphertext(&key, &mut output_ciphertext, &plaintext, noise)?;
+    /// #
+    /// assert_eq!(output_ciphertext.lwe_dimension(), lwe_dimension);
+    ///
+    /// engine.destroy(key)?;
+    /// engine.destroy(plaintext)?;
+    /// engine.destroy(output_ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_encrypt_lwe_ciphertext(
+        &mut self,
+        key: &LweSecretKey32,
+        output: &mut LweCiphertextMutView32,
+        input: &Plaintext32,
+        noise: Variance,
+    ) -> Result<(), LweCiphertextDiscardingEncryptionError<Self::EngineError>> {
+        LweCiphertextDiscardingEncryptionError::perform_generic_checks(key, output)?;
+        unsafe { self.discard_encrypt_lwe_ciphertext_unchecked(key, output, input, noise) };
+        Ok(())
+    }
+
+    unsafe fn discard_encrypt_lwe_ciphertext_unchecked(
+        &mut self,
+        key: &LweSecretKey32,
+        output: &mut LweCiphertextMutView32,
+        input: &Plaintext32,
+        noise: Variance,
+    ) {
+        key.0.encrypt_lwe(
+            &mut output.0,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextDiscardingEncryptionEngine`] for [`CoreEngine`] that operates
+/// on 64 bits integers.
+impl
+    LweCiphertextDiscardingEncryptionEngine<LweSecretKey64, Plaintext64, LweCiphertextMutView64<'_>>
+    for CoreEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = 3_u64 << 50;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// let mut engine = CoreEngine::new(())?;
+    /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let plaintext = engine.create_plaintext(&input)?;
+    ///
+    /// let mut output_cipertext_container = vec![0_64; lwe_dimension.to_lwe_size().0];
+    /// let mut output_ciphertext: LweCiphertextMutView64 =
+    ///     engine.create_lwe_ciphertext(&mut output_cipertext_container[..])?;
+    ///
+    /// engine.discard_encrypt_lwe_ciphertext(&key, &mut output_ciphertext, &plaintext, noise)?;
+    /// #
+    /// assert_eq!(output_ciphertext.lwe_dimension(), lwe_dimension);
+    ///
+    /// engine.destroy(key)?;
+    /// engine.destroy(plaintext)?;
+    /// engine.destroy(output_ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_encrypt_lwe_ciphertext(
+        &mut self,
+        key: &LweSecretKey64,
+        output: &mut LweCiphertextMutView64,
+        input: &Plaintext64,
+        noise: Variance,
+    ) -> Result<(), LweCiphertextDiscardingEncryptionError<Self::EngineError>> {
+        LweCiphertextDiscardingEncryptionError::perform_generic_checks(key, output)?;
+        unsafe { self.discard_encrypt_lwe_ciphertext_unchecked(key, output, input, noise) };
+        Ok(())
+    }
+
+    unsafe fn discard_encrypt_lwe_ciphertext_unchecked(
+        &mut self,
+        key: &LweSecretKey64,
+        output: &mut LweCiphertextMutView64,
         input: &Plaintext64,
         noise: Variance,
     ) {


### PR DESCRIPTION
### Resolves:

closes https://github.com/zama-ai/concrete-core-internal/issues/99

### Description

The compiler used an encryption in an already provided ciphertext, this corresponds to a discarding encryption. This PR adds the implementation of the discarding encryption for LweCiphertextMutViews, it was added to the bench and test apps

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
