### PR TITLE
feat(csprng): add API to check availability of seeders on current machine

### DIFF
--- a/concrete-core/src/commons/mod.rs
+++ b/concrete-core/src/commons/mod.rs
@@ -100,6 +100,10 @@ pub mod test_tools {
         fn seed(&mut self) -> Seed {
             Seed(rand::thread_rng().gen())
         }
+
+        fn is_available() -> bool {
+            true
+        }
     }
 
     pub fn assert_delta_std_dev<First, Second, Element>(

--- a/concrete-csprng/build.rs
+++ b/concrete-csprng/build.rs
@@ -1,0 +1,106 @@
+// To have clear error messages during compilation about why some piece of code may not be available
+// we decided to check the features compatibility with the target configuration in this script.
+
+use std::collections::HashMap;
+use std::env;
+
+// See https://doc.rust-lang.org/reference/conditional-compilation.html#target_arch for various
+// compilation configuration
+
+// Can be easily extended if needed
+pub struct FeatureRequirement {
+    pub feature_name: &'static str,
+    // target_arch requirement
+    pub feature_req_target_arch: Option<&'static str>,
+    // target_family requirement
+    pub feature_req_target_family: Option<&'static str>,
+}
+
+// We implement a version of default that is const which is not possible through the Default trait
+impl FeatureRequirement {
+    // As we cannot use cfg!(feature = "feature_name") with something else than a literal, we need
+    // a reference to the HashMap we populate with the enabled features
+    fn is_activated(&self, build_activated_features: &HashMap<&'static str, bool>) -> bool {
+        *build_activated_features.get(self.feature_name).unwrap()
+    }
+
+    // panics if the requirements are not met
+    fn check_requirements(&self) {
+        let target_arch = get_target_arch_cfg();
+        if let Some(feature_req_target_arch) = self.feature_req_target_arch {
+            if feature_req_target_arch != target_arch {
+                panic!(
+                    "Feature `{}` requires target_arch `{}`, current cfg: `{}`",
+                    self.feature_name, feature_req_target_arch, target_arch
+                )
+            }
+        }
+
+        let target_family = get_target_family_cfg();
+        if let Some(feature_req_target_family) = self.feature_req_target_family {
+            if feature_req_target_family != target_family {
+                panic!(
+                    "Feature `{}` requires target_family `{}`, current cfg: `{}`",
+                    self.feature_name, feature_req_target_family, target_family
+                )
+            }
+        }
+    }
+}
+
+// const vecs are not yet a thing so use a fixed size array (update the array size when adding
+// requirements)
+static FEATURE_REQUIREMENTS: [FeatureRequirement; 3] = [
+    FeatureRequirement {
+        feature_name: "seeder_x86_64_rdseed",
+        feature_req_target_arch: Some("x86_64"),
+        feature_req_target_family: None,
+    },
+    FeatureRequirement {
+        feature_name: "generator_x86_64_aesni",
+        feature_req_target_arch: Some("x86_64"),
+        feature_req_target_family: None,
+    },
+    FeatureRequirement {
+        feature_name: "seeder_unix",
+        feature_req_target_arch: None,
+        feature_req_target_family: Some("unix"),
+    },
+];
+
+// For a "feature_name" feature_cfg!("feature_name") expands to
+// ("feature_name", cfg!(feature = "feature_name"))
+macro_rules! feature_cfg {
+    ($feat_name:literal) => {
+        ($feat_name, cfg!(feature = $feat_name))
+    };
+}
+
+// Static HashMap would require an additional crate (phf or lazy static e.g.), so we just write a
+// function that returns the HashMap we are interested in
+fn get_feature_enabled_status() -> HashMap<&'static str, bool> {
+    HashMap::from([
+        feature_cfg!("seeder_x86_64_rdseed"),
+        feature_cfg!("generator_x86_64_aesni"),
+        feature_cfg!("seeder_unix"),
+    ])
+}
+
+// See https://stackoverflow.com/a/43435335/18088947 for the inspiration of this code
+fn get_target_arch_cfg() -> String {
+    env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH is not set")
+}
+
+fn get_target_family_cfg() -> String {
+    env::var("CARGO_CFG_TARGET_FAMILY").expect("CARGO_CFG_TARGET_FAMILY is not set")
+}
+
+fn main() {
+    let feature_enabled_status = get_feature_enabled_status();
+
+    // This will panic if some requirements for a feature are not met
+    FEATURE_REQUIREMENTS
+        .iter()
+        .filter(|&req| FeatureRequirement::is_activated(req, &feature_enabled_status))
+        .for_each(FeatureRequirement::check_requirements);
+}

--- a/concrete-csprng/src/seeders/implem/rdseed.rs
+++ b/concrete-csprng/src/seeders/implem/rdseed.rs
@@ -10,6 +10,10 @@ impl Seeder for RdseedSeeder {
     fn seed(&mut self) -> Seed {
         Seed(rdseed_random_m128())
     }
+
+    fn is_available() -> bool {
+        is_x86_feature_detected!("rdseed")
+    }
 }
 
 // Generates a random 128 bits value from rdseed

--- a/concrete-csprng/src/seeders/implem/unix.rs
+++ b/concrete-csprng/src/seeders/implem/unix.rs
@@ -37,6 +37,10 @@ impl Seeder for UnixSeeder {
         self.counter = self.counter.wrapping_add(1);
         Seed(output)
     }
+
+    fn is_available() -> bool {
+        cfg!(target_family = "unix")
+    }
 }
 
 fn dev_random(random: &mut File) -> u128 {

--- a/concrete-csprng/src/seeders/mod.rs
+++ b/concrete-csprng/src/seeders/mod.rs
@@ -13,6 +13,12 @@ pub struct Seed(pub u128);
 pub trait Seeder {
     /// Generates a new seed.
     fn seed(&mut self) -> Seed;
+
+    /// Check whether the seeder can be used on the current machine. This function may check if some
+    /// required CPU features are available or if some OS features are availble for example.
+    fn is_available() -> bool
+    where
+        Self: Sized;
 }
 
 mod implem;


### PR DESCRIPTION
### Resolves:

closes https://github.com/zama-ai/concrete-core-internal/issues/136
closes https://github.com/zama-ai/concrete-core-internal/issues/143

### Description

if a seeder requires specific hardware features or OS features (among
other things) the availability of such a seeder on the current machine can
be checked through a call to `is_available` that was added to the Seeder
trait and implemented for existing seeders

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
