### PR TITLE
Feature/additional view engines for compiler

### DIFF
--- a/concrete-core-bench/src/core.rs
+++ b/concrete-core-bench/src/core.rs
@@ -107,6 +107,8 @@ bench! {
     (LweCiphertextPlaintextFusingSubtractionFixture, (Plaintext, LweCiphertext)),
     (LweCiphertextDiscardingBootstrapFixture1, (FourierLweBootstrapKey, GlweCiphertext, LweCiphertext, LweCiphertext)),
     (LweCiphertextDiscardingBootstrapFixture2, (FourierLweBootstrapKey, GlweCiphertext, LweCiphertext, LweCiphertext)),
+    (LweCiphertextDiscardingBootstrapFixture1, (FourierLweBootstrapKey, GlweCiphertextView, LweCiphertextView, LweCiphertextMutView)),
+    (LweCiphertextDiscardingBootstrapFixture2, (FourierLweBootstrapKey, GlweCiphertextView, LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextDiscardingExtractionFixture, (GlweCiphertext, LweCiphertext)),
     (LweCiphertextVectorGlweCiphertextDiscardingPackingKeyswitchFixture, (LweCiphertextVector,
         PackingKeyswitchKey, GlweCiphertext)),

--- a/concrete-core-bench/src/core.rs
+++ b/concrete-core-bench/src/core.rs
@@ -74,6 +74,7 @@ bench! {
     (LweCiphertextTrivialDecryptionFixture, (Plaintext, LweCiphertext)),
     (LweCiphertextVectorZeroEncryptionFixture, (LweSecretKey, LweCiphertextVector)),
     (LweCiphertextDecryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
+    (LweCiphertextDecryptionFixture, (Plaintext, LweSecretKey, LweCiphertextView)),
     (LweCiphertextDiscardingEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
     (LweCiphertextDiscardingEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertextMutView)),
     (LweCiphertextVectorDecryptionFixture, (PlaintextVector, LweSecretKey, LweCiphertextVector)),

--- a/concrete-core-bench/src/core.rs
+++ b/concrete-core-bench/src/core.rs
@@ -93,6 +93,7 @@ bench! {
     (LweCiphertextVectorDiscardingAdditionFixture, (LweCiphertextVector, LweCiphertextVector)),
     (LweCiphertextVectorDiscardingAffineTransformationFixture, (LweCiphertextVector, CleartextVector, Plaintext, LweCiphertext)),
     (LweCiphertextDiscardingKeyswitchFixture, (LweKeyswitchKey, LweCiphertext, LweCiphertext)),
+    (LweCiphertextDiscardingKeyswitchFixture, (LweKeyswitchKey, LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextDiscardingAdditionFixture, (LweCiphertext, LweCiphertext)),
     (LweCiphertextDiscardingOppositeFixture, (LweCiphertext, LweCiphertext)),
     (LweCiphertextFusingAdditionFixture, (LweCiphertext, LweCiphertext)),

--- a/concrete-core-bench/src/core.rs
+++ b/concrete-core-bench/src/core.rs
@@ -97,6 +97,7 @@ bench! {
     (LweCiphertextDiscardingKeyswitchFixture, (LweKeyswitchKey, LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextDiscardingAdditionFixture, (LweCiphertext, LweCiphertext)),
     (LweCiphertextDiscardingOppositeFixture, (LweCiphertext, LweCiphertext)),
+    (LweCiphertextDiscardingOppositeFixture, (LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextFusingAdditionFixture, (LweCiphertext, LweCiphertext)),
     (LweCiphertextVectorTrivialDecryptionFixture, (PlaintextVector, LweCiphertextVector)),
     (LweCiphertextVectorTrivialEncryptionFixture, (PlaintextVector, LweCiphertextVector)),

--- a/concrete-core-bench/src/core.rs
+++ b/concrete-core-bench/src/core.rs
@@ -84,6 +84,7 @@ bench! {
     (LweCiphertextVectorDiscardingDecryptionFixture, (PlaintextVector, LweSecretKey,
         LweCiphertextVector)),
     (LweCiphertextCleartextDiscardingMultiplicationFixture, (LweCiphertext, Cleartext, LweCiphertext)),
+    (LweCiphertextCleartextDiscardingMultiplicationFixture, (LweCiphertextView, Cleartext, LweCiphertextMutView)),
     (LweCiphertextCleartextFusingMultiplicationFixture, (LweCiphertext, Cleartext)),
     (LweCiphertextFusingOppositeFixture, (LweCiphertext)),
     (LweCiphertextFusingSubtractionFixture, (LweCiphertext, LweCiphertext)),

--- a/concrete-core-bench/src/core.rs
+++ b/concrete-core-bench/src/core.rs
@@ -105,6 +105,7 @@ bench! {
     (LweCiphertextDiscardingSubtractionFixture, (LweCiphertext, LweCiphertext)),
     (LweCiphertextDiscardingDecryptionFixture, (LweCiphertext, LweSecretKey, Plaintext)),
     (LweCiphertextPlaintextDiscardingAdditionFixture, (LweCiphertext, Plaintext, LweCiphertext)),
+    (LweCiphertextPlaintextDiscardingAdditionFixture, (LweCiphertextView, Plaintext, LweCiphertextMutView)),
     (LweCiphertextPlaintextFusingAdditionFixture, (Plaintext, LweCiphertext)),
     (LweCiphertextPlaintextDiscardingSubtractionFixture, (LweCiphertext, Plaintext, LweCiphertext)),
     (LweCiphertextPlaintextFusingSubtractionFixture, (Plaintext, LweCiphertext)),

--- a/concrete-core-bench/src/core.rs
+++ b/concrete-core-bench/src/core.rs
@@ -96,6 +96,7 @@ bench! {
     (LweCiphertextDiscardingKeyswitchFixture, (LweKeyswitchKey, LweCiphertext, LweCiphertext)),
     (LweCiphertextDiscardingKeyswitchFixture, (LweKeyswitchKey, LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextDiscardingAdditionFixture, (LweCiphertext, LweCiphertext)),
+    (LweCiphertextDiscardingAdditionFixture, (LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextDiscardingOppositeFixture, (LweCiphertext, LweCiphertext)),
     (LweCiphertextDiscardingOppositeFixture, (LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextFusingAdditionFixture, (LweCiphertext, LweCiphertext)),

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -89,6 +89,7 @@ test! {
     (LweCiphertextVectorDiscardingDecryptionFixture, (PlaintextVector, LweSecretKey,
         LweCiphertextVector)),
     (LweCiphertextCleartextDiscardingMultiplicationFixture, (LweCiphertext, Cleartext, LweCiphertext)),
+    (LweCiphertextCleartextDiscardingMultiplicationFixture, (LweCiphertextView, Cleartext, LweCiphertextMutView)),
     (LweCiphertextCleartextFusingMultiplicationFixture, (LweCiphertext, Cleartext)),
     (LweCiphertextFusingOppositeFixture, (LweCiphertext)),
     (LweCiphertextFusingSubtractionFixture, (LweCiphertext, LweCiphertext)),

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -101,6 +101,7 @@ test! {
     (LweCiphertextDiscardingKeyswitchFixture, (LweKeyswitchKey, LweCiphertext, LweCiphertext)),
     (LweCiphertextDiscardingKeyswitchFixture, (LweKeyswitchKey, LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextDiscardingAdditionFixture, (LweCiphertext, LweCiphertext)),
+    (LweCiphertextDiscardingAdditionFixture, (LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextDiscardingOppositeFixture, (LweCiphertext, LweCiphertext)),
     (LweCiphertextDiscardingOppositeFixture, (LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextFusingAdditionFixture, (LweCiphertext, LweCiphertext)),

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -110,6 +110,7 @@ test! {
     (LweCiphertextDiscardingSubtractionFixture, (LweCiphertext, LweCiphertext)),
     (LweCiphertextDiscardingDecryptionFixture, (LweCiphertext, LweSecretKey, Plaintext)),
     (LweCiphertextPlaintextDiscardingAdditionFixture, (LweCiphertext, Plaintext, LweCiphertext)),
+    (LweCiphertextPlaintextDiscardingAdditionFixture, (LweCiphertextView, Plaintext, LweCiphertextMutView)),
     (LweCiphertextPlaintextFusingAdditionFixture, (Plaintext, LweCiphertext)),
     (LweCiphertextPlaintextDiscardingSubtractionFixture, (LweCiphertext, Plaintext, LweCiphertext)),
     (LweCiphertextPlaintextFusingSubtractionFixture, (Plaintext, LweCiphertext)),

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -98,6 +98,7 @@ test! {
     (LweCiphertextVectorDiscardingAdditionFixture, (LweCiphertextVector, LweCiphertextVector)),
     (LweCiphertextVectorDiscardingAffineTransformationFixture, (LweCiphertextVector, CleartextVector, Plaintext, LweCiphertext)),
     (LweCiphertextDiscardingKeyswitchFixture, (LweKeyswitchKey, LweCiphertext, LweCiphertext)),
+    (LweCiphertextDiscardingKeyswitchFixture, (LweKeyswitchKey, LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextDiscardingAdditionFixture, (LweCiphertext, LweCiphertext)),
     (LweCiphertextDiscardingOppositeFixture, (LweCiphertext, LweCiphertext)),
     (LweCiphertextFusingAdditionFixture, (LweCiphertext, LweCiphertext)),

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -102,6 +102,7 @@ test! {
     (LweCiphertextDiscardingKeyswitchFixture, (LweKeyswitchKey, LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextDiscardingAdditionFixture, (LweCiphertext, LweCiphertext)),
     (LweCiphertextDiscardingOppositeFixture, (LweCiphertext, LweCiphertext)),
+    (LweCiphertextDiscardingOppositeFixture, (LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextFusingAdditionFixture, (LweCiphertext, LweCiphertext)),
     (LweCiphertextVectorTrivialDecryptionFixture, (PlaintextVector, LweCiphertextVector)),
     (LweCiphertextVectorTrivialEncryptionFixture, (PlaintextVector, LweCiphertextVector)),

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -79,6 +79,7 @@ test! {
     (LweCiphertextTrivialDecryptionFixture, (Plaintext, LweCiphertext)),
     (LweCiphertextVectorZeroEncryptionFixture, (LweSecretKey, LweCiphertextVector)),
     (LweCiphertextDecryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
+    (LweCiphertextDecryptionFixture, (Plaintext, LweSecretKey, LweCiphertextView)),
     (LweCiphertextDiscardingEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
     (LweCiphertextDiscardingEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertextMutView)),
     (LweCiphertextVectorDecryptionFixture, (PlaintextVector, LweSecretKey, LweCiphertextVector)),

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -112,6 +112,8 @@ test! {
     (LweCiphertextPlaintextFusingSubtractionFixture, (Plaintext, LweCiphertext)),
     (LweCiphertextDiscardingBootstrapFixture1, (FourierLweBootstrapKey, GlweCiphertext, LweCiphertext, LweCiphertext)),
     (LweCiphertextDiscardingBootstrapFixture2, (FourierLweBootstrapKey, GlweCiphertext, LweCiphertext, LweCiphertext)),
+    (LweCiphertextDiscardingBootstrapFixture1, (FourierLweBootstrapKey, GlweCiphertextView, LweCiphertextView, LweCiphertextMutView)),
+    (LweCiphertextDiscardingBootstrapFixture2, (FourierLweBootstrapKey, GlweCiphertextView, LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextDiscardingExtractionFixture, (GlweCiphertext, LweCiphertext)),
     (LweCiphertextVectorGlweCiphertextDiscardingPackingKeyswitchFixture, (LweCiphertextVector,
         PackingKeyswitchKey, GlweCiphertext)),

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_cleartext_discarding_multiplication.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_cleartext_discarding_multiplication.rs
@@ -1,6 +1,7 @@
 use crate::backends::core::implementation::engines::CoreEngine;
 use crate::backends::core::implementation::entities::{
-    Cleartext32, Cleartext64, LweCiphertext32, LweCiphertext64,
+    Cleartext32, Cleartext64, LweCiphertext32, LweCiphertext64, LweCiphertextMutView32,
+    LweCiphertextMutView64, LweCiphertextView32, LweCiphertextView64,
 };
 use crate::specification::engines::{
     LweCiphertextCleartextDiscardingMultiplicationEngine,
@@ -137,6 +138,164 @@ impl
         &mut self,
         output: &mut LweCiphertext64,
         input_1: &LweCiphertext64,
+        input_2: &Cleartext64,
+    ) {
+        output.0.fill_with_scalar_mul(&input_1.0, &input_2.0);
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextCleartextDiscardingMultiplicationEngine`] for [`CoreEngine`]
+/// that operates on views containing 32 bits integers.
+impl
+    LweCiphertextCleartextDiscardingMultiplicationEngine<
+        LweCiphertextView32<'_>,
+        Cleartext32,
+        LweCiphertextMutView32<'_>,
+    > for CoreEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u32 << 20;
+    /// let cleartext_input = 12_u32;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// let mut engine = CoreEngine::new(())?;
+    /// let cleartext: Cleartext32 = engine.create_cleartext(&cleartext_input)?;
+    /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let plaintext = engine.create_plaintext(&input)?;
+    ///
+    /// let mut ciphertext_1_container = vec![0_u32; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_1: LweCiphertextMutView32 =
+    ///     engine.create_lwe_ciphertext(&mut ciphertext_1_container[..])?;
+    /// engine.discard_encrypt_lwe_ciphertext(&key, &mut ciphertext_1, &plaintext, noise)?;
+    ///
+    /// // Convert MutView to View
+    /// let raw_ciphertext_1 = engine.consume_retrieve_lwe_ciphertext(ciphertext_1)?;
+    /// let ciphertext_1: LweCiphertextView32 = engine.create_lwe_ciphertext(&raw_ciphertext_1[..])?;
+    ///
+    /// let mut ciphertext_2_container = vec![0_u32; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_2: LweCiphertextMutView32 =
+    ///     engine.create_lwe_ciphertext(&mut ciphertext_2_container[..])?;
+    ///
+    /// engine.discard_mul_lwe_ciphertext_cleartext(&mut ciphertext_2, &ciphertext_1, &cleartext)?;
+    /// #
+    /// assert_eq!(ciphertext_2.lwe_dimension(), lwe_dimension);
+    ///
+    /// engine.destroy(cleartext)?;
+    /// engine.destroy(key)?;
+    /// engine.destroy(plaintext)?;
+    /// engine.destroy(ciphertext_1)?;
+    /// engine.destroy(ciphertext_2)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_mul_lwe_ciphertext_cleartext(
+        &mut self,
+        output: &mut LweCiphertextMutView32,
+        input_1: &LweCiphertextView32,
+        input_2: &Cleartext32,
+    ) -> Result<(), LweCiphertextCleartextDiscardingMultiplicationError<Self::EngineError>> {
+        LweCiphertextCleartextDiscardingMultiplicationError::perform_generic_checks(
+            output, input_1,
+        )?;
+        unsafe { self.discard_mul_lwe_ciphertext_cleartext_unchecked(output, input_1, input_2) };
+        Ok(())
+    }
+
+    unsafe fn discard_mul_lwe_ciphertext_cleartext_unchecked(
+        &mut self,
+        output: &mut LweCiphertextMutView32,
+        input_1: &LweCiphertextView32,
+        input_2: &Cleartext32,
+    ) {
+        output.0.fill_with_scalar_mul(&input_1.0, &input_2.0);
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextCleartextDiscardingMultiplicationEngine`] for [`CoreEngine`]
+/// that operates on views containing 64 bits integers.
+impl
+    LweCiphertextCleartextDiscardingMultiplicationEngine<
+        LweCiphertextView64<'_>,
+        Cleartext64,
+        LweCiphertextMutView64<'_>,
+    > for CoreEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = 3_u64 << 50;
+    /// let cleartext_input = 12_u64;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// let mut engine = CoreEngine::new(())?;
+    /// let cleartext: Cleartext64 = engine.create_cleartext(&cleartext_input)?;
+    /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let plaintext = engine.create_plaintext(&input)?;
+    ///
+    /// let mut ciphertext_1_container = vec![0_u64; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_1: LweCiphertextMutView64 =
+    ///     engine.create_lwe_ciphertext(&mut ciphertext_1_container[..])?;
+    /// engine.discard_encrypt_lwe_ciphertext(&key, &mut ciphertext_1, &plaintext, noise)?;
+    ///
+    /// // Convert MutView to View
+    /// let raw_ciphertext_1 = engine.consume_retrieve_lwe_ciphertext(ciphertext_1)?;
+    /// let ciphertext_1: LweCiphertextView64 = engine.create_lwe_ciphertext(&raw_ciphertext_1[..])?;
+    ///
+    /// let mut ciphertext_2_container = vec![0_u64; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_2: LweCiphertextMutView64 =
+    ///     engine.create_lwe_ciphertext(&mut ciphertext_2_container[..])?;
+    ///
+    /// engine.discard_mul_lwe_ciphertext_cleartext(&mut ciphertext_2, &ciphertext_1, &cleartext)?;
+    /// #
+    /// assert_eq!(ciphertext_2.lwe_dimension(), lwe_dimension);
+    ///
+    /// engine.destroy(cleartext)?;
+    /// engine.destroy(key)?;
+    /// engine.destroy(plaintext)?;
+    /// engine.destroy(ciphertext_1)?;
+    /// engine.destroy(ciphertext_2)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_mul_lwe_ciphertext_cleartext(
+        &mut self,
+        output: &mut LweCiphertextMutView64,
+        input_1: &LweCiphertextView64,
+        input_2: &Cleartext64,
+    ) -> Result<(), LweCiphertextCleartextDiscardingMultiplicationError<Self::EngineError>> {
+        LweCiphertextCleartextDiscardingMultiplicationError::perform_generic_checks(
+            output, input_1,
+        )?;
+        unsafe { self.discard_mul_lwe_ciphertext_cleartext_unchecked(output, input_1, input_2) };
+        Ok(())
+    }
+
+    unsafe fn discard_mul_lwe_ciphertext_cleartext_unchecked(
+        &mut self,
+        output: &mut LweCiphertextMutView64,
+        input_1: &LweCiphertextView64,
         input_2: &Cleartext64,
     ) {
         output.0.fill_with_scalar_mul(&input_1.0, &input_2.0);

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_decryption.rs
@@ -1,6 +1,7 @@
 use crate::backends::core::implementation::engines::CoreEngine;
 use crate::backends::core::implementation::entities::{
-    LweCiphertext32, LweCiphertext64, LweSecretKey32, LweSecretKey64, Plaintext32, Plaintext64,
+    LweCiphertext32, LweCiphertext64, LweCiphertextView32, LweCiphertextView64, LweSecretKey32,
+    LweSecretKey64, Plaintext32, Plaintext64,
 };
 use crate::backends::core::private::crypto::encoding::Plaintext as ImplPlaintext;
 use crate::specification::engines::{LweCiphertextDecryptionEngine, LweCiphertextDecryptionError};
@@ -102,6 +103,130 @@ impl LweCiphertextDecryptionEngine<LweSecretKey64, LweCiphertext64, Plaintext64>
         &mut self,
         key: &LweSecretKey64,
         input: &LweCiphertext64,
+    ) -> Plaintext64 {
+        let mut plaintext = ImplPlaintext(0u64);
+        key.0.decrypt_lwe(&mut plaintext, &input.0);
+        Plaintext64(plaintext)
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextDecryptionEngine`] for [`CoreEngine`] that operates on
+/// an [`LweCiphertextView32`] containing 32 bits integers.
+impl LweCiphertextDecryptionEngine<LweSecretKey32, LweCiphertextView32<'_>, Plaintext32>
+    for CoreEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u32 << 20;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// let mut engine = CoreEngine::new(())?;
+    /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let plaintext = engine.create_plaintext(&input)?;
+    ///
+    /// let mut raw_ciphertext = vec![0_u32; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_view: LweCiphertextMutView32 =
+    ///     engine.create_lwe_ciphertext(&mut raw_ciphertext[..])?;
+    /// engine.discard_encrypt_lwe_ciphertext(&key, &mut ciphertext_view, &plaintext, noise)?;
+    ///
+    /// // Convert MutView to View
+    /// let raw_ciphertext = engine.consume_retrieve_lwe_ciphertext(ciphertext_view)?;
+    /// let ciphertext_view: LweCiphertextView32 = engine.create_lwe_ciphertext(&raw_ciphertext[..])?;
+    ///
+    /// let decrypted_plaintext = engine.decrypt_lwe_ciphertext(&key, &ciphertext_view)?;
+    ///
+    /// engine.destroy(key)?;
+    /// engine.destroy(plaintext)?;
+    /// engine.destroy(ciphertext_view)?;
+    /// engine.destroy(decrypted_plaintext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn decrypt_lwe_ciphertext(
+        &mut self,
+        key: &LweSecretKey32,
+        input: &LweCiphertextView32<'_>,
+    ) -> Result<Plaintext32, LweCiphertextDecryptionError<Self::EngineError>> {
+        Ok(unsafe { self.decrypt_lwe_ciphertext_unchecked(key, input) })
+    }
+
+    unsafe fn decrypt_lwe_ciphertext_unchecked(
+        &mut self,
+        key: &LweSecretKey32,
+        input: &LweCiphertextView32<'_>,
+    ) -> Plaintext32 {
+        let mut plaintext = ImplPlaintext(0u32);
+        key.0.decrypt_lwe(&mut plaintext, &input.0);
+        Plaintext32(plaintext)
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextDecryptionEngine`] for [`CoreEngine`] that operates on
+/// an [`LweCiphertextView64`] containing 64 bits integers.
+impl LweCiphertextDecryptionEngine<LweSecretKey64, LweCiphertextView64<'_>, Plaintext64>
+    for CoreEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u64 << 20;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// let mut engine = CoreEngine::new(())?;
+    /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let plaintext = engine.create_plaintext(&input)?;
+    ///
+    /// let mut raw_ciphertext = vec![0_u64; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_view: LweCiphertextMutView64 =
+    ///     engine.create_lwe_ciphertext(&mut raw_ciphertext[..])?;
+    /// engine.discard_encrypt_lwe_ciphertext(&key, &mut ciphertext_view, &plaintext, noise)?;
+    ///
+    /// // Convert MutView to View
+    /// let raw_ciphertext = engine.consume_retrieve_lwe_ciphertext(ciphertext_view)?;
+    /// let ciphertext_view: LweCiphertextView64 = engine.create_lwe_ciphertext(&raw_ciphertext[..])?;
+    ///
+    /// let decrypted_plaintext = engine.decrypt_lwe_ciphertext(&key, &ciphertext_view)?;
+    ///
+    /// engine.destroy(key)?;
+    /// engine.destroy(plaintext)?;
+    /// engine.destroy(ciphertext_view)?;
+    /// engine.destroy(decrypted_plaintext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn decrypt_lwe_ciphertext(
+        &mut self,
+        key: &LweSecretKey64,
+        input: &LweCiphertextView64<'_>,
+    ) -> Result<Plaintext64, LweCiphertextDecryptionError<Self::EngineError>> {
+        Ok(unsafe { self.decrypt_lwe_ciphertext_unchecked(key, input) })
+    }
+
+    unsafe fn decrypt_lwe_ciphertext_unchecked(
+        &mut self,
+        key: &LweSecretKey64,
+        input: &LweCiphertextView64<'_>,
     ) -> Plaintext64 {
         let mut plaintext = ImplPlaintext(0u64);
         key.0.decrypt_lwe(&mut plaintext, &input.0);

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_addition.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_addition.rs
@@ -1,5 +1,8 @@
 use crate::backends::core::implementation::engines::CoreEngine;
-use crate::backends::core::implementation::entities::{LweCiphertext32, LweCiphertext64};
+use crate::backends::core::implementation::entities::{
+    LweCiphertext32, LweCiphertext64, LweCiphertextMutView32, LweCiphertextMutView64,
+    LweCiphertextView32, LweCiphertextView64,
+};
 use crate::backends::core::private::math::tensor::{AsMutTensor, AsRefTensor};
 use crate::specification::engines::{
     LweCiphertextDiscardingAdditionEngine, LweCiphertextDiscardingAdditionError,
@@ -128,6 +131,174 @@ impl LweCiphertextDiscardingAdditionEngine<LweCiphertext64, LweCiphertext64> for
         output: &mut LweCiphertext64,
         input_1: &LweCiphertext64,
         input_2: &LweCiphertext64,
+    ) {
+        output
+            .0
+            .as_mut_tensor()
+            .fill_with_copy(input_1.0.as_tensor());
+        output.0.update_with_add(&input_2.0);
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextDiscardingAdditionEngine`] for [`CoreEngine`] that operates on
+/// views containing 32 bits integers.
+impl LweCiphertextDiscardingAdditionEngine<LweCiphertextView32<'_>, LweCiphertextMutView32<'_>>
+    for CoreEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input_1 = 3_u32 << 20;
+    /// let input_2 = 7_u32 << 20;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// let mut engine = CoreEngine::new(())?;
+    /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let plaintext_1 = engine.create_plaintext(&input_1)?;
+    /// let plaintext_2 = engine.create_plaintext(&input_2)?;
+    ///
+    /// let mut ciphertext_1_container = vec![0_u32; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_1: LweCiphertextMutView32 =
+    ///     engine.create_lwe_ciphertext(&mut ciphertext_1_container[..])?;
+    /// engine.discard_encrypt_lwe_ciphertext(&key, &mut ciphertext_1, &plaintext_1, noise)?;
+    /// let mut ciphertext_2_container = vec![0_u32; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_2: LweCiphertextMutView32 =
+    ///     engine.create_lwe_ciphertext(&mut ciphertext_2_container[..])?;
+    /// engine.discard_encrypt_lwe_ciphertext(&key, &mut ciphertext_2, &plaintext_2, noise)?;
+    ///
+    /// // Convert MutView to View
+    /// let raw_ciphertext_1 = engine.consume_retrieve_lwe_ciphertext(ciphertext_1)?;
+    /// let ciphertext_1: LweCiphertextView32 = engine.create_lwe_ciphertext(&raw_ciphertext_1[..])?;
+    /// let raw_ciphertext_2 = engine.consume_retrieve_lwe_ciphertext(ciphertext_2)?;
+    /// let ciphertext_2: LweCiphertextView32 = engine.create_lwe_ciphertext(&raw_ciphertext_2[..])?;
+    ///
+    /// let mut ciphertext_3_container = vec![0_u32; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_3: LweCiphertextMutView32 =
+    ///     engine.create_lwe_ciphertext(&mut ciphertext_3_container[..])?;
+    ///
+    /// engine.discard_add_lwe_ciphertext(&mut ciphertext_3, &ciphertext_1, &ciphertext_2)?;
+    /// #
+    /// assert_eq!(ciphertext_3.lwe_dimension(), lwe_dimension);
+    ///
+    /// engine.destroy(key)?;
+    /// engine.destroy(plaintext_1)?;
+    /// engine.destroy(plaintext_2)?;
+    /// engine.destroy(ciphertext_1)?;
+    /// engine.destroy(ciphertext_2)?;
+    /// engine.destroy(ciphertext_3)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_add_lwe_ciphertext(
+        &mut self,
+        output: &mut LweCiphertextMutView32,
+        input_1: &LweCiphertextView32,
+        input_2: &LweCiphertextView32,
+    ) -> Result<(), LweCiphertextDiscardingAdditionError<Self::EngineError>> {
+        LweCiphertextDiscardingAdditionError::perform_generic_checks(output, input_1, input_2)?;
+        unsafe { self.discard_add_lwe_ciphertext_unchecked(output, input_1, input_2) };
+        Ok(())
+    }
+
+    unsafe fn discard_add_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut LweCiphertextMutView32,
+        input_1: &LweCiphertextView32,
+        input_2: &LweCiphertextView32,
+    ) {
+        output
+            .0
+            .as_mut_tensor()
+            .fill_with_copy(input_1.0.as_tensor());
+        output.0.update_with_add(&input_2.0);
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextDiscardingAdditionEngine`] for [`CoreEngine`] that operates on
+/// on views containing 64 bits integers.
+impl LweCiphertextDiscardingAdditionEngine<LweCiphertextView64<'_>, LweCiphertextMutView64<'_>>
+    for CoreEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input_1 = 3_u64 << 50;
+    /// let input_2 = 7_u64 << 50;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// let mut engine = CoreEngine::new(())?;
+    /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let plaintext_1 = engine.create_plaintext(&input_1)?;
+    /// let plaintext_2 = engine.create_plaintext(&input_2)?;
+    ///
+    /// let mut ciphertext_1_container = vec![0_u64; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_1: LweCiphertextMutView64 =
+    ///     engine.create_lwe_ciphertext(&mut ciphertext_1_container[..])?;
+    /// engine.discard_encrypt_lwe_ciphertext(&key, &mut ciphertext_1, &plaintext_1, noise)?;
+    /// let mut ciphertext_2_container = vec![0_u64; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_2: LweCiphertextMutView64 =
+    ///     engine.create_lwe_ciphertext(&mut ciphertext_2_container[..])?;
+    /// engine.discard_encrypt_lwe_ciphertext(&key, &mut ciphertext_2, &plaintext_2, noise)?;
+    ///
+    /// // Convert MutView to View
+    /// let raw_ciphertext_1 = engine.consume_retrieve_lwe_ciphertext(ciphertext_1)?;
+    /// let ciphertext_1: LweCiphertextView64 = engine.create_lwe_ciphertext(&raw_ciphertext_1[..])?;
+    /// let raw_ciphertext_2 = engine.consume_retrieve_lwe_ciphertext(ciphertext_2)?;
+    /// let ciphertext_2: LweCiphertextView64 = engine.create_lwe_ciphertext(&raw_ciphertext_2[..])?;
+    ///
+    /// let mut ciphertext_3_container = vec![0_u64; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_3: LweCiphertextMutView64 =
+    ///     engine.create_lwe_ciphertext(&mut ciphertext_3_container[..])?;
+    ///
+    /// engine.discard_add_lwe_ciphertext(&mut ciphertext_3, &ciphertext_1, &ciphertext_2)?;
+    /// #
+    /// assert_eq!(ciphertext_3.lwe_dimension(), lwe_dimension);
+    ///
+    /// engine.destroy(key)?;
+    /// engine.destroy(plaintext_1)?;
+    /// engine.destroy(plaintext_2)?;
+    /// engine.destroy(ciphertext_1)?;
+    /// engine.destroy(ciphertext_2)?;
+    /// engine.destroy(ciphertext_3)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_add_lwe_ciphertext(
+        &mut self,
+        output: &mut LweCiphertextMutView64,
+        input_1: &LweCiphertextView64,
+        input_2: &LweCiphertextView64,
+    ) -> Result<(), LweCiphertextDiscardingAdditionError<Self::EngineError>> {
+        LweCiphertextDiscardingAdditionError::perform_generic_checks(output, input_1, input_2)?;
+        unsafe { self.discard_add_lwe_ciphertext_unchecked(output, input_1, input_2) };
+        Ok(())
+    }
+
+    unsafe fn discard_add_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut LweCiphertextMutView64,
+        input_1: &LweCiphertextView64,
+        input_2: &LweCiphertextView64,
     ) {
         output
             .0

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_bootstrap.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_bootstrap.rs
@@ -1,7 +1,8 @@
 use crate::backends::core::implementation::engines::CoreEngine;
 use crate::backends::core::implementation::entities::{
     FourierLweBootstrapKey32, FourierLweBootstrapKey64, GlweCiphertext32, GlweCiphertext64,
-    LweCiphertext32, LweCiphertext64,
+    GlweCiphertextView32, GlweCiphertextView64, LweCiphertext32, LweCiphertext64,
+    LweCiphertextMutView32, LweCiphertextMutView64, LweCiphertextView32, LweCiphertextView64,
 };
 use crate::backends::core::private::math::fft::ALLOWED_POLY_SIZE;
 use crate::prelude::{CoreError, GlweCiphertextEntity, LweBootstrapKeyEntity};
@@ -197,6 +198,226 @@ impl
         output: &mut LweCiphertext64,
         input: &LweCiphertext64,
         acc: &GlweCiphertext64,
+        bsk: &FourierLweBootstrapKey64,
+    ) {
+        let buffers =
+            self.get_fourier_u64_buffer(bsk.polynomial_size(), bsk.glwe_dimension().to_glwe_size());
+
+        bsk.0.bootstrap(&mut output.0, &input.0, &acc.0, buffers);
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextDiscardingBootstrapEngine`] for [`CoreEngine`] that operates on
+/// views containing 32 bits integers.
+impl
+    LweCiphertextDiscardingBootstrapEngine<
+        FourierLweBootstrapKey32,
+        GlweCiphertextView32<'_>,
+        LweCiphertextView32<'_>,
+        LweCiphertextMutView32<'_>,
+    > for CoreEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u32 << 20;
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let (lwe_dim, lwe_dim_output, glwe_dim, poly_size) = (
+    ///     LweDimension(4),
+    ///     LweDimension(1024),
+    ///     GlweDimension(1),
+    ///     PolynomialSize(1024),
+    /// );
+    /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
+    /// // A constant function is applied during the bootstrap
+    /// let lut = vec![8_u32 << 20; poly_size.0];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// let mut engine = CoreEngine::new(())?;
+    /// let lwe_sk: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dim)?;
+    /// let glwe_sk: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dim, poly_size)?;
+    /// let bsk: FourierLweBootstrapKey32 =
+    ///     engine.create_lwe_bootstrap_key(&lwe_sk, &glwe_sk, dec_bl, dec_lc, noise)?;
+    /// let lwe_sk_output: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dim_output)?;
+    /// let plaintext = engine.create_plaintext(&input)?;
+    /// let plaintext_vector = engine.create_plaintext_vector(&lut)?;
+    /// let acc =
+    ///     engine.trivially_encrypt_glwe_ciphertext(glwe_dim.to_glwe_size(), &plaintext_vector)?;
+    ///
+    /// // Get the GlweCiphertext as a View
+    /// let raw_glwe = engine.consume_retrieve_glwe_ciphertext(acc)?;
+    /// let acc: GlweCiphertextView32 = engine.create_glwe_ciphertext(&raw_glwe[..], poly_size)?;
+    ///
+    /// let mut raw_input_container = vec![0_u32; lwe_sk.lwe_dimension().to_lwe_size().0];
+    /// let input: LweCiphertextMutView32 =
+    ///     engine.create_lwe_ciphertext(&mut raw_input_container[..])?;
+    /// let input = engine.encrypt_lwe_ciphertext(&lwe_sk, &plaintext, noise)?;
+    ///
+    /// // Convert MutView to View
+    /// let raw_input = engine.consume_retrieve_lwe_ciphertext(input)?;
+    /// let input = engine.create_lwe_ciphertext(&raw_input[..])?;
+    ///
+    /// let mut raw_output_container = vec![0_u32; lwe_sk_output.lwe_dimension().to_lwe_size().0];
+    /// let mut output = engine.create_lwe_ciphertext(&mut raw_output_container[..])?;
+    ///
+    /// engine.discard_bootstrap_lwe_ciphertext(&mut output, &input, &acc, &bsk)?;
+    /// #
+    /// assert_eq!(output.lwe_dimension(), lwe_dim_output);
+    ///
+    /// engine.destroy(lwe_sk)?;
+    /// engine.destroy(glwe_sk)?;
+    /// engine.destroy(bsk)?;
+    /// engine.destroy(lwe_sk_output)?;
+    /// engine.destroy(plaintext)?;
+    /// engine.destroy(plaintext_vector)?;
+    /// engine.destroy(acc)?;
+    /// engine.destroy(input)?;
+    /// engine.destroy(output)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_bootstrap_lwe_ciphertext(
+        &mut self,
+        output: &mut LweCiphertextMutView32<'_>,
+        input: &LweCiphertextView32<'_>,
+        acc: &GlweCiphertextView32<'_>,
+        bsk: &FourierLweBootstrapKey32,
+    ) -> Result<(), LweCiphertextDiscardingBootstrapError<Self::EngineError>> {
+        if !ALLOWED_POLY_SIZE.contains(&acc.polynomial_size().0) {
+            return Err(LweCiphertextDiscardingBootstrapError::from(
+                CoreError::UnsupportedPolynomialSize,
+            ));
+        }
+        LweCiphertextDiscardingBootstrapError::perform_generic_checks(output, input, acc, bsk)?;
+        unsafe { self.discard_bootstrap_lwe_ciphertext_unchecked(output, input, acc, bsk) };
+        Ok(())
+    }
+
+    unsafe fn discard_bootstrap_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut LweCiphertextMutView32<'_>,
+        input: &LweCiphertextView32<'_>,
+        acc: &GlweCiphertextView32<'_>,
+        bsk: &FourierLweBootstrapKey32,
+    ) {
+        let buffers =
+            self.get_fourier_u32_buffer(bsk.polynomial_size(), bsk.glwe_dimension().to_glwe_size());
+
+        bsk.0.bootstrap(&mut output.0, &input.0, &acc.0, buffers);
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextDiscardingBootstrapEngine`] for [`CoreEngine`] that operates on
+/// views containing 64 bits integers.
+impl
+    LweCiphertextDiscardingBootstrapEngine<
+        FourierLweBootstrapKey64,
+        GlweCiphertextView64<'_>,
+        LweCiphertextView64<'_>,
+        LweCiphertextMutView64<'_>,
+    > for CoreEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = 3_u64 << 50;
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let (lwe_dim, lwe_dim_output, glwe_dim, poly_size) = (
+    ///     LweDimension(4),
+    ///     LweDimension(1024),
+    ///     GlweDimension(1),
+    ///     PolynomialSize(1024),
+    /// );
+    /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
+    /// // A constant function is applied during the bootstrap
+    /// let lut = vec![8_u64 << 50; poly_size.0];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// let mut engine = CoreEngine::new(())?;
+    /// let lwe_sk: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dim)?;
+    /// let glwe_sk: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dim, poly_size)?;
+    /// let bsk: FourierLweBootstrapKey64 =
+    ///     engine.create_lwe_bootstrap_key(&lwe_sk, &glwe_sk, dec_bl, dec_lc, noise)?;
+    /// let lwe_sk_output: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dim_output)?;
+    /// let plaintext = engine.create_plaintext(&input)?;
+    /// let plaintext_vector = engine.create_plaintext_vector(&lut)?;
+    /// let acc =
+    ///     engine.trivially_encrypt_glwe_ciphertext(glwe_dim.to_glwe_size(), &plaintext_vector)?;
+    ///
+    /// // Get the GlweCiphertext as a View
+    /// let raw_glwe = engine.consume_retrieve_glwe_ciphertext(acc)?;
+    /// let acc: GlweCiphertextView64 = engine.create_glwe_ciphertext(&raw_glwe[..], poly_size)?;
+    ///
+    /// let mut raw_input_container = vec![0_u64; lwe_sk.lwe_dimension().to_lwe_size().0];
+    /// let input: LweCiphertextMutView64 =
+    ///     engine.create_lwe_ciphertext(&mut raw_input_container[..])?;
+    /// let input = engine.encrypt_lwe_ciphertext(&lwe_sk, &plaintext, noise)?;
+    ///
+    /// // Convert MutView to View
+    /// let raw_input = engine.consume_retrieve_lwe_ciphertext(input)?;
+    /// let input = engine.create_lwe_ciphertext(&raw_input[..])?;
+    ///
+    /// let mut raw_output_container = vec![0_u64; lwe_sk_output.lwe_dimension().to_lwe_size().0];
+    /// let mut output = engine.create_lwe_ciphertext(&mut raw_output_container[..])?;
+    ///
+    /// engine.discard_bootstrap_lwe_ciphertext(&mut output, &input, &acc, &bsk)?;
+    /// #
+    /// assert_eq!(output.lwe_dimension(), lwe_dim_output);
+    ///
+    /// engine.destroy(lwe_sk)?;
+    /// engine.destroy(glwe_sk)?;
+    /// engine.destroy(bsk)?;
+    /// engine.destroy(lwe_sk_output)?;
+    /// engine.destroy(plaintext)?;
+    /// engine.destroy(plaintext_vector)?;
+    /// engine.destroy(acc)?;
+    /// engine.destroy(input)?;
+    /// engine.destroy(output)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_bootstrap_lwe_ciphertext(
+        &mut self,
+        output: &mut LweCiphertextMutView64<'_>,
+        input: &LweCiphertextView64<'_>,
+        acc: &GlweCiphertextView64<'_>,
+        bsk: &FourierLweBootstrapKey64,
+    ) -> Result<(), LweCiphertextDiscardingBootstrapError<Self::EngineError>> {
+        if !ALLOWED_POLY_SIZE.contains(&acc.polynomial_size().0) {
+            return Err(LweCiphertextDiscardingBootstrapError::from(
+                CoreError::UnsupportedPolynomialSize,
+            ));
+        }
+        LweCiphertextDiscardingBootstrapError::perform_generic_checks(output, input, acc, bsk)?;
+        unsafe { self.discard_bootstrap_lwe_ciphertext_unchecked(output, input, acc, bsk) };
+        Ok(())
+    }
+
+    unsafe fn discard_bootstrap_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut LweCiphertextMutView64<'_>,
+        input: &LweCiphertextView64<'_>,
+        acc: &GlweCiphertextView64<'_>,
         bsk: &FourierLweBootstrapKey64,
     ) {
         let buffers =

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_keyswitch.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_keyswitch.rs
@@ -1,6 +1,7 @@
 use crate::backends::core::implementation::engines::CoreEngine;
 use crate::backends::core::implementation::entities::{
-    LweCiphertext32, LweCiphertext64, LweKeyswitchKey32, LweKeyswitchKey64,
+    LweCiphertext32, LweCiphertext64, LweCiphertextMutView32, LweCiphertextMutView64,
+    LweCiphertextView32, LweCiphertextView64, LweKeyswitchKey32, LweKeyswitchKey64,
 };
 use crate::specification::engines::{
     LweCiphertextDiscardingKeyswitchEngine, LweCiphertextDiscardingKeyswitchError,
@@ -148,6 +149,184 @@ impl LweCiphertextDiscardingKeyswitchEngine<LweKeyswitchKey64, LweCiphertext64, 
         &mut self,
         output: &mut LweCiphertext64,
         input: &LweCiphertext64,
+        ksk: &LweKeyswitchKey64,
+    ) {
+        ksk.0.keyswitch_ciphertext(&mut output.0, &input.0);
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextDiscardingKeyswitchEngine`] for [`CoreEngine`] that operates on
+/// views containing 32 bits integers.
+impl
+    LweCiphertextDiscardingKeyswitchEngine<
+        LweKeyswitchKey32,
+        LweCiphertextView32<'_>,
+        LweCiphertextMutView32<'_>,
+    > for CoreEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, LweDimension,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let input_lwe_dimension = LweDimension(6);
+    /// let output_lwe_dimension = LweDimension(3);
+    /// let decomposition_level_count = DecompositionLevelCount(2);
+    /// let decomposition_base_log = DecompositionBaseLog(8);
+    /// let noise = Variance(2_f64.powf(-25.));
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u32 << 20;
+    ///
+    /// let mut engine = CoreEngine::new(())?;
+    /// let input_key: LweSecretKey32 = engine.create_lwe_secret_key(input_lwe_dimension)?;
+    /// let output_key: LweSecretKey32 = engine.create_lwe_secret_key(output_lwe_dimension)?;
+    /// let keyswitch_key = engine.create_lwe_keyswitch_key(
+    ///     &input_key,
+    ///     &output_key,
+    ///     decomposition_level_count,
+    ///     decomposition_base_log,
+    ///     noise,
+    /// )?;
+    /// let plaintext = engine.create_plaintext(&input)?;
+    ///
+    /// let mut raw_ciphertext_1_container = vec![0_u32; input_key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_1: LweCiphertextMutView32 =
+    ///     engine.create_lwe_ciphertext(&mut raw_ciphertext_1_container[..])?;
+    /// engine.discard_encrypt_lwe_ciphertext(&input_key, &mut ciphertext_1, &plaintext, noise)?;
+    ///
+    /// // Convert MutView to View
+    /// let raw_ciphertext_1 = engine.consume_retrieve_lwe_ciphertext(ciphertext_1)?;
+    /// let ciphertext_1: LweCiphertextView32 = engine.create_lwe_ciphertext(&raw_ciphertext_1[..])?;
+    ///
+    /// let mut raw_ciphertext_2_container = vec![0_u32; output_key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_2: LweCiphertextMutView32 =
+    ///     engine.create_lwe_ciphertext(&mut raw_ciphertext_2_container[..])?;
+    ///
+    /// engine.discard_keyswitch_lwe_ciphertext(&mut ciphertext_2, &ciphertext_1, &keyswitch_key)?;
+    /// #
+    /// assert_eq!(ciphertext_2.lwe_dimension(), output_lwe_dimension);
+    ///
+    /// engine.destroy(input_key)?;
+    /// engine.destroy(output_key)?;
+    /// engine.destroy(keyswitch_key)?;
+    /// engine.destroy(plaintext)?;
+    /// engine.destroy(ciphertext_1)?;
+    /// engine.destroy(ciphertext_2)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_keyswitch_lwe_ciphertext(
+        &mut self,
+        output: &mut LweCiphertextMutView32<'_>,
+        input: &LweCiphertextView32<'_>,
+        ksk: &LweKeyswitchKey32,
+    ) -> Result<(), LweCiphertextDiscardingKeyswitchError<Self::EngineError>> {
+        LweCiphertextDiscardingKeyswitchError::perform_generic_checks(output, input, ksk)?;
+        unsafe { self.discard_keyswitch_lwe_ciphertext_unchecked(output, input, ksk) };
+        Ok(())
+    }
+
+    unsafe fn discard_keyswitch_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut LweCiphertextMutView32<'_>,
+        input: &LweCiphertextView32<'_>,
+        ksk: &LweKeyswitchKey32,
+    ) {
+        ksk.0.keyswitch_ciphertext(&mut output.0, &input.0);
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextDiscardingKeyswitchEngine`] for [`CoreEngine`] that operates on
+/// views containing 64 bits integers.
+impl
+    LweCiphertextDiscardingKeyswitchEngine<
+        LweKeyswitchKey64,
+        LweCiphertextView64<'_>,
+        LweCiphertextMutView64<'_>,
+    > for CoreEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, LweDimension,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let input_lwe_dimension = LweDimension(6);
+    /// let output_lwe_dimension = LweDimension(3);
+    /// let decomposition_level_count = DecompositionLevelCount(2);
+    /// let decomposition_base_log = DecompositionBaseLog(8);
+    /// let noise = Variance(2_f64.powf(-25.));
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = 3_u64 << 50;
+    ///
+    /// let mut engine = CoreEngine::new(())?;
+    /// let input_key: LweSecretKey64 = engine.create_lwe_secret_key(input_lwe_dimension)?;
+    /// let output_key: LweSecretKey64 = engine.create_lwe_secret_key(output_lwe_dimension)?;
+    /// let keyswitch_key = engine.create_lwe_keyswitch_key(
+    ///     &input_key,
+    ///     &output_key,
+    ///     decomposition_level_count,
+    ///     decomposition_base_log,
+    ///     noise,
+    /// )?;
+    /// let plaintext = engine.create_plaintext(&input)?;
+    ///
+    /// let mut raw_ciphertext_1_container = vec![0_u64; input_key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_1: LweCiphertextMutView64 =
+    ///     engine.create_lwe_ciphertext(&mut raw_ciphertext_1_container[..])?;
+    /// engine.discard_encrypt_lwe_ciphertext(&input_key, &mut ciphertext_1, &plaintext, noise)?;
+    ///
+    /// // Convert MutView to View
+    /// let raw_ciphertext_1 = engine.consume_retrieve_lwe_ciphertext(ciphertext_1)?;
+    /// let ciphertext_1: LweCiphertextView64 = engine.create_lwe_ciphertext(&raw_ciphertext_1[..])?;
+    ///
+    /// let mut raw_ciphertext_2_container = vec![0_u64; output_key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_2: LweCiphertextMutView64 =
+    ///     engine.create_lwe_ciphertext(&mut raw_ciphertext_2_container[..])?;
+    ///
+    /// engine.discard_keyswitch_lwe_ciphertext(&mut ciphertext_2, &ciphertext_1, &keyswitch_key)?;
+    /// #
+    /// assert_eq!(ciphertext_2.lwe_dimension(), output_lwe_dimension);
+    ///
+    /// engine.destroy(input_key)?;
+    /// engine.destroy(output_key)?;
+    /// engine.destroy(keyswitch_key)?;
+    /// engine.destroy(plaintext)?;
+    /// engine.destroy(ciphertext_1)?;
+    /// engine.destroy(ciphertext_2)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_keyswitch_lwe_ciphertext(
+        &mut self,
+        output: &mut LweCiphertextMutView64<'_>,
+        input: &LweCiphertextView64<'_>,
+        ksk: &LweKeyswitchKey64,
+    ) -> Result<(), LweCiphertextDiscardingKeyswitchError<Self::EngineError>> {
+        LweCiphertextDiscardingKeyswitchError::perform_generic_checks(output, input, ksk)?;
+        unsafe { self.discard_keyswitch_lwe_ciphertext_unchecked(output, input, ksk) };
+        Ok(())
+    }
+
+    unsafe fn discard_keyswitch_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut LweCiphertextMutView64<'_>,
+        input: &LweCiphertextView64<'_>,
         ksk: &LweKeyswitchKey64,
     ) {
         ksk.0.keyswitch_ciphertext(&mut output.0, &input.0);

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_plaintext_discarding_addition.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_plaintext_discarding_addition.rs
@@ -1,6 +1,7 @@
 use crate::backends::core::implementation::engines::CoreEngine;
 use crate::backends::core::implementation::entities::{
-    LweCiphertext32, LweCiphertext64, Plaintext32, Plaintext64,
+    LweCiphertext32, LweCiphertext64, LweCiphertextMutView32, LweCiphertextMutView64,
+    LweCiphertextView32, LweCiphertextView64, Plaintext32, Plaintext64,
 };
 use crate::backends::core::private::math::tensor::{AsMutTensor, AsRefTensor};
 use crate::specification::engines::{
@@ -123,6 +124,160 @@ impl LweCiphertextPlaintextDiscardingAdditionEngine<LweCiphertext64, Plaintext64
         &mut self,
         output: &mut LweCiphertext64,
         input_1: &LweCiphertext64,
+        input_2: &Plaintext64,
+    ) {
+        output
+            .0
+            .as_mut_tensor()
+            .fill_with_copy(input_1.0.as_tensor());
+        output.0.get_mut_body().0 = output.0.get_body().0.wrapping_add(input_2.0 .0);
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextPlaintextDiscardingAdditionEngine`] for [`CoreEngine`] that
+/// operates on views containing 32 bits integers.
+impl
+    LweCiphertextPlaintextDiscardingAdditionEngine<
+        LweCiphertextView32<'_>,
+        Plaintext32,
+        LweCiphertextMutView32<'_>,
+    > for CoreEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u32 << 20;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// let mut engine = CoreEngine::new(())?;
+    /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let plaintext = engine.create_plaintext(&input)?;
+    ///
+    /// let mut ciphertext_1_container = vec![0_u32; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_1: LweCiphertextMutView32 =
+    ///     engine.create_lwe_ciphertext(&mut ciphertext_1_container[..])?;
+    /// engine.discard_encrypt_lwe_ciphertext(&key, &mut ciphertext_1, &plaintext, noise)?;
+    ///
+    /// // Convert MutView to View
+    /// let raw_ciphertext_1 = engine.consume_retrieve_lwe_ciphertext(ciphertext_1)?;
+    /// let ciphertext_1: LweCiphertextView32 = engine.create_lwe_ciphertext(&raw_ciphertext_1[..])?;
+    ///
+    /// let mut ciphertext_2_container = vec![0_u32; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_2 = engine.create_lwe_ciphertext(&mut ciphertext_2_container[..])?;
+    ///
+    /// engine.discard_add_lwe_ciphertext_plaintext(&mut ciphertext_2, &ciphertext_1, &plaintext)?;
+    /// #
+    /// assert_eq!(ciphertext_2.lwe_dimension(), lwe_dimension);
+    ///
+    /// engine.destroy(key)?;
+    /// engine.destroy(plaintext)?;
+    /// engine.destroy(ciphertext_1)?;
+    /// engine.destroy(ciphertext_2)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_add_lwe_ciphertext_plaintext(
+        &mut self,
+        output: &mut LweCiphertextMutView32,
+        input_1: &LweCiphertextView32,
+        input_2: &Plaintext32,
+    ) -> Result<(), LweCiphertextPlaintextDiscardingAdditionError<Self::EngineError>> {
+        LweCiphertextPlaintextDiscardingAdditionError::perform_generic_checks(output, input_1)?;
+        unsafe { self.discard_add_lwe_ciphertext_plaintext_unchecked(output, input_1, input_2) };
+        Ok(())
+    }
+
+    unsafe fn discard_add_lwe_ciphertext_plaintext_unchecked(
+        &mut self,
+        output: &mut LweCiphertextMutView32,
+        input_1: &LweCiphertextView32,
+        input_2: &Plaintext32,
+    ) {
+        output
+            .0
+            .as_mut_tensor()
+            .fill_with_copy(input_1.0.as_tensor());
+        output.0.get_mut_body().0 = output.0.get_body().0.wrapping_add(input_2.0 .0);
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextPlaintextDiscardingAdditionEngine`] for [`CoreEngine`] that
+/// operates on views containing 64 bits integers.
+impl
+    LweCiphertextPlaintextDiscardingAdditionEngine<
+        LweCiphertextView64<'_>,
+        Plaintext64,
+        LweCiphertextMutView64<'_>,
+    > for CoreEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = 3_u64 << 50;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// let mut engine = CoreEngine::new(())?;
+    /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let plaintext = engine.create_plaintext(&input)?;
+    ///
+    /// let mut ciphertext_1_container = vec![0_u64; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_1: LweCiphertextMutView64 =
+    ///     engine.create_lwe_ciphertext(&mut ciphertext_1_container[..])?;
+    /// engine.discard_encrypt_lwe_ciphertext(&key, &mut ciphertext_1, &plaintext, noise)?;
+    ///
+    /// // Convert MutView to View
+    /// let raw_ciphertext_1 = engine.consume_retrieve_lwe_ciphertext(ciphertext_1)?;
+    /// let ciphertext_1: LweCiphertextView64 = engine.create_lwe_ciphertext(&raw_ciphertext_1[..])?;
+    ///
+    /// let mut ciphertext_2_container = vec![0_u64; key.lwe_dimension().to_lwe_size().0];
+    /// let mut ciphertext_2 = engine.create_lwe_ciphertext(&mut ciphertext_2_container[..])?;
+    ///
+    /// engine.discard_add_lwe_ciphertext_plaintext(&mut ciphertext_2, &ciphertext_1, &plaintext)?;
+    /// #
+    /// assert_eq!(ciphertext_2.lwe_dimension(), lwe_dimension);
+    ///
+    /// engine.destroy(key)?;
+    /// engine.destroy(plaintext)?;
+    /// engine.destroy(ciphertext_1)?;
+    /// engine.destroy(ciphertext_2)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_add_lwe_ciphertext_plaintext(
+        &mut self,
+        output: &mut LweCiphertextMutView64,
+        input_1: &LweCiphertextView64,
+        input_2: &Plaintext64,
+    ) -> Result<(), LweCiphertextPlaintextDiscardingAdditionError<Self::EngineError>> {
+        LweCiphertextPlaintextDiscardingAdditionError::perform_generic_checks(output, input_1)?;
+        unsafe { self.discard_add_lwe_ciphertext_plaintext_unchecked(output, input_1, input_2) };
+        Ok(())
+    }
+
+    unsafe fn discard_add_lwe_ciphertext_plaintext_unchecked(
+        &mut self,
+        output: &mut LweCiphertextMutView64,
+        input_1: &LweCiphertextView64,
         input_2: &Plaintext64,
     ) {
         output


### PR DESCRIPTION
### Resolves:

closes https://github.com/zama-ai/concrete-core-internal/issues/100

### Description

The missing engines for the C FFI for the compiler.

There remains (at least) the question about managing the accumulator for a bootstrap to know if require an additional engine to trivially encrypt it in a GLWE View

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
