### PR TITLE
chore(core): generalize the use of results in prng forks

### DIFF
--- a/concrete-core/src/backends/core/private/math/random/generator.rs
+++ b/concrete-core/src/backends/core/private/math/random/generator.rs
@@ -104,11 +104,10 @@ impl<G: ByteRandomGenerator> RandomGenerator<G> {
         &mut self,
         n_child: usize,
         bytes_per_child: usize,
-    ) -> Option<impl Iterator<Item = RandomGenerator<G>>> {
+    ) -> Result<impl Iterator<Item = RandomGenerator<G>>, ForkError> {
         self.0
             .try_fork(ChildrenCount(n_child), BytesPerChild(bytes_per_child))
             .map(|iter| iter.map(Self))
-            .ok()
     }
 
     /// Generates a random uniform unsigned integer.


### PR DESCRIPTION
### Resolves: 

closes zama-ai/concrete-core-internal#137

### Description

In concrete-core private api, some of the fork operations of the random generators still returns Options. On the other side, the underlying concrete-csprng api exposes a Result which returns an error type with more informations. It would be nice to expose that.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
