### PR TITLE
Refactor external product

### DIFF
--- a/concrete-core-test/src/default.rs
+++ b/concrete-core-test/src/default.rs
@@ -22,11 +22,6 @@ macro_rules! test {
             }
         }
     };
-    ($(($fixture: ident, $precision: ident, ($($types:ident),+))),+) => {
-        $(
-            test!{$fixture, $precision, ($($types),+)}
-        )+
-    };
     ($(($fixture: ident, ($($types:ident),+))),+) => {
         $(
             paste!{

--- a/concrete-core-test/src/fftw.rs
+++ b/concrete-core-test/src/fftw.rs
@@ -21,11 +21,6 @@ macro_rules! test {
             }
         }
     };
-    ($(($fixture: ident, $precision: ident, ($($types:ident),+))),+) => {
-        $(
-            test!{$fixture, $precision, ($($types),+)}
-        )+
-    };
     ($(($fixture: ident, ($($types:ident),+))),+) => {
         $(
             paste!{

--- a/concrete-core/src/backends/fftw/implementation/engines/glwe_ciphertext_ggsw_ciphertext_discarding_external_product.rs
+++ b/concrete-core/src/backends/fftw/implementation/engines/glwe_ciphertext_ggsw_ciphertext_discarding_external_product.rs
@@ -122,9 +122,12 @@ impl
             ggsw_input.polynomial_size(),
             ggsw_input.glwe_dimension().to_glwe_size(),
         );
-        ggsw_input
-            .0
-            .external_product(&mut output.0, &glwe_input.0, buffers);
+        ggsw_input.0.external_product(
+            &mut output.0,
+            &glwe_input.0,
+            &mut buffers.fft_buffers,
+            &mut buffers.rounded_buffer,
+        );
     }
 }
 
@@ -238,8 +241,11 @@ impl
             ggsw_input.polynomial_size(),
             ggsw_input.glwe_dimension().to_glwe_size(),
         );
-        ggsw_input
-            .0
-            .external_product(&mut output.0, &glwe_input.0, buffers);
+        ggsw_input.0.external_product(
+            &mut output.0,
+            &glwe_input.0,
+            &mut buffers.fft_buffers,
+            &mut buffers.rounded_buffer,
+        );
     }
 }

--- a/concrete-core/src/backends/fftw/implementation/engines/glwe_ciphertext_ggsw_ciphertext_external_product.rs
+++ b/concrete-core/src/backends/fftw/implementation/engines/glwe_ciphertext_ggsw_ciphertext_external_product.rs
@@ -110,9 +110,12 @@ impl
             ggsw_input.polynomial_size(),
             ggsw_input.glwe_dimension().to_glwe_size(),
         );
-        ggsw_input
-            .0
-            .external_product(&mut output, &glwe_input.0, buffers);
+        ggsw_input.0.external_product(
+            &mut output,
+            &glwe_input.0,
+            &mut buffers.fft_buffers,
+            &mut buffers.rounded_buffer,
+        );
         GlweCiphertext32(output)
     }
 }
@@ -212,9 +215,12 @@ impl
             ggsw_input.polynomial_size(),
             ggsw_input.glwe_dimension().to_glwe_size(),
         );
-        ggsw_input
-            .0
-            .external_product(&mut output, &glwe_input.0, buffers);
+        ggsw_input.0.external_product(
+            &mut output,
+            &glwe_input.0,
+            &mut buffers.fft_buffers,
+            &mut buffers.rounded_buffer,
+        );
         GlweCiphertext64(output)
     }
 }

--- a/concrete-core/src/backends/fftw/private/crypto/bootstrap/fourier/mod.rs
+++ b/concrete-core/src/backends/fftw/private/crypto/bootstrap/fourier/mod.rs
@@ -14,17 +14,14 @@ mod buffers;
 mod tests;
 
 use crate::backends::fftw::private::crypto::ggsw::FourierGgswCiphertext;
-use crate::backends::fftw::private::math::fft::{Complex64, FourierPolynomial};
+use crate::backends::fftw::private::math::fft::Complex64;
 use crate::commons::crypto::bootstrap::StandardBootstrapKey;
 use crate::commons::crypto::glwe::GlweCiphertext;
 use crate::commons::crypto::lwe::LweCiphertext;
-use crate::commons::math::decomposition::SignedDecomposer;
-use crate::commons::math::polynomial::Polynomial;
 use crate::commons::math::tensor::{
-    ck_dim_div, ck_dim_eq, AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, IntoTensor, Tensor,
+    ck_dim_div, AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, IntoTensor, Tensor,
 };
 use crate::commons::math::torus::UnsignedTorus;
-use crate::commons::utils::{zip, zip_args};
 pub use buffers::{FftBuffers, FourierBuffers};
 
 /// A bootstrapping key in the fourier domain.
@@ -450,190 +447,6 @@ where
             })
     }
 
-    fn external_product<C1, C2, C3>(
-        &self,
-        output: &mut GlweCiphertext<C1>,
-        ggsw: &FourierGgswCiphertext<C2, Scalar>,
-        glwe: &GlweCiphertext<C3>,
-        fft_buffers: &mut FftBuffers,
-        rounded_buffer: &mut GlweCiphertext<Vec<Scalar>>,
-    ) where
-        GlweCiphertext<C1>: AsMutTensor<Element = Scalar>,
-        FourierGgswCiphertext<C2, Scalar>: AsRefTensor<Element = Complex64>,
-        GlweCiphertext<C3>: AsRefTensor<Element = Scalar>,
-        Scalar: UnsignedTorus,
-    {
-        // We check that the polynomial sizes match
-        ck_dim_eq!(
-            self.poly_size =>
-            glwe.polynomial_size(),
-            ggsw.polynomial_size(),
-            output.polynomial_size()
-        );
-        // We check that the glwe sizes match
-        ck_dim_eq!(
-            self.glwe_size =>
-            glwe.size(),
-            ggsw.glwe_size(),
-            output.size()
-        );
-
-        // "alias" buffers to save some typing
-        let fft = &mut fft_buffers.fft;
-        let first_fft_buffer = &mut fft_buffers.first_buffer;
-        let second_fft_buffer = &mut fft_buffers.second_buffer;
-        let output_fft_buffer = &mut fft_buffers.output_buffer;
-        output_fft_buffer.fill_with_element(Complex64::new(0., 0.));
-
-        let rounded_input_glwe = rounded_buffer;
-
-        // We round the input mask and body
-        let decomposer = SignedDecomposer::new(self.decomp_base_log, self.decomp_level);
-        decomposer.fill_tensor_with_closest_representable(rounded_input_glwe, glwe);
-
-        // ------------------------------------------------------ EXTERNAL PRODUCT IN FOURIER DOMAIN
-        // In this section, we perform the external product in the fourier domain, and accumulate
-        // the result in the output_fft_buffer variable.
-        let mut decomposition = decomposer.decompose_tensor(rounded_input_glwe);
-        // We loop through the levels (we reverse to match the order of the decomposition iterator.)
-        for ggsw_decomp_matrix in ggsw.level_matrix_iter().rev() {
-            // We retrieve the decomposition of this level.
-            let glwe_decomp_term = decomposition.next_term().unwrap();
-            debug_assert_eq!(
-                ggsw_decomp_matrix.decomposition_level(),
-                glwe_decomp_term.level()
-            );
-            // For each levels we have to add the result of the vector-matrix product between the
-            // decomposition of the glwe, and the ggsw level matrix to the output. To do so, we
-            // iteratively add to the output, the product between every lines of the matrix, and
-            // the corresponding (scalar) polynomial in the glwe decomposition:
-            //
-            //                ggsw_mat                        ggsw_mat
-            //   glwe_dec   | - - - - | <        glwe_dec   | - - - - |
-            //  | - - - | x | - - - - |         | - - - | x | - - - - | <
-            //    ^         | - - - - |             ^       | - - - - |
-            //
-            //        t = 1                           t = 2                     ...
-            // When possible we iterate two times in a row, to benefit from the fact that fft can
-            // transform two polynomials at once.
-            let mut iterator = zip!(
-                ggsw_decomp_matrix.row_iter(),
-                glwe_decomp_term
-                    .as_tensor()
-                    .subtensor_iter(self.poly_size.0)
-                    .map(Polynomial::from_tensor)
-            );
-
-            //---------------------------------------------------------------- VECTOR-MATRIX PRODUCT
-            loop {
-                match (iterator.next(), iterator.next()) {
-                    // Two iterates are available, we use the fast fft.
-                    (Some(first), Some(second)) => {
-                        // We unpack the iterator values
-                        let zip_args!(first_ggsw_row, first_glwe_poly) = first;
-                        let zip_args!(second_ggsw_row, second_glwe_poly) = second;
-                        // We perform the forward fft transform for the glwe polynomials
-                        fft.forward_two_as_integer(
-                            first_fft_buffer,
-                            second_fft_buffer,
-                            &first_glwe_poly,
-                            &second_glwe_poly,
-                        );
-                        // Now we loop through the polynomials of the output, and add the
-                        // corresponding product of polynomials.
-                        let iterator = zip!(
-                            first_ggsw_row
-                                .as_tensor()
-                                .subtensor_iter(self.poly_size.0)
-                                .map(FourierPolynomial::from_tensor),
-                            second_ggsw_row
-                                .as_tensor()
-                                .subtensor_iter(self.poly_size.0)
-                                .map(FourierPolynomial::from_tensor),
-                            output_fft_buffer
-                                .as_mut_tensor()
-                                .subtensor_iter_mut(self.poly_size.0)
-                                .map(FourierPolynomial::from_tensor)
-                        );
-                        for zip_args!(first_ggsw_poly, second_ggsw_poly, mut output_poly) in
-                            iterator
-                        {
-                            output_poly.update_with_two_multiply_accumulate(
-                                &first_ggsw_poly,
-                                first_fft_buffer,
-                                &second_ggsw_poly,
-                                second_fft_buffer,
-                            );
-                        }
-                    }
-                    // We reach the  end of the loop and one element remains.
-                    (Some(first), None) => {
-                        // We unpack the iterator values
-                        let (first_ggsw_row, first_glwe_poly) = first;
-                        // We perform the forward fft transform for the glwe polynomial
-                        fft.forward_as_integer(first_fft_buffer, &first_glwe_poly);
-                        // Now we loop through the polynomials of the output, and add the
-                        // corresponding product of polynomials.
-                        let iterator = zip!(
-                            first_ggsw_row
-                                .as_tensor()
-                                .subtensor_iter(self.poly_size.0)
-                                .map(FourierPolynomial::from_tensor),
-                            output_fft_buffer
-                                .subtensor_iter_mut(self.poly_size.0)
-                                .map(FourierPolynomial::from_tensor)
-                        );
-                        for zip_args!(first_ggsw_poly, mut output_poly) in iterator {
-                            output_poly.update_with_multiply_accumulate(
-                                &first_ggsw_poly,
-                                first_fft_buffer,
-                            );
-                        }
-                    }
-                    // The loop is over, we can exit.
-                    _ => break,
-                }
-            }
-        }
-
-        // --------------------------------------------  TRANSFORMATION OF RESULT TO STANDARD DOMAIN
-        // In this section, we bring the result from the fourier domain, back to the standard
-        // domain, and add it to the output.
-        //
-        // We iterate over the polynomials in the output. Again, when possible, we process two
-        // iterations simultaneously to benefit from the fft acceleration.
-        let mut _output_bind = output.as_mut_polynomial_list();
-        let mut iterator = zip!(
-            _output_bind.polynomial_iter_mut(),
-            output_fft_buffer
-                .subtensor_iter_mut(self.poly_size.0)
-                .map(FourierPolynomial::from_tensor)
-        );
-        loop {
-            match (iterator.next(), iterator.next()) {
-                (Some(first), Some(second)) => {
-                    // We unpack the iterates
-                    let zip_args!(mut first_output, mut first_fourier) = first;
-                    let zip_args!(mut second_output, mut second_fourier) = second;
-                    // We perform the backward transform
-                    fft.add_backward_two_as_torus(
-                        &mut first_output,
-                        &mut second_output,
-                        &mut first_fourier,
-                        &mut second_fourier,
-                    );
-                }
-                (Some(first), None) => {
-                    // We unpack the iterates
-                    let (mut first_output, mut first_fourier) = first;
-                    // We perform the backward transform
-                    fft.add_backward_as_torus(&mut first_output, &mut first_fourier);
-                }
-                _ => break,
-            }
-        }
-    }
-
     // This cmux mutates both ct1 and ct0. The result is in ct0 after the method was called.
     fn cmux<C0, C1, C2>(
         &self,
@@ -650,7 +463,7 @@ where
     {
         ct1.as_mut_tensor()
             .update_with_wrapping_sub(ct0.as_tensor());
-        self.external_product(ct0, ggsw, ct1, fft_buffers, rounded_buffer);
+        ggsw.external_product(ct0, ct1, fft_buffers, rounded_buffer);
     }
 
     fn blind_rotate<C2>(&self, buffers: &mut FourierBuffers<Scalar>, lwe: &LweCiphertext<C2>)

--- a/concrete-core/src/backends/fftw/private/crypto/ggsw/fourier.rs
+++ b/concrete-core/src/backends/fftw/private/crypto/ggsw/fourier.rs
@@ -10,6 +10,7 @@ use concrete_fftw::array::AlignedVec;
 #[cfg(feature = "multithread")]
 use rayon::{iter::IndexedParallelIterator, prelude::*};
 
+use crate::backends::fftw::private::crypto::bootstrap::fourier::FftBuffers;
 use crate::backends::fftw::private::crypto::bootstrap::FourierBuffers;
 use crate::backends::fftw::private::math::fft::{Complex64, FourierPolynomial};
 use crate::commons::crypto::ggsw::{GgswLevelMatrix, StandardGgswCiphertext};
@@ -512,7 +513,8 @@ impl<Cont, Scalar> FourierGgswCiphertext<Cont, Scalar> {
         &self,
         output: &mut GlweCiphertext<C1>,
         glwe: &GlweCiphertext<C2>,
-        buffers: &mut FourierBuffers<Scalar>,
+        fft_buffers: &mut FftBuffers,
+        rounded_buffer: &mut GlweCiphertext<Vec<Scalar>>,
     ) where
         Self: AsRefTensor<Element = Complex64>,
         GlweCiphertext<C1>: AsMutTensor<Element = Scalar>,
@@ -531,9 +533,6 @@ impl<Cont, Scalar> FourierGgswCiphertext<Cont, Scalar> {
             glwe.size(),
             output.size()
         );
-
-        let fft_buffers = &mut buffers.fft_buffers;
-        let rounded_buffer = &mut buffers.rounded_buffer;
 
         // "alias" buffers to save some typing
         let fft = &mut fft_buffers.fft;


### PR DESCRIPTION
### Resolves: zama-ai/concrete-core-internal#113

### Description
The external_product function was copied (and slightly adapted) into the GGSW implementation. In order not to break anything, the function inside the FourierBootstrapKey was also kept, but we need to refactor this to avoid the current code duplication.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
