### PR TITLE
chore(lint): fix clippy::derive-partial-eq-without-eq lint

### DIFF
--- a/concrete-commons/src/key_kinds.rs
+++ b/concrete-commons/src/key_kinds.rs
@@ -3,19 +3,19 @@
 use serde::{Deserialize, Serialize};
 
 /// This type is a marker for keys using binary elements as scalar.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct BinaryKeyKind;
 /// This type is a marker for keys using ternary elements as scalar.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct TernaryKeyKind;
 /// This type is a marker for keys using normaly sampled elements as scalar.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct GaussianKeyKind;
 /// This type is a marker for keys using uniformly sampled elements as scalar.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct UniformKeyKind;
 

--- a/concrete-core-fixture/src/generation/prototypes/glwe_secret_key.rs
+++ b/concrete-core-fixture/src/generation/prototypes/glwe_secret_key.rs
@@ -9,7 +9,7 @@ pub trait GlweSecretKeyPrototype: PartialEq {
 }
 
 /// A type representing the prototype of a 32 bit binary glwe secret key entity.
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub struct ProtoBinaryGlweSecretKey32(pub(crate) GlweSecretKey32);
 impl GlweSecretKeyPrototype for ProtoBinaryGlweSecretKey32 {
     type KeyDistribution = BinaryKeyDistribution;
@@ -17,7 +17,7 @@ impl GlweSecretKeyPrototype for ProtoBinaryGlweSecretKey32 {
 }
 
 /// A type representing the prototype of a 64 bit binary glwe secret key entity.
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub struct ProtoBinaryGlweSecretKey64(pub(crate) GlweSecretKey64);
 impl GlweSecretKeyPrototype for ProtoBinaryGlweSecretKey64 {
     type KeyDistribution = BinaryKeyDistribution;

--- a/concrete-core-fixture/src/generation/prototypes/lwe_secret_key.rs
+++ b/concrete-core-fixture/src/generation/prototypes/lwe_secret_key.rs
@@ -9,7 +9,7 @@ pub trait LweSecretKeyPrototype: PartialEq {
 }
 
 /// A type representing the prototype of a 32 bit binary lwe secret key entity.
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub struct ProtoBinaryLweSecretKey32(pub(crate) LweSecretKey32);
 impl LweSecretKeyPrototype for ProtoBinaryLweSecretKey32 {
     type KeyDistribution = BinaryKeyDistribution;
@@ -17,7 +17,7 @@ impl LweSecretKeyPrototype for ProtoBinaryLweSecretKey32 {
 }
 
 /// A type representing the prototype of a 64 bit binary lwe secret key entity.
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub struct ProtoBinaryLweSecretKey64(pub(crate) LweSecretKey64);
 impl LweSecretKeyPrototype for ProtoBinaryLweSecretKey64 {
     type KeyDistribution = BinaryKeyDistribution;

--- a/concrete-core/src/backends/default/implementation/entities/cleartext.rs
+++ b/concrete-core/src/backends/default/implementation/entities/cleartext.rs
@@ -3,7 +3,7 @@ use crate::specification::entities::markers::CleartextKind;
 use crate::specification::entities::{AbstractEntity, CleartextEntity};
 
 /// A structure representing a cleartext with 32 bits of precision.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Cleartext32(pub(crate) ImplCleartext<u32>);
 impl AbstractEntity for Cleartext32 {
     type Kind = CleartextKind;
@@ -11,7 +11,7 @@ impl AbstractEntity for Cleartext32 {
 impl CleartextEntity for Cleartext32 {}
 
 /// A structure representing a cleartext with 64 bits of precision.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Cleartext64(pub(crate) ImplCleartext<u64>);
 impl AbstractEntity for Cleartext64 {
     type Kind = CleartextKind;

--- a/concrete-core/src/backends/default/implementation/entities/cleartext_vector.rs
+++ b/concrete-core/src/backends/default/implementation/entities/cleartext_vector.rs
@@ -4,7 +4,7 @@ use crate::specification::entities::{AbstractEntity, CleartextVectorEntity};
 use concrete_commons::parameters::CleartextCount;
 
 /// A structure representing a vector of cleartexts with 32 bits of precision.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CleartextVector32(pub(crate) ImplCleartextList<Vec<u32>>);
 impl AbstractEntity for CleartextVector32 {
     type Kind = CleartextVectorKind;
@@ -16,7 +16,7 @@ impl CleartextVectorEntity for CleartextVector32 {
 }
 
 /// A structure representing a vector of cleartexts with 64 bits of precision.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CleartextVector64(pub(crate) ImplCleartextList<Vec<u64>>);
 impl AbstractEntity for CleartextVector64 {
     type Kind = CleartextVectorKind;

--- a/concrete-core/src/backends/default/implementation/entities/ggsw_ciphertext.rs
+++ b/concrete-core/src/backends/default/implementation/entities/ggsw_ciphertext.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 /// A structure representing a GGSW ciphertext with 32 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GgswCiphertext32(pub(crate) ImplStandardGgswCiphertext<Vec<u32>>);
 impl AbstractEntity for GgswCiphertext32 {
     type Kind = GgswCiphertextKind;
@@ -36,7 +36,7 @@ impl GgswCiphertextEntity for GgswCiphertext32 {
 
 /// A structure representing a GGSW ciphertext with 64 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GgswCiphertext64(pub(crate) ImplStandardGgswCiphertext<Vec<u64>>);
 impl AbstractEntity for GgswCiphertext64 {
     type Kind = GgswCiphertextKind;

--- a/concrete-core/src/backends/default/implementation/entities/glwe_ciphertext.rs
+++ b/concrete-core/src/backends/default/implementation/entities/glwe_ciphertext.rs
@@ -10,7 +10,7 @@ use crate::commons::crypto::glwe::GlweCiphertext as ImplGlweCiphertext;
 
 /// A structure representing a GLWE ciphertext with 32 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlweCiphertext32(pub(crate) ImplGlweCiphertext<Vec<u32>>);
 
 impl AbstractEntity for GlweCiphertext32 {
@@ -31,7 +31,7 @@ impl GlweCiphertextEntity for GlweCiphertext32 {
 
 /// A structure representing a GLWE ciphertext with 64 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlweCiphertext64(pub(crate) ImplGlweCiphertext<Vec<u64>>);
 
 impl AbstractEntity for GlweCiphertext64 {
@@ -62,7 +62,7 @@ impl GlweCiphertextEntity for GlweCiphertext64 {
 /// This view is not Clone as Clone for a slice is not defined. It is not Deserialize either,
 /// as Deserialize of a slice is not defined. Immutable variant.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct GlweCiphertextView32<'a>(pub(crate) ImplGlweCiphertext<&'a [u32]>);
 impl AbstractEntity for GlweCiphertextView32<'_> {
     type Kind = GlweCiphertextKind;
@@ -89,7 +89,7 @@ impl GlweCiphertextEntity for GlweCiphertextView32<'_> {
 /// This view is not Clone as Clone for a slice is not defined. It is not Deserialize either,
 /// as Deserialize of a slice is not defined. Mutable variant.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct GlweCiphertextMutView32<'a>(pub(crate) ImplGlweCiphertext<&'a mut [u32]>);
 impl AbstractEntity for GlweCiphertextMutView32<'_> {
     type Kind = GlweCiphertextKind;
@@ -116,7 +116,7 @@ impl GlweCiphertextEntity for GlweCiphertextMutView32<'_> {
 /// This view is not Clone as Clone for a slice is not defined. It is not Deserialize either,
 /// as Deserialize of a slice is not defined. Immutable variant.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct GlweCiphertextView64<'a>(pub(crate) ImplGlweCiphertext<&'a [u64]>);
 
 impl AbstractEntity for GlweCiphertextView64<'_> {
@@ -144,7 +144,7 @@ impl GlweCiphertextEntity for GlweCiphertextView64<'_> {
 /// This view is not Clone as Clone for a slice is not defined. It is not Deserialize either,
 /// as Deserialize of a slice is not defined. Mutable variant.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct GlweCiphertextMutView64<'a>(pub(crate) ImplGlweCiphertext<&'a mut [u64]>);
 
 impl AbstractEntity for GlweCiphertextMutView64<'_> {

--- a/concrete-core/src/backends/default/implementation/entities/glwe_ciphertext_vector.rs
+++ b/concrete-core/src/backends/default/implementation/entities/glwe_ciphertext_vector.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// A structure representing a vector of GLWE ciphertexts with 32 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlweCiphertextVector32(pub(crate) ImplGlweList<Vec<u32>>);
 impl AbstractEntity for GlweCiphertextVector32 {
     type Kind = GlweCiphertextVectorKind;
@@ -30,7 +30,7 @@ impl GlweCiphertextVectorEntity for GlweCiphertextVector32 {
 
 /// A structure representing a vector of GLWE ciphertexts with 64 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlweCiphertextVector64(pub(crate) ImplGlweList<Vec<u64>>);
 impl AbstractEntity for GlweCiphertextVector64 {
     type Kind = GlweCiphertextVectorKind;

--- a/concrete-core/src/backends/default/implementation/entities/glwe_secret_key.rs
+++ b/concrete-core/src/backends/default/implementation/entities/glwe_secret_key.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 /// A structure representing a GLWE secret key with 32 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlweSecretKey32(pub(crate) ImpGlweSecretKey<BinaryKeyKind, Vec<u32>>);
 impl AbstractEntity for GlweSecretKey32 {
     type Kind = GlweSecretKeyKind;
@@ -27,7 +27,7 @@ impl GlweSecretKeyEntity for GlweSecretKey32 {
 
 /// A structure representing a GLWE secret key with 64 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlweSecretKey64(pub(crate) ImpGlweSecretKey<BinaryKeyKind, Vec<u64>>);
 impl AbstractEntity for GlweSecretKey64 {
     type Kind = GlweSecretKeyKind;

--- a/concrete-core/src/backends/default/implementation/entities/gsw_ciphertext.rs
+++ b/concrete-core/src/backends/default/implementation/entities/gsw_ciphertext.rs
@@ -9,7 +9,7 @@ use crate::specification::entities::{AbstractEntity, GswCiphertextEntity};
 
 /// A structure representing a GSW ciphertext with 32 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GswCiphertext32(ImplGswCiphertext<Vec<u32>, u32>);
 
 impl AbstractEntity for GswCiphertext32 {
@@ -34,7 +34,7 @@ impl GswCiphertextEntity for GswCiphertext32 {
 
 /// A structure representing a GSW ciphertext with 64 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GswCiphertext64(ImplGswCiphertext<Vec<u64>, u64>);
 
 impl AbstractEntity for GswCiphertext64 {

--- a/concrete-core/src/backends/default/implementation/entities/lwe_bootstrap_key.rs
+++ b/concrete-core/src/backends/default/implementation/entities/lwe_bootstrap_key.rs
@@ -6,7 +6,7 @@ use concrete_commons::parameters::{
 };
 
 /// A structure representing an LWE bootstrap key with 32 bits of precision.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweBootstrapKey32(pub(crate) ImplStandardBootstrapKey<Vec<u32>>);
 impl AbstractEntity for LweBootstrapKey32 {
     type Kind = LweBootstrapKeyKind;
@@ -37,7 +37,7 @@ impl LweBootstrapKeyEntity for LweBootstrapKey32 {
 }
 
 /// A structure representing an LWE bootstrap key with 64 bits of precision.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweBootstrapKey64(pub(crate) ImplStandardBootstrapKey<Vec<u64>>);
 impl AbstractEntity for LweBootstrapKey64 {
     type Kind = LweBootstrapKeyKind;

--- a/concrete-core/src/backends/default/implementation/entities/lwe_keyswitch_key.rs
+++ b/concrete-core/src/backends/default/implementation/entities/lwe_keyswitch_key.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// A structure representing an LWE keyswitch key with 32 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweKeyswitchKey32(pub(crate) ImplLweKeyswitchKey<Vec<u32>>);
 impl AbstractEntity for LweKeyswitchKey32 {
     type Kind = LweKeyswitchKeyKind;
@@ -35,7 +35,7 @@ impl LweKeyswitchKeyEntity for LweKeyswitchKey32 {
 
 /// A structure representing an LWE keyswitch key with 64 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweKeyswitchKey64(pub(crate) ImplLweKeyswitchKey<Vec<u64>>);
 impl AbstractEntity for LweKeyswitchKey64 {
     type Kind = LweKeyswitchKeyKind;

--- a/concrete-core/src/backends/default/implementation/entities/lwe_secret_key.rs
+++ b/concrete-core/src/backends/default/implementation/entities/lwe_secret_key.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 /// A structure representing an LWE secret key with 32 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweSecretKey32(pub(crate) ImpLweSecretKey<BinaryKeyKind, Vec<u32>>);
 impl AbstractEntity for LweSecretKey32 {
     type Kind = LweSecretKeyKind;
@@ -23,7 +23,7 @@ impl LweSecretKeyEntity for LweSecretKey32 {
 
 /// A structure representing an LWE secret key with 64 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweSecretKey64(pub(crate) ImpLweSecretKey<BinaryKeyKind, Vec<u64>>);
 impl AbstractEntity for LweSecretKey64 {
     type Kind = LweSecretKeyKind;

--- a/concrete-core/src/backends/default/implementation/entities/packing_keyswitch_key.rs
+++ b/concrete-core/src/backends/default/implementation/entities/packing_keyswitch_key.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 /// A structure representing a packing keyswitch key with 32 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PackingKeyswitchKey32(pub(crate) ImplPackingKeyswitchKey<Vec<u32>>);
 impl AbstractEntity for PackingKeyswitchKey32 {
     type Kind = PackingKeyswitchKeyKind;
@@ -43,7 +43,7 @@ impl PackingKeyswitchKeyEntity for PackingKeyswitchKey32 {
 
 /// A structure representing a packing keyswitch key with 64 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PackingKeyswitchKey64(pub(crate) ImplPackingKeyswitchKey<Vec<u64>>);
 impl AbstractEntity for PackingKeyswitchKey64 {
     type Kind = PackingKeyswitchKeyKind;

--- a/concrete-core/src/backends/default/implementation/entities/plaintext.rs
+++ b/concrete-core/src/backends/default/implementation/entities/plaintext.rs
@@ -3,7 +3,7 @@ use crate::specification::entities::markers::PlaintextKind;
 use crate::specification::entities::{AbstractEntity, PlaintextEntity};
 
 /// A structure representing a plaintext with 32 bits of precision.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Plaintext32(pub(crate) ImplPlaintext<u32>);
 impl AbstractEntity for Plaintext32 {
     type Kind = PlaintextKind;
@@ -11,7 +11,7 @@ impl AbstractEntity for Plaintext32 {
 impl PlaintextEntity for Plaintext32 {}
 
 /// A structure representing a plaintext with 64 bits of precision.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Plaintext64(pub(crate) ImplPlaintext<u64>);
 impl AbstractEntity for Plaintext64 {
     type Kind = PlaintextKind;

--- a/concrete-core/src/backends/default/implementation/entities/plaintext_vector.rs
+++ b/concrete-core/src/backends/default/implementation/entities/plaintext_vector.rs
@@ -4,7 +4,7 @@ use crate::specification::entities::{AbstractEntity, PlaintextVectorEntity};
 use concrete_commons::parameters::PlaintextCount;
 
 /// A structure representing a vector of plaintexts with 32 bits of precision.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlaintextVector32(pub(crate) ImplPlaintextList<Vec<u32>>);
 impl AbstractEntity for PlaintextVector32 {
     type Kind = PlaintextVectorKind;
@@ -16,7 +16,7 @@ impl PlaintextVectorEntity for PlaintextVector32 {
 }
 
 /// A structure representing a vector of plaintexts with 64 bits of precision.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlaintextVector64(pub(crate) ImplPlaintextList<Vec<u64>>);
 impl AbstractEntity for PlaintextVector64 {
     type Kind = PlaintextVectorKind;

--- a/concrete-core/src/backends/fftw/private/crypto/bootstrap/fourier/mod.rs
+++ b/concrete-core/src/backends/fftw/private/crypto/bootstrap/fourier/mod.rs
@@ -26,7 +26,7 @@ pub use buffers::{FftBuffers, FourierBuffers};
 
 /// A bootstrapping key in the fourier domain.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FourierBootstrapKey<Cont, Scalar>
 where
     Scalar: UnsignedTorus,

--- a/concrete-core/src/backends/fftw/private/crypto/ggsw/fourier.rs
+++ b/concrete-core/src/backends/fftw/private/crypto/ggsw/fourier.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 
 /// A GGSW ciphertext in the Fourier Domain.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FourierGgswCiphertext<Cont, Scalar> {
     tensor: Tensor<Cont>,
     poly_size: PolynomialSize,

--- a/concrete-core/src/backends/fftw/private/crypto/glwe/fourier.rs
+++ b/concrete-core/src/backends/fftw/private/crypto/glwe/fourier.rs
@@ -13,7 +13,7 @@ use concrete_commons::parameters::{GlweSize, PolynomialSize};
 
 /// A GLWE ciphertext in the Fourier Domain.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FourierGlweCiphertext<Cont, Scalar> {
     tensor: Tensor<Cont>,
     pub poly_size: PolynomialSize,

--- a/concrete-core/src/commons/crypto/bootstrap/standard/mod.rs
+++ b/concrete-core/src/commons/crypto/bootstrap/standard/mod.rs
@@ -22,7 +22,7 @@ use concrete_commons::parameters::{
 use rayon::{iter::IndexedParallelIterator, prelude::*};
 
 /// A bootstrapping key represented in the standard domain.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StandardBootstrapKey<Cont> {
     tensor: Tensor<Cont>,
     poly_size: PolynomialSize,

--- a/concrete-core/src/commons/crypto/encoding/cleartext.rs
+++ b/concrete-core/src/commons/crypto/encoding/cleartext.rs
@@ -7,7 +7,7 @@ use concrete_commons::parameters::CleartextCount;
 pub struct Cleartext<T: Numeric>(pub T);
 
 /// A list of clear, non-encoded, values.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CleartextList<Cont> {
     tensor: Tensor<Cont>,
 }

--- a/concrete-core/src/commons/crypto/encoding/plaintext.rs
+++ b/concrete-core/src/commons/crypto/encoding/plaintext.rs
@@ -11,7 +11,7 @@ use concrete_commons::parameters::PlaintextCount;
 pub struct Plaintext<T: Numeric>(pub T);
 
 /// A list of plaintexts
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlaintextList<Cont> {
     pub(crate) tensor: Tensor<Cont>,
 }

--- a/concrete-core/src/commons/crypto/ggsw/standard.rs
+++ b/concrete-core/src/commons/crypto/ggsw/standard.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 
 /// A GGSW ciphertext.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StandardGgswCiphertext<Cont> {
     tensor: Tensor<Cont>,
     poly_size: PolynomialSize,

--- a/concrete-core/src/commons/crypto/glwe/ciphertext.rs
+++ b/concrete-core/src/commons/crypto/glwe/ciphertext.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 /// An GLWE ciphertext.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlweCiphertext<Cont> {
     pub(crate) tensor: Tensor<Cont>,
     pub(crate) poly_size: PolynomialSize,

--- a/concrete-core/src/commons/crypto/glwe/list.rs
+++ b/concrete-core/src/commons/crypto/glwe/list.rs
@@ -14,7 +14,7 @@ use concrete_commons::parameters::{
 
 /// A list of ciphertexts encoded with the GLWE scheme.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlweList<Cont> {
     pub(crate) tensor: Tensor<Cont>,
     pub(crate) rlwe_size: GlweSize,

--- a/concrete-core/src/commons/crypto/gsw/ciphertext.rs
+++ b/concrete-core/src/commons/crypto/gsw/ciphertext.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 /// A GSW ciphertext.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GswCiphertext<Cont, Scalar> {
     tensor: Tensor<Cont>,
     lwe_size: LweSize,

--- a/concrete-core/src/commons/crypto/secret/glwe.rs
+++ b/concrete-core/src/commons/crypto/secret/glwe.rs
@@ -29,7 +29,7 @@ use std::ops::Add;
 
 /// A GLWE secret key
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlweSecretKey<Kind, Container>
 where
     Kind: KeyKind,

--- a/concrete-core/src/commons/crypto/secret/lwe.rs
+++ b/concrete-core/src/commons/crypto/secret/lwe.rs
@@ -28,7 +28,7 @@ use crate::commons::math::torus::UnsignedTorus;
 
 /// A LWE secret key.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweSecretKey<Kind, Cont>
 where
     Kind: KeyKind,

--- a/concrete-csprng/src/seeders/mod.rs
+++ b/concrete-csprng/src/seeders/mod.rs
@@ -6,7 +6,7 @@
 //! seeds that can accomodate varying scenarios.
 
 /// A seed value, used to initialize a generator.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Seed(pub u128);
 
 /// A trait representing a seeding strategy.


### PR DESCRIPTION
### Resolves:

closes https://github.com/zama-ai/concrete-core-internal/issues/161

### Description

New clippy lint asks to implement Eq in addition to PartialEq if all members of a struct are Eq.

This PR fixes the build issue by providing derive(Eq) to the offending structs.

Not sure if the release notes should be updated to indicate the classes deriving Eq now

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

~~* [ ] Tests for the changes have been added (for bug fixes / features)~~
~~* [ ] Docs have been added / updated (for bug fixes / features)~~
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
~~* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)~~
~~* [ ] The draft release description has been updated~~
~~* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]~~

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
