### PR TITLE
feat(core): add an aesni backend for the key creations

### DIFF
--- a/concrete-core-bench/Cargo.toml
+++ b/concrete-core-bench/Cargo.toml
@@ -14,4 +14,6 @@ criterion = "0.3.5"
 [features]
 backend_default = ["concrete-core/backend_default", "concrete-core-fixture/backend_default"]
 backend_fftw = ["concrete-core/backend_fftw", "concrete-core-fixture/backend_fftw"]
+backend_x86_64_aesni = ["concrete-core/backend_x86_64_aesni", 
+    "concrete-core-fixture/backend_x86_64_aesni"]
 parallel = ["concrete-core/parallel", "concrete-core-fixture/parallel"]

--- a/concrete-core-bench/src/aesni.rs
+++ b/concrete-core-bench/src/aesni.rs
@@ -1,0 +1,53 @@
+use crate::benchmark::BenchmarkFixture;
+use concrete_core::prelude::*;
+use concrete_core_fixture::fixture::*;
+use concrete_core_fixture::generation::{Maker, Precision32, Precision64};
+use concrete_csprng::seeders::UnixSeeder;
+use criterion::Criterion;
+
+use paste::paste;
+
+macro_rules! bench {
+    ($fixture: ident, $precision: ident, ($($types:ident),+), $maker: ident, $engine: ident, $criterion: ident) => {
+        paste!{
+            <$fixture as BenchmarkFixture<$precision, AesniEngine, ($($types,)+),
+            >>::bench_all_parameters(
+                &mut $maker,
+                &mut $engine,
+                &mut $criterion,
+                None
+            );
+        }
+    };
+    ($(($fixture: ident, ($($types:ident),+))),+) => {
+        pub fn bench() {
+            let mut criterion = Criterion::default().configure_from_args();
+            let mut maker = Maker::default();
+            let mut engine = AesniEngine::new(Box::new(UnixSeeder::new(0))).unwrap();
+            $(
+                paste!{
+                    bench!{$fixture, Precision32, ($([< $types 32 >]),+), maker, engine, criterion}
+                    bench!{$fixture, Precision64, ($([< $types 64 >]),+), maker, engine, criterion}
+                }
+            )+
+        }
+    };
+}
+
+bench! {
+    (GlweCiphertextDiscardingEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertext)),
+    (GlweCiphertextEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertext)),
+    (GlweCiphertextVectorDiscardingEncryptionFixture, (PlaintextVector, GlweSecretKey,
+        GlweCiphertextVector)),
+    (GlweCiphertextZeroEncryptionFixture, (GlweSecretKey, GlweCiphertext)),
+    (GlweCiphertextVectorZeroEncryptionFixture, (GlweSecretKey, GlweCiphertextVector)),
+    (GlweCiphertextVectorEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertextVector)),
+    (GlweSecretKeyCreationFixture, (GlweSecretKey)),
+    (LweCiphertextEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
+    (LweCiphertextZeroEncryptionFixture, (LweSecretKey, LweCiphertext)),
+    (LweCiphertextVectorEncryptionFixture, (PlaintextVector, LweSecretKey, LweCiphertextVector)),
+    (LweCiphertextVectorZeroEncryptionFixture, (LweSecretKey, LweCiphertextVector)),
+    (LweBootstrapKeyCreationFixture, (LweSecretKey, GlweSecretKey, LweBootstrapKey)),
+    (LweKeyswitchKeyCreationFixture, (LweSecretKey, LweSecretKey, LweKeyswitchKey)),
+    (LweSecretKeyCreationFixture, (LweSecretKey))
+}

--- a/concrete-core-bench/src/main.rs
+++ b/concrete-core-bench/src/main.rs
@@ -13,6 +13,9 @@ mod default;
 #[cfg(feature = "backend_fftw")]
 mod fftw;
 
+#[cfg(feature = "backend_x86_64_aesni")]
+mod aesni;
+
 // The main entry point. Uses criterion as benchmark harness.
 fn main() {
     // We instantiate the benchmarks for different backends depending on the feature flag activated.
@@ -22,6 +25,8 @@ fn main() {
     default::bench_parallel();
     #[cfg(feature = "backend_fftw")]
     fftw::bench();
+    #[cfg(feature = "backend_x86_64_aesni")]
+    aesni::bench();
 
     // We launch the benchmarks.
     criterion::Criterion::default()

--- a/concrete-core-fixture/Cargo.toml
+++ b/concrete-core-fixture/Cargo.toml
@@ -15,4 +15,5 @@ paste = "1.0"
 [features]
 backend_default = []
 backend_fftw = ["concrete-core/backend_fftw"]
+backend_x86_64_aesni = ["concrete-core/backend_x86_64_aesni"]
 parallel = ["concrete-core/parallel"]

--- a/concrete-core-test/Cargo.toml
+++ b/concrete-core-test/Cargo.toml
@@ -13,3 +13,4 @@ paste = "1.0"
 [features]
 backend_default = ["concrete-core/backend_default", "concrete-core-fixture/backend_default"]
 backend_fftw = ["concrete-core/backend_fftw", "concrete-core-fixture/backend_fftw"]
+backend_x86_64_aesni = ["concrete-core/backend_x86_64_aesni", "concrete-core-fixture/backend_x86_64_aesni"]

--- a/concrete-core-test/src/aesni.rs
+++ b/concrete-core-test/src/aesni.rs
@@ -1,0 +1,47 @@
+use crate::{REPETITIONS, SAMPLE_SIZE};
+use concrete_core::prelude::*;
+use concrete_core_fixture::fixture::*;
+use concrete_core_fixture::generation::{Maker, Precision32, Precision64};
+use concrete_csprng::seeders::UnixSeeder;
+use paste::paste;
+
+macro_rules! test {
+    ($fixture: ident, $precision: ident, ($($types:ident),+)) => {
+        paste!{
+            #[test]
+            fn [< test_ $fixture:snake _ $precision:snake _ $($types:snake)_+ >]() {
+                let mut maker = Maker::default();
+                let mut engine = AesniEngine::new(Box::new(UnixSeeder::new(0))).unwrap();
+                let test_result =
+                    <$fixture as Fixture<
+                        $precision,
+                        AesniEngine,
+                        ($($types,)+),
+                    >>::stress_all_parameters(&mut maker, &mut engine, REPETITIONS, SAMPLE_SIZE);
+                assert!(test_result);
+            }
+        }
+    };
+    ($(($fixture: ident, ($($types:ident),+))),+) => {
+        $(
+            paste!{
+                test!{$fixture, Precision32, ($([< $types 32 >]),+)}
+                test!{$fixture, Precision64, ($([< $types 64 >]),+)}
+            }
+        )+
+    };
+}
+
+test! {
+    (GlweCiphertextDiscardingEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertext)),
+    (GlweCiphertextEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertext)),
+    (GlweCiphertextVectorDiscardingEncryptionFixture, (PlaintextVector, GlweSecretKey,
+        GlweCiphertextVector)),
+    (GlweCiphertextZeroEncryptionFixture, (GlweSecretKey, GlweCiphertext)),
+    (GlweCiphertextVectorZeroEncryptionFixture, (GlweSecretKey, GlweCiphertextVector)),
+    (GlweCiphertextVectorEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertextVector)),
+    (LweCiphertextEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
+    (LweCiphertextZeroEncryptionFixture, (LweSecretKey, LweCiphertext)),
+    (LweCiphertextVectorEncryptionFixture, (PlaintextVector, LweSecretKey, LweCiphertextVector)),
+    (LweCiphertextVectorZeroEncryptionFixture, (LweSecretKey, LweCiphertextVector))
+}

--- a/concrete-core-test/src/lib.rs
+++ b/concrete-core-test/src/lib.rs
@@ -16,3 +16,5 @@ pub const SAMPLE_SIZE: SampleSize = SampleSize(100);
 pub mod default;
 #[cfg(all(test, feature = "backend_fftw"))]
 pub mod fftw;
+#[cfg(all(test, feature = "backend_x86_64_aesni"))]
+pub mod aesni;

--- a/concrete-core/Cargo.toml
+++ b/concrete-core/Cargo.toml
@@ -46,6 +46,11 @@ backend_fftw = [
     "concrete-fftw"
 ]
 
+# An accelerated backend, using the `aesni` feature of x86_64 processors.
+backend_x86_64_aesni = [
+    "concrete-csprng/generator_x86_64_aesni"
+]
+
 seeder_unix = ["concrete-csprng/seeder_unix"]
 seeder_x86_64_rdseed = ["concrete-csprng/seeder_x86_64_rdseed"]
 parallel = ["rayon", "concrete-csprng/parallel"]

--- a/concrete-core/src/backends/aesni/implementation/engines/ggsw_ciphertext_scalar_discarding_encryption.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/ggsw_ciphertext_scalar_discarding_encryption.rs
@@ -1,0 +1,177 @@
+use concrete_commons::dispersion::Variance;
+
+use crate::backends::aesni::implementation::engines::AesniEngine;
+use crate::prelude::{
+    GgswCiphertext32, GgswCiphertext64, GlweSecretKey32, GlweSecretKey64, Plaintext32, Plaintext64,
+};
+use crate::specification::engines::{
+    GgswCiphertextScalarDiscardingEncryptionEngine, GgswCiphertextScalarDiscardingEncryptionError,
+};
+
+/// # Description:
+/// Implementation of [`GgswCiphertextScalarDiscardingEncryptionEngine`] for [`AesniEngine`] that
+/// operates on 32 bits integers.
+impl GgswCiphertextScalarDiscardingEncryptionEngine<GlweSecretKey32, Plaintext32, GgswCiphertext32>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(4);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u32 << 20;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key_1: GlweSecretKey32 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    /// let mut ciphertext =
+    ///     aesni_engine.encrypt_scalar_ggsw_ciphertext(&key_1, &plaintext, noise, level, 
+    /// base_log)?;
+    /// // We're going to re-encrypt the input with another secret key
+    /// // For this, it is required that the second secret key uses the same GLWE dimension
+    /// // and polynomial size as the first one.
+    /// let key_2: GlweSecretKey32 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    ///
+    /// aesni_engine.discard_encrypt_scalar_ggsw_ciphertext(&key_2, &mut ciphertext, &plaintext, 
+    /// noise)?;
+    /// #
+    /// assert_eq!(ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(ciphertext.polynomial_size(), polynomial_size);
+    ///
+    /// default_engine.destroy(ciphertext)?;
+    /// default_engine.destroy(plaintext)?;
+    /// default_engine.destroy(key_1)?;
+    /// default_engine.destroy(key_2)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_encrypt_scalar_ggsw_ciphertext(
+        &mut self,
+        key: &GlweSecretKey32,
+        output: &mut GgswCiphertext32,
+        input: &Plaintext32,
+        noise: Variance,
+    ) -> Result<(), GgswCiphertextScalarDiscardingEncryptionError<Self::EngineError>> {
+        GgswCiphertextScalarDiscardingEncryptionError::perform_generic_checks(key, output)?;
+        unsafe { self.discard_encrypt_scalar_ggsw_ciphertext_unchecked(key, output, input, noise) };
+        Ok(())
+    }
+
+    unsafe fn discard_encrypt_scalar_ggsw_ciphertext_unchecked(
+        &mut self,
+        key: &GlweSecretKey32,
+        output: &mut GgswCiphertext32,
+        input: &Plaintext32,
+        noise: Variance,
+    ) {
+        key.0.encrypt_constant_ggsw(
+            &mut output.0,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+    }
+}
+
+/// # Description:
+/// Implementation of [`GgswCiphertextScalarDiscardingEncryptionEngine`] for [`AesniEngine`] that
+/// operates on 64 bits integers.
+impl GgswCiphertextScalarDiscardingEncryptionEngine<GlweSecretKey64, Plaintext64, GgswCiphertext64>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(4);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = 3_u64 << 50;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key_1: GlweSecretKey64 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    /// let mut ciphertext =
+    ///     aesni_engine.encrypt_scalar_ggsw_ciphertext(&key_1, &plaintext, noise, level, 
+    /// base_log)?;
+    /// // We're going to re-encrypt the input with another secret key
+    /// // For this, it is required that the second secret key uses the same GLWE dimension
+    /// // and polynomial size as the first one.
+    /// let key_2: GlweSecretKey64 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    ///
+    /// aesni_engine.discard_encrypt_scalar_ggsw_ciphertext(&key_2, &mut ciphertext, &plaintext, 
+    /// noise)?;
+    /// #
+    /// assert_eq!(ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(ciphertext.polynomial_size(), polynomial_size);
+    ///
+    /// default_engine.destroy(ciphertext)?;
+    /// default_engine.destroy(plaintext)?;
+    /// default_engine.destroy(key_1)?;
+    /// default_engine.destroy(key_2)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_encrypt_scalar_ggsw_ciphertext(
+        &mut self,
+        key: &GlweSecretKey64,
+        output: &mut GgswCiphertext64,
+        input: &Plaintext64,
+        noise: Variance,
+    ) -> Result<(), GgswCiphertextScalarDiscardingEncryptionError<Self::EngineError>> {
+        GgswCiphertextScalarDiscardingEncryptionError::perform_generic_checks(key, output)?;
+        unsafe { self.discard_encrypt_scalar_ggsw_ciphertext_unchecked(key, output, input, noise) };
+        Ok(())
+    }
+
+    unsafe fn discard_encrypt_scalar_ggsw_ciphertext_unchecked(
+        &mut self,
+        key: &GlweSecretKey64,
+        output: &mut GgswCiphertext64,
+        input: &Plaintext64,
+        noise: Variance,
+    ) {
+        key.0.encrypt_constant_ggsw(
+            &mut output.0,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/ggsw_ciphertext_scalar_encryption.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/ggsw_ciphertext_scalar_encryption.rs
@@ -1,0 +1,194 @@
+use concrete_commons::dispersion::Variance;
+use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+
+use crate::backends::aesni::implementation::engines::AesniEngine;
+use crate::prelude::{
+    GgswCiphertext32, GgswCiphertext64, GlweSecretKey32, GlweSecretKey64, Plaintext32, Plaintext64,
+};
+use crate::commons::crypto::ggsw::StandardGgswCiphertext as ImplGgswCiphertext;
+use crate::specification::engines::{
+    GgswCiphertextScalarEncryptionEngine, GgswCiphertextScalarEncryptionError,
+};
+use crate::specification::entities::GlweSecretKeyEntity;
+
+/// # Description:
+/// Implementation of [`GgswCiphertextScalarEncryptionEngine`] for [`AesniEngine`] that operates
+/// on 32 bits integers.
+impl GgswCiphertextScalarEncryptionEngine<GlweSecretKey32, Plaintext32, GgswCiphertext32>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(4);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u32 << 20;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: GlweSecretKey32 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    ///
+    /// let ciphertext =
+    ///     aesni_engine.encrypt_scalar_ggsw_ciphertext(&key, &plaintext, noise, level, base_log)?;
+    /// #
+    /// assert_eq!(ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(ciphertext.polynomial_size(), polynomial_size);
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(plaintext)?;
+    /// default_engine.destroy(ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn encrypt_scalar_ggsw_ciphertext(
+        &mut self,
+        key: &GlweSecretKey32,
+        input: &Plaintext32,
+        noise: Variance,
+        decomposition_level_count: DecompositionLevelCount,
+        decomposition_base_log: DecompositionBaseLog,
+    ) -> Result<GgswCiphertext32, GgswCiphertextScalarEncryptionError<Self::EngineError>> {
+        Ok(unsafe {
+            self.encrypt_scalar_ggsw_ciphertext_unchecked(
+                key,
+                input,
+                noise,
+                decomposition_level_count,
+                decomposition_base_log,
+            )
+        })
+    }
+
+    unsafe fn encrypt_scalar_ggsw_ciphertext_unchecked(
+        &mut self,
+        key: &GlweSecretKey32,
+        input: &Plaintext32,
+        noise: Variance,
+        decomposition_level_count: DecompositionLevelCount,
+        decomposition_base_log: DecompositionBaseLog,
+    ) -> GgswCiphertext32 {
+        let mut ciphertext = ImplGgswCiphertext::allocate(
+            0u32,
+            key.polynomial_size(),
+            key.glwe_dimension().to_glwe_size(),
+            decomposition_level_count,
+            decomposition_base_log,
+        );
+        key.0.encrypt_constant_ggsw(
+            &mut ciphertext,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+        GgswCiphertext32(ciphertext)
+    }
+}
+
+/// # Description:
+/// Implementation of [`GgswCiphertextScalarEncryptionEngine`] for [`AesniEngine`] that operates
+/// on 64 bits integers.
+impl GgswCiphertextScalarEncryptionEngine<GlweSecretKey64, Plaintext64, GgswCiphertext64>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(4);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = 3_u64 << 50;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: GlweSecretKey64 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    ///
+    /// let ciphertext =
+    ///     aesni_engine.encrypt_scalar_ggsw_ciphertext(&key, &plaintext, noise, level, base_log)?;
+    /// #
+    /// assert_eq!(ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(ciphertext.polynomial_size(), polynomial_size);
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(plaintext)?;
+    /// default_engine.destroy(ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn encrypt_scalar_ggsw_ciphertext(
+        &mut self,
+        key: &GlweSecretKey64,
+        input: &Plaintext64,
+        noise: Variance,
+        decomposition_level_count: DecompositionLevelCount,
+        decomposition_base_log: DecompositionBaseLog,
+    ) -> Result<GgswCiphertext64, GgswCiphertextScalarEncryptionError<Self::EngineError>> {
+        Ok(unsafe {
+            self.encrypt_scalar_ggsw_ciphertext_unchecked(
+                key,
+                input,
+                noise,
+                decomposition_level_count,
+                decomposition_base_log,
+            )
+        })
+    }
+
+    unsafe fn encrypt_scalar_ggsw_ciphertext_unchecked(
+        &mut self,
+        key: &GlweSecretKey64,
+        input: &Plaintext64,
+        noise: Variance,
+        decomposition_level_count: DecompositionLevelCount,
+        decomposition_base_log: DecompositionBaseLog,
+    ) -> GgswCiphertext64 {
+        let mut ciphertext = ImplGgswCiphertext::allocate(
+            0u64,
+            key.polynomial_size(),
+            key.glwe_dimension().to_glwe_size(),
+            decomposition_level_count,
+            decomposition_base_log,
+        );
+        key.0.encrypt_constant_ggsw(
+            &mut ciphertext,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+        GgswCiphertext64(ciphertext)
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/glwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/glwe_ciphertext_discarding_encryption.rs
@@ -1,0 +1,168 @@
+use concrete_commons::dispersion::Variance;
+
+use crate::backends::aesni::implementation::engines::AesniEngine;
+use crate::prelude::{
+    GlweCiphertext32, GlweCiphertext64, GlweSecretKey32, GlweSecretKey64, PlaintextVector32,
+    PlaintextVector64,
+};
+use crate::specification::engines::{
+    GlweCiphertextDiscardingEncryptionEngine, GlweCiphertextDiscardingEncryptionError,
+};
+
+/// # Description:
+/// Implementation of [`GlweCiphertextDiscardingEncryptionEngine`] for [`AesniEngine`] that
+/// operates on 32 bits integers.
+impl GlweCiphertextDiscardingEncryptionEngine<GlweSecretKey32, PlaintextVector32, GlweCiphertext32>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(4);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = vec![3_u32 << 20; 4];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key_1: GlweSecretKey32 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    /// let plaintext_vector = default_engine.create_plaintext_vector(&input)?;
+    /// let mut ciphertext = aesni_engine.encrypt_glwe_ciphertext(&key_1, &plaintext_vector, 
+    /// noise)?;
+    /// // We're going to re-encrypt the input with another secret key
+    /// // For this, it is required that the second secret key uses the same GLWE dimension
+    /// // and polynomial size as the first one.
+    /// let key_2: GlweSecretKey32 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    ///
+    /// aesni_engine.discard_encrypt_glwe_ciphertext(&key_2, &mut ciphertext, &plaintext_vector, 
+    /// noise)?;
+    /// #
+    /// assert_eq!(ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(ciphertext.polynomial_size(), polynomial_size);
+    ///
+    /// default_engine.destroy(ciphertext)?;
+    /// default_engine.destroy(plaintext_vector)?;
+    /// default_engine.destroy(key_1)?;
+    /// default_engine.destroy(key_2)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_encrypt_glwe_ciphertext(
+        &mut self,
+        key: &GlweSecretKey32,
+        output: &mut GlweCiphertext32,
+        input: &PlaintextVector32,
+        noise: Variance,
+    ) -> Result<(), GlweCiphertextDiscardingEncryptionError<Self::EngineError>> {
+        GlweCiphertextDiscardingEncryptionError::perform_generic_checks(key, output, input)?;
+        unsafe { self.discard_encrypt_glwe_ciphertext_unchecked(key, output, input, noise) };
+        Ok(())
+    }
+
+    unsafe fn discard_encrypt_glwe_ciphertext_unchecked(
+        &mut self,
+        key: &GlweSecretKey32,
+        output: &mut GlweCiphertext32,
+        input: &PlaintextVector32,
+        noise: Variance,
+    ) {
+        key.0.encrypt_glwe(
+            &mut output.0,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+    }
+}
+
+/// # Description:
+/// Implementation of [`GlweCiphertextDiscardingEncryptionEngine`] for [`AesniEngine`] that
+/// operates on 64 bits integers.
+impl GlweCiphertextDiscardingEncryptionEngine<GlweSecretKey64, PlaintextVector64, GlweCiphertext64>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(4);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = vec![3_u64 << 50; 4];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key_1: GlweSecretKey64 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    /// let plaintext_vector = default_engine.create_plaintext_vector(&input)?;
+    /// let mut ciphertext = aesni_engine.encrypt_glwe_ciphertext(&key_1, &plaintext_vector, 
+    /// noise)?;
+    /// // We're going to re-encrypt the input with another secret key
+    /// // For this, it is required that the second secret key uses the same GLWE dimension
+    /// // and polynomial size as the first one.
+    /// let key_2: GlweSecretKey64 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    ///
+    /// aesni_engine.discard_encrypt_glwe_ciphertext(&key_2, &mut ciphertext, &plaintext_vector, 
+    /// noise)?;
+    /// #
+    /// assert_eq!(ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(ciphertext.polynomial_size(), polynomial_size);
+    ///
+    /// default_engine.destroy(ciphertext)?;
+    /// default_engine.destroy(plaintext_vector)?;
+    /// default_engine.destroy(key_1)?;
+    /// default_engine.destroy(key_2)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_encrypt_glwe_ciphertext(
+        &mut self,
+        key: &GlweSecretKey64,
+        output: &mut GlweCiphertext64,
+        input: &PlaintextVector64,
+        noise: Variance,
+    ) -> Result<(), GlweCiphertextDiscardingEncryptionError<Self::EngineError>> {
+        GlweCiphertextDiscardingEncryptionError::perform_generic_checks(key, output, input)?;
+        unsafe { self.discard_encrypt_glwe_ciphertext_unchecked(key, output, input, noise) };
+        Ok(())
+    }
+
+    unsafe fn discard_encrypt_glwe_ciphertext_unchecked(
+        &mut self,
+        key: &GlweSecretKey64,
+        output: &mut GlweCiphertext64,
+        input: &PlaintextVector64,
+        noise: Variance,
+    ) {
+        key.0.encrypt_glwe(
+            &mut output.0,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/glwe_ciphertext_encryption.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/glwe_ciphertext_encryption.rs
@@ -1,0 +1,160 @@
+use concrete_commons::dispersion::Variance;
+
+use crate::backends::aesni::implementation::engines::AesniEngine;
+use crate::prelude::{
+    GlweCiphertext32, GlweCiphertext64, GlweSecretKey32, GlweSecretKey64, PlaintextVector32,
+    PlaintextVector64,
+};
+use crate::commons::crypto::glwe::GlweCiphertext as ImplGlweCiphertext;
+use crate::specification::engines::{
+    GlweCiphertextEncryptionEngine, GlweCiphertextEncryptionError,
+};
+use crate::specification::entities::GlweSecretKeyEntity;
+
+/// # Description:
+/// Implementation of [`GlweCiphertextEncryptionEngine`] for [`AesniEngine`] that operates on 32
+/// bits integers.
+impl GlweCiphertextEncryptionEngine<GlweSecretKey32, PlaintextVector32, GlweCiphertext32>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(4);
+    /// // There are always polynomial_size messages encrypted in the GLWE ciphertext
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = vec![3_u32 << 20; polynomial_size.0];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: GlweSecretKey32 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    /// let plaintext_vector = default_engine.create_plaintext_vector(&input)?;
+    ///
+    /// let ciphertext = aesni_engine.encrypt_glwe_ciphertext(&key, &plaintext_vector, noise)?;
+    /// #
+    /// assert_eq!(ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(ciphertext.polynomial_size(), polynomial_size);
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(plaintext_vector)?;
+    /// default_engine.destroy(ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn encrypt_glwe_ciphertext(
+        &mut self,
+        key: &GlweSecretKey32,
+        input: &PlaintextVector32,
+        noise: Variance,
+    ) -> Result<GlweCiphertext32, GlweCiphertextEncryptionError<Self::EngineError>> {
+        GlweCiphertextEncryptionError::perform_generic_checks(key, input)?;
+        Ok(unsafe { self.encrypt_glwe_ciphertext_unchecked(key, input, noise) })
+    }
+
+    unsafe fn encrypt_glwe_ciphertext_unchecked(
+        &mut self,
+        key: &GlweSecretKey32,
+        input: &PlaintextVector32,
+        noise: Variance,
+    ) -> GlweCiphertext32 {
+        let mut ciphertext = ImplGlweCiphertext::allocate(
+            0u32,
+            key.polynomial_size(),
+            key.glwe_dimension().to_glwe_size(),
+        );
+        key.0.encrypt_glwe(
+            &mut ciphertext,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+        GlweCiphertext32(ciphertext)
+    }
+}
+
+/// # Description:
+/// Implementation of [`GlweCiphertextEncryptionEngine`] for [`AesniEngine`] that operates on 64
+/// bits integers.
+impl GlweCiphertextEncryptionEngine<GlweSecretKey64, PlaintextVector64, GlweCiphertext64>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(4);
+    /// // There are always polynomial_size messages encrypted in the GLWE ciphertext
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = vec![3_u64 << 50; polynomial_size.0];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: GlweSecretKey64 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    /// let plaintext_vector = default_engine.create_plaintext_vector(&input)?;
+    ///
+    /// let ciphertext = aesni_engine.encrypt_glwe_ciphertext(&key, &plaintext_vector, noise)?;
+    /// #
+    /// assert_eq!(ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(ciphertext.polynomial_size(), polynomial_size);
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(plaintext_vector)?;
+    /// default_engine.destroy(ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn encrypt_glwe_ciphertext(
+        &mut self,
+        key: &GlweSecretKey64,
+        input: &PlaintextVector64,
+        noise: Variance,
+    ) -> Result<GlweCiphertext64, GlweCiphertextEncryptionError<Self::EngineError>> {
+        GlweCiphertextEncryptionError::perform_generic_checks(key, input)?;
+        Ok(unsafe { self.encrypt_glwe_ciphertext_unchecked(key, input, noise) })
+    }
+
+    unsafe fn encrypt_glwe_ciphertext_unchecked(
+        &mut self,
+        key: &GlweSecretKey64,
+        input: &PlaintextVector64,
+        noise: Variance,
+    ) -> GlweCiphertext64 {
+        let mut ciphertext = ImplGlweCiphertext::allocate(
+            0u64,
+            key.polynomial_size(),
+            key.glwe_dimension().to_glwe_size(),
+        );
+        key.0.encrypt_glwe(
+            &mut ciphertext,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+        GlweCiphertext64(ciphertext)
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/glwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/glwe_ciphertext_vector_discarding_encryption.rs
@@ -1,0 +1,186 @@
+use concrete_commons::dispersion::Variance;
+
+use crate::backends::aesni::implementation::engines::AesniEngine;
+use crate::prelude::{
+    GlweCiphertextVector32, GlweCiphertextVector64, GlweSecretKey32, GlweSecretKey64,
+    PlaintextVector32, PlaintextVector64,
+};
+use crate::specification::engines::{
+    GlweCiphertextVectorDiscardingEncryptionEngine, GlweCiphertextVectorDiscardingEncryptionError,
+};
+
+/// # Description:
+/// Implementation of [`GlweCiphertextVectorDiscardingEncryptionEngine`] for [`AesniEngine`] that
+/// operates on 32 bits integers.
+impl
+    GlweCiphertextVectorDiscardingEncryptionEngine<
+        GlweSecretKey32,
+        PlaintextVector32,
+        GlweCiphertextVector32,
+    > for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{GlweCiphertextCount, GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(4);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = vec![3_u32 << 20; 8];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key_1: GlweSecretKey32 =
+    ///     aesni_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let key_2: GlweSecretKey32 =
+    ///     aesni_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext_vector = default_engine.create_plaintext_vector(&input)?;
+    /// let mut ciphertext_vector =
+    ///     aesni_engine.encrypt_glwe_ciphertext_vector(&key_1, &plaintext_vector, noise)?;
+    ///
+    /// aesni_engine.discard_encrypt_glwe_ciphertext_vector(
+    ///     &key_2,
+    ///     &mut ciphertext_vector,
+    ///     &plaintext_vector,
+    ///     noise,
+    /// )?;
+    /// #
+    /// assert_eq!(ciphertext_vector.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(ciphertext_vector.polynomial_size(), polynomial_size);
+    /// assert_eq!(
+    /// #     ciphertext_vector.glwe_ciphertext_count(),
+    /// #     GlweCiphertextCount(2)
+    /// # );
+    ///
+    /// default_engine.destroy(ciphertext_vector)?;
+    /// default_engine.destroy(plaintext_vector)?;
+    /// default_engine.destroy(key_1)?;
+    /// default_engine.destroy(key_2)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_encrypt_glwe_ciphertext_vector(
+        &mut self,
+        key: &GlweSecretKey32,
+        output: &mut GlweCiphertextVector32,
+        input: &PlaintextVector32,
+        noise: Variance,
+    ) -> Result<(), GlweCiphertextVectorDiscardingEncryptionError<Self::EngineError>> {
+        GlweCiphertextVectorDiscardingEncryptionError::perform_generic_checks(key, output, input)?;
+        unsafe { self.discard_encrypt_glwe_ciphertext_vector_unchecked(key, output, input, noise) };
+        Ok(())
+    }
+
+    unsafe fn discard_encrypt_glwe_ciphertext_vector_unchecked(
+        &mut self,
+        key: &GlweSecretKey32,
+        output: &mut GlweCiphertextVector32,
+        input: &PlaintextVector32,
+        noise: Variance,
+    ) {
+        key.0.encrypt_glwe_list(
+            &mut output.0,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+    }
+}
+
+/// # Description:
+/// Implementation of [`GlweCiphertextVectorDiscardingEncryptionEngine`] for [`AesniEngine`] that
+/// operates on 64 bits integers.
+impl
+    GlweCiphertextVectorDiscardingEncryptionEngine<
+        GlweSecretKey64,
+        PlaintextVector64,
+        GlweCiphertextVector64,
+    > for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{GlweCiphertextCount, GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(4);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = vec![3_u64 << 50; 8];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key_1: GlweSecretKey64 =
+    ///     aesni_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let key_2: GlweSecretKey64 =
+    ///     aesni_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext_vector = default_engine.create_plaintext_vector(&input)?;
+    /// let mut ciphertext_vector =
+    ///     aesni_engine.encrypt_glwe_ciphertext_vector(&key_1, &plaintext_vector, noise)?;
+    ///
+    /// aesni_engine.discard_encrypt_glwe_ciphertext_vector(
+    ///     &key_2,
+    ///     &mut ciphertext_vector,
+    ///     &plaintext_vector,
+    ///     noise,
+    /// )?;
+    /// #
+    /// assert_eq!(ciphertext_vector.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(ciphertext_vector.polynomial_size(), polynomial_size);
+    /// assert_eq!(
+    /// #     ciphertext_vector.glwe_ciphertext_count(),
+    /// #     GlweCiphertextCount(2)
+    /// # );
+    ///
+    /// default_engine.destroy(ciphertext_vector)?;
+    /// default_engine.destroy(plaintext_vector)?;
+    /// default_engine.destroy(key_1)?;
+    /// default_engine.destroy(key_2)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_encrypt_glwe_ciphertext_vector(
+        &mut self,
+        key: &GlweSecretKey64,
+        output: &mut GlweCiphertextVector64,
+        input: &PlaintextVector64,
+        noise: Variance,
+    ) -> Result<(), GlweCiphertextVectorDiscardingEncryptionError<Self::EngineError>> {
+        GlweCiphertextVectorDiscardingEncryptionError::perform_generic_checks(key, output, input)?;
+        unsafe { self.discard_encrypt_glwe_ciphertext_vector_unchecked(key, output, input, noise) };
+        Ok(())
+    }
+
+    unsafe fn discard_encrypt_glwe_ciphertext_vector_unchecked(
+        &mut self,
+        key: &GlweSecretKey64,
+        output: &mut GlweCiphertextVector64,
+        input: &PlaintextVector64,
+        noise: Variance,
+    ) {
+        key.0.encrypt_glwe_list(
+            &mut output.0,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/glwe_ciphertext_vector_encryption.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/glwe_ciphertext_vector_encryption.rs
@@ -1,0 +1,175 @@
+use concrete_commons::dispersion::Variance;
+use concrete_commons::parameters::CiphertextCount;
+
+use crate::backends::aesni::implementation::engines::AesniEngine;
+use crate::prelude::{
+    GlweCiphertextVector32, GlweCiphertextVector64, GlweSecretKey32, GlweSecretKey64,
+    PlaintextVector32, PlaintextVector64,
+};
+use crate::commons::crypto::glwe::GlweList as ImplGlweList;
+use crate::specification::engines::{
+    GlweCiphertextVectorEncryptionEngine, GlweCiphertextVectorEncryptionError,
+};
+use crate::specification::entities::{GlweSecretKeyEntity, PlaintextVectorEntity};
+
+/// # Description:
+/// Implementation of [`GlweCiphertextVectorEncryptionEngine`] for [`AesniEngine`] that operates
+/// on 32 bits integers.
+impl
+    GlweCiphertextVectorEncryptionEngine<GlweSecretKey32, PlaintextVector32, GlweCiphertextVector32>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{GlweCiphertextCount, GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(4);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = vec![3_u32 << 20; 8];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: GlweSecretKey32 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    /// let plaintext_vector = default_engine.create_plaintext_vector(&input)?;
+    ///
+    /// let ciphertext_vector =
+    ///     aesni_engine.encrypt_glwe_ciphertext_vector(&key, &plaintext_vector, noise)?;
+    /// #
+    /// assert_eq!(
+    /// #     ciphertext_vector.glwe_ciphertext_count(),
+    /// #     GlweCiphertextCount(2)
+    /// # );
+    /// assert_eq!(ciphertext_vector.polynomial_size(), polynomial_size);
+    /// assert_eq!(ciphertext_vector.glwe_dimension(), glwe_dimension);
+    ///
+    /// default_engine.destroy(ciphertext_vector)?;
+    /// default_engine.destroy(plaintext_vector)?;
+    /// default_engine.destroy(key)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn encrypt_glwe_ciphertext_vector(
+        &mut self,
+        key: &GlweSecretKey32,
+        input: &PlaintextVector32,
+        noise: Variance,
+    ) -> Result<GlweCiphertextVector32, GlweCiphertextVectorEncryptionError<Self::EngineError>>
+    {
+        GlweCiphertextVectorEncryptionError::perform_generic_checks(key, input)?;
+        Ok(unsafe { self.encrypt_glwe_ciphertext_vector_unchecked(key, input, noise) })
+    }
+
+    unsafe fn encrypt_glwe_ciphertext_vector_unchecked(
+        &mut self,
+        key: &GlweSecretKey32,
+        input: &PlaintextVector32,
+        noise: Variance,
+    ) -> GlweCiphertextVector32 {
+        let mut ciphertext_vector = ImplGlweList::allocate(
+            0u32,
+            key.polynomial_size(),
+            key.glwe_dimension(),
+            CiphertextCount(input.plaintext_count().0 / key.polynomial_size().0),
+        );
+        key.0.encrypt_glwe_list(
+            &mut ciphertext_vector,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+        GlweCiphertextVector32(ciphertext_vector)
+    }
+}
+
+/// # Description:
+/// Implementation of [`GlweCiphertextVectorEncryptionEngine`] for [`AesniEngine`] that operates
+/// on 64 bits integers.
+impl
+    GlweCiphertextVectorEncryptionEngine<GlweSecretKey64, PlaintextVector64, GlweCiphertextVector64>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{GlweCiphertextCount, GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(4);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = vec![3_u64 << 50; 8];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: GlweSecretKey64 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    /// let plaintext_vector = default_engine.create_plaintext_vector(&input)?;
+    ///
+    /// let ciphertext_vector =
+    ///     aesni_engine.encrypt_glwe_ciphertext_vector(&key, &plaintext_vector, noise)?;
+    /// #
+    /// assert_eq!(
+    /// #     ciphertext_vector.glwe_ciphertext_count(),
+    /// #     GlweCiphertextCount(2)
+    /// # );
+    /// assert_eq!(ciphertext_vector.polynomial_size(), polynomial_size);
+    /// assert_eq!(ciphertext_vector.glwe_dimension(), glwe_dimension);
+    ///
+    /// default_engine.destroy(ciphertext_vector)?;
+    /// default_engine.destroy(plaintext_vector)?;
+    /// default_engine.destroy(key)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn encrypt_glwe_ciphertext_vector(
+        &mut self,
+        key: &GlweSecretKey64,
+        input: &PlaintextVector64,
+        noise: Variance,
+    ) -> Result<GlweCiphertextVector64, GlweCiphertextVectorEncryptionError<Self::EngineError>>
+    {
+        GlweCiphertextVectorEncryptionError::perform_generic_checks(key, input)?;
+        Ok(unsafe { self.encrypt_glwe_ciphertext_vector_unchecked(key, input, noise) })
+    }
+
+    unsafe fn encrypt_glwe_ciphertext_vector_unchecked(
+        &mut self,
+        key: &GlweSecretKey64,
+        input: &PlaintextVector64,
+        noise: Variance,
+    ) -> GlweCiphertextVector64 {
+        let mut ciphertext_vector = ImplGlweList::allocate(
+            0u64,
+            key.polynomial_size(),
+            key.glwe_dimension(),
+            CiphertextCount(input.plaintext_count().0 / key.polynomial_size().0),
+        );
+        key.0.encrypt_glwe_list(
+            &mut ciphertext_vector,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+        GlweCiphertextVector64(ciphertext_vector)
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/glwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/glwe_ciphertext_vector_zero_encryption.rs
@@ -1,0 +1,158 @@
+use concrete_commons::dispersion::Variance;
+use concrete_commons::parameters::{CiphertextCount, GlweCiphertextCount};
+
+use crate::backends::aesni::implementation::engines::AesniEngine;
+use crate::prelude::{
+    GlweCiphertextVector32, GlweCiphertextVector64, GlweSecretKey32, GlweSecretKey64,
+};
+use crate::commons::crypto::glwe::GlweList as ImplGlweList;
+use crate::specification::engines::{
+    GlweCiphertextVectorZeroEncryptionEngine, GlweCiphertextVectorZeroEncryptionError,
+};
+use crate::specification::entities::GlweSecretKeyEntity;
+
+/// # Description:
+/// Implementation of [`GlweCiphertextVectorZeroEncryptionEngine`] for [`AesniEngine`] that
+/// operates on 32 bits integers.
+impl GlweCiphertextVectorZeroEncryptionEngine<GlweSecretKey32, GlweCiphertextVector32>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{GlweCiphertextCount, GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(1024);
+    /// let ciphertext_count = GlweCiphertextCount(3);
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: GlweSecretKey32 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    ///
+    /// let ciphertext_vector =
+    ///     aesni_engine.zero_encrypt_glwe_ciphertext_vector(&key, noise, ciphertext_count)?;
+    /// #
+    /// assert_eq!(ciphertext_vector.glwe_ciphertext_count(), ciphertext_count);
+    /// assert_eq!(ciphertext_vector.polynomial_size(), polynomial_size);
+    /// assert_eq!(ciphertext_vector.glwe_dimension(), glwe_dimension);
+    ///
+    /// default_engine.destroy(ciphertext_vector)?;
+    /// default_engine.destroy(key)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn zero_encrypt_glwe_ciphertext_vector(
+        &mut self,
+        key: &GlweSecretKey32,
+        noise: Variance,
+        count: GlweCiphertextCount,
+    ) -> Result<GlweCiphertextVector32, GlweCiphertextVectorZeroEncryptionError<Self::EngineError>>
+    {
+        GlweCiphertextVectorZeroEncryptionError::perform_generic_checks(count)?;
+        Ok(unsafe { self.zero_encrypt_glwe_ciphertext_vector_unchecked(key, noise, count) })
+    }
+
+    unsafe fn zero_encrypt_glwe_ciphertext_vector_unchecked(
+        &mut self,
+        key: &GlweSecretKey32,
+        noise: Variance,
+        count: GlweCiphertextCount,
+    ) -> GlweCiphertextVector32 {
+        let mut ciphertext_vector = ImplGlweList::allocate(
+            0u32,
+            key.polynomial_size(),
+            key.glwe_dimension(),
+            CiphertextCount(count.0),
+        );
+        key.0.encrypt_zero_glwe_list(
+            &mut ciphertext_vector,
+            noise,
+            &mut self.encryption_generator,
+        );
+        GlweCiphertextVector32(ciphertext_vector)
+    }
+}
+
+/// # Description:
+/// Implementation of [`GlweCiphertextVectorZeroEncryptionEngine`] for [`AesniEngine`] that
+/// operates on 64 bits integers.
+impl GlweCiphertextVectorZeroEncryptionEngine<GlweSecretKey64, GlweCiphertextVector64>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{GlweCiphertextCount, GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(1024);
+    /// let ciphertext_count = GlweCiphertextCount(3);
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: GlweSecretKey64 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    ///
+    /// let ciphertext_vector =
+    ///     aesni_engine.zero_encrypt_glwe_ciphertext_vector(&key, noise, ciphertext_count)?;
+    /// #
+    /// assert_eq!(ciphertext_vector.glwe_ciphertext_count(), ciphertext_count);
+    /// assert_eq!(ciphertext_vector.polynomial_size(), polynomial_size);
+    /// assert_eq!(ciphertext_vector.glwe_dimension(), glwe_dimension);
+    ///
+    /// default_engine.destroy(ciphertext_vector)?;
+    /// default_engine.destroy(key)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn zero_encrypt_glwe_ciphertext_vector(
+        &mut self,
+        key: &GlweSecretKey64,
+        noise: Variance,
+        count: GlweCiphertextCount,
+    ) -> Result<GlweCiphertextVector64, GlweCiphertextVectorZeroEncryptionError<Self::EngineError>>
+    {
+        GlweCiphertextVectorZeroEncryptionError::perform_generic_checks(count)?;
+        Ok(unsafe { self.zero_encrypt_glwe_ciphertext_vector_unchecked(key, noise, count) })
+    }
+
+    unsafe fn zero_encrypt_glwe_ciphertext_vector_unchecked(
+        &mut self,
+        key: &GlweSecretKey64,
+        noise: Variance,
+        count: GlweCiphertextCount,
+    ) -> GlweCiphertextVector64 {
+        let mut ciphertext_vector = ImplGlweList::allocate(
+            0u64,
+            key.polynomial_size(),
+            key.glwe_dimension(),
+            CiphertextCount(count.0),
+        );
+        key.0.encrypt_zero_glwe_list(
+            &mut ciphertext_vector,
+            noise,
+            &mut self.encryption_generator,
+        );
+        GlweCiphertextVector64(ciphertext_vector)
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/glwe_ciphertext_zero_encryption.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/glwe_ciphertext_zero_encryption.rs
@@ -1,0 +1,129 @@
+use concrete_commons::dispersion::Variance;
+
+use crate::backends::aesni::implementation::engines::AesniEngine;
+use crate::prelude::{
+    GlweCiphertext32, GlweCiphertext64, GlweSecretKey32, GlweSecretKey64,
+};
+use crate::commons::crypto::glwe::GlweCiphertext as ImplGlweCiphertext;
+use crate::specification::engines::{
+    GlweCiphertextZeroEncryptionEngine, GlweCiphertextZeroEncryptionError,
+};
+use crate::specification::entities::GlweSecretKeyEntity;
+
+/// # Description:
+/// Implementation of [`GlweCiphertextZeroEncryptionEngine`] for [`AesniEngine`] that operates on
+/// 32 bits integers.
+impl GlweCiphertextZeroEncryptionEngine<GlweSecretKey32, GlweCiphertext32> for AesniEngine {
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(1024);
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: GlweSecretKey32 = aesni_engine.create_glwe_secret_key(glwe_dimension, 
+    /// polynomial_size)?;
+    ///
+    /// let ciphertext = aesni_engine.zero_encrypt_glwe_ciphertext(&key, noise)?;
+    /// #
+    /// assert_eq!(ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(ciphertext.polynomial_size(), polynomial_size);
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn zero_encrypt_glwe_ciphertext(
+        &mut self,
+        key: &GlweSecretKey32,
+        noise: Variance,
+    ) -> Result<GlweCiphertext32, GlweCiphertextZeroEncryptionError<Self::EngineError>> {
+        Ok(unsafe { self.zero_encrypt_glwe_ciphertext_unchecked(key, noise) })
+    }
+
+    unsafe fn zero_encrypt_glwe_ciphertext_unchecked(
+        &mut self,
+        key: &GlweSecretKey32,
+        noise: Variance,
+    ) -> GlweCiphertext32 {
+        let mut ciphertext = ImplGlweCiphertext::allocate(
+            0u32,
+            key.polynomial_size(),
+            key.glwe_dimension().to_glwe_size(),
+        );
+        key.0
+            .encrypt_zero_glwe(&mut ciphertext, noise, &mut self.encryption_generator);
+        GlweCiphertext32(ciphertext)
+    }
+}
+
+/// # Description:
+/// Implementation of [`GlweCiphertextZeroEncryptionEngine`] for [`AesniEngine`] that operates on
+/// 64 bits integers.
+impl GlweCiphertextZeroEncryptionEngine<GlweSecretKey64, GlweCiphertext64> for AesniEngine {
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(1024);
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    ///
+    /// let ciphertext = engine.zero_encrypt_glwe_ciphertext(&key, noise)?;
+    /// #
+    /// assert_eq!(ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(ciphertext.polynomial_size(), polynomial_size);
+    ///
+    /// engine.destroy(key)?;
+    /// engine.destroy(ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn zero_encrypt_glwe_ciphertext(
+        &mut self,
+        key: &GlweSecretKey64,
+        noise: Variance,
+    ) -> Result<GlweCiphertext64, GlweCiphertextZeroEncryptionError<Self::EngineError>> {
+        Ok(unsafe { self.zero_encrypt_glwe_ciphertext_unchecked(key, noise) })
+    }
+
+    unsafe fn zero_encrypt_glwe_ciphertext_unchecked(
+        &mut self,
+        key: &GlweSecretKey64,
+        noise: Variance,
+    ) -> GlweCiphertext64 {
+        let mut ciphertext = ImplGlweCiphertext::allocate(
+            0u64,
+            key.polynomial_size(),
+            key.glwe_dimension().to_glwe_size(),
+        );
+        key.0
+            .encrypt_zero_glwe(&mut ciphertext, noise, &mut self.encryption_generator);
+        GlweCiphertext64(ciphertext)
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/glwe_secret_key_creation.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/glwe_secret_key_creation.rs
@@ -1,0 +1,112 @@
+use concrete_commons::parameters::{GlweDimension, PolynomialSize};
+
+use crate::backends::aesni::implementation::engines::AesniEngine;
+use crate::commons::crypto::secret::GlweSecretKey as ImplGlweSecretKey;
+use crate::prelude::{GlweSecretKey32, GlweSecretKey64};
+use crate::specification::engines::{GlweSecretKeyCreationEngine, GlweSecretKeyCreationError};
+
+/// # Description:
+/// Implementation of [`GlweSecretKeyCreationEngine`] for [`AesniEngine`] that operates on
+/// 32 bits integers.
+impl GlweSecretKeyCreationEngine<GlweSecretKey32> for AesniEngine {
+    /// # Example:
+    /// ```
+    /// use concrete_commons::parameters::{GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(4);
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let glwe_secret_key: GlweSecretKey32 =
+    ///     aesni_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// #
+    /// assert_eq!(glwe_secret_key.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(glwe_secret_key.polynomial_size(), polynomial_size);
+    ///
+    /// default_engine.destroy(glwe_secret_key)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn create_glwe_secret_key(
+        &mut self,
+        glwe_dimension: GlweDimension,
+        polynomial_size: PolynomialSize,
+    ) -> Result<GlweSecretKey32, GlweSecretKeyCreationError<Self::EngineError>> {
+        GlweSecretKeyCreationError::perform_generic_checks(glwe_dimension, polynomial_size)?;
+        Ok(unsafe { self.create_glwe_secret_key_unchecked(glwe_dimension, polynomial_size) })
+    }
+
+    unsafe fn create_glwe_secret_key_unchecked(
+        &mut self,
+        glwe_dimension: GlweDimension,
+        polynomial_size: PolynomialSize,
+    ) -> GlweSecretKey32 {
+        GlweSecretKey32(ImplGlweSecretKey::generate_binary(
+            glwe_dimension,
+            polynomial_size,
+            &mut self.secret_generator,
+        ))
+    }
+}
+
+/// # Description:
+/// Implementation of [`GlweSecretKeyCreationEngine`] for [`AesniEngine`] that operates on
+/// 64 bits integers.
+impl GlweSecretKeyCreationEngine<GlweSecretKey64> for AesniEngine {
+    /// # Example:
+    /// ```
+    /// use concrete_commons::parameters::{GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(4);
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let glwe_secret_key: GlweSecretKey64 =
+    ///     aesni_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// #
+    /// assert_eq!(glwe_secret_key.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(glwe_secret_key.polynomial_size(), polynomial_size);
+    ///
+    /// default_engine.destroy(glwe_secret_key)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn create_glwe_secret_key(
+        &mut self,
+        glwe_dimension: GlweDimension,
+        polynomial_size: PolynomialSize,
+    ) -> Result<GlweSecretKey64, GlweSecretKeyCreationError<Self::EngineError>> {
+        GlweSecretKeyCreationError::perform_generic_checks(glwe_dimension, polynomial_size)?;
+        Ok(unsafe { self.create_glwe_secret_key_unchecked(glwe_dimension, polynomial_size) })
+    }
+
+    unsafe fn create_glwe_secret_key_unchecked(
+        &mut self,
+        glwe_dimension: GlweDimension,
+        polynomial_size: PolynomialSize,
+    ) -> GlweSecretKey64 {
+        GlweSecretKey64(ImplGlweSecretKey::generate_binary(
+            glwe_dimension,
+            polynomial_size,
+            &mut self.secret_generator,
+        ))
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/lwe_bootstrap_key_creation.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/lwe_bootstrap_key_creation.rs
@@ -1,0 +1,197 @@
+use concrete_commons::dispersion::Variance;
+use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+
+use crate::backends::aesni::implementation::engines::AesniEngine;
+use crate::commons::crypto::bootstrap::StandardBootstrapKey as ImplStandardBootstrapKey;
+use crate::prelude::{GlweSecretKey32, GlweSecretKey64, GlweSecretKeyEntity, LweBootstrapKey32, LweBootstrapKey64, LweSecretKey32, LweSecretKey64, LweSecretKeyEntity};
+use crate::specification::engines::{LweBootstrapKeyCreationEngine, LweBootstrapKeyCreationError};
+
+/// # Description:
+/// Implementation of [`LweBootstrapKeyCreationEngine`] for [`AesniEngine`] that operates on
+/// 32 bits integers. It outputs a bootstrap key in the standard domain.
+impl LweBootstrapKeyCreationEngine<LweSecretKey32, GlweSecretKey32, LweBootstrapKey32>
+    for AesniEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let (lwe_dim, glwe_dim, poly_size) = (LweDimension(4), GlweDimension(6), PolynomialSize(256));
+    /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let lwe_sk: LweSecretKey32 = aesni_engine.create_lwe_secret_key(lwe_dim)?;
+    /// let glwe_sk: GlweSecretKey32 = aesni_engine.create_glwe_secret_key(glwe_dim, poly_size)?;
+    ///
+    /// let bsk: LweBootstrapKey32 =
+    ///     aesni_engine.create_lwe_bootstrap_key(&lwe_sk, &glwe_sk, dec_bl, dec_lc, noise)?;
+    /// #
+    /// assert_eq!(bsk.glwe_dimension(), glwe_dim);
+    /// assert_eq!(bsk.polynomial_size(), poly_size);
+    /// assert_eq!(bsk.input_lwe_dimension(), lwe_dim);
+    /// assert_eq!(bsk.decomposition_base_log(), dec_bl);
+    /// assert_eq!(bsk.decomposition_level_count(), dec_lc);
+    ///
+    /// default_engine.destroy(lwe_sk)?;
+    /// default_engine.destroy(glwe_sk)?;
+    /// default_engine.destroy(bsk)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn create_lwe_bootstrap_key(
+        &mut self,
+        input_key: &LweSecretKey32,
+        output_key: &GlweSecretKey32,
+        decomposition_base_log: DecompositionBaseLog,
+        decomposition_level_count: DecompositionLevelCount,
+        noise: Variance,
+    ) -> Result<LweBootstrapKey32, LweBootstrapKeyCreationError<Self::EngineError>> {
+        LweBootstrapKeyCreationError::perform_generic_checks(
+            decomposition_base_log,
+            decomposition_level_count,
+            32,
+        )?;
+        Ok(unsafe {
+            self.create_lwe_bootstrap_key_unchecked(
+                input_key,
+                output_key,
+                decomposition_base_log,
+                decomposition_level_count,
+                noise,
+            )
+        })
+    }
+
+    unsafe fn create_lwe_bootstrap_key_unchecked(
+        &mut self,
+        input_key: &LweSecretKey32,
+        output_key: &GlweSecretKey32,
+        decomposition_base_log: DecompositionBaseLog,
+        decomposition_level_count: DecompositionLevelCount,
+        noise: Variance,
+    ) -> LweBootstrapKey32 {
+        let mut key = ImplStandardBootstrapKey::allocate(
+            0,
+            output_key.glwe_dimension().to_glwe_size(),
+            output_key.polynomial_size(),
+            decomposition_level_count,
+            decomposition_base_log,
+            input_key.lwe_dimension(),
+        );
+        key.fill_with_new_key(
+            &input_key.0,
+            &output_key.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+        LweBootstrapKey32(key)
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweBootstrapKeyCreationEngine`] for [`AesniEngine`] that operates on
+/// 64 bits integers. It outputs a bootstrap key in the standard domain.
+impl LweBootstrapKeyCreationEngine<LweSecretKey64, GlweSecretKey64, LweBootstrapKey64>
+    for AesniEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let (lwe_dim, glwe_dim, poly_size) = (LweDimension(4), GlweDimension(6), PolynomialSize(256));
+    /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let lwe_sk: LweSecretKey64 = aesni_engine.create_lwe_secret_key(lwe_dim)?;
+    /// let glwe_sk: GlweSecretKey64 = aesni_engine.create_glwe_secret_key(glwe_dim, poly_size)?;
+    ///
+    /// let bsk: LweBootstrapKey64 =
+    ///     aesni_engine.create_lwe_bootstrap_key(&lwe_sk, &glwe_sk, dec_bl, dec_lc, noise)?;
+    /// #
+    /// assert_eq!(bsk.glwe_dimension(), glwe_dim);
+    /// assert_eq!(bsk.polynomial_size(), poly_size);
+    /// assert_eq!(bsk.input_lwe_dimension(), lwe_dim);
+    /// assert_eq!(bsk.decomposition_base_log(), dec_bl);
+    /// assert_eq!(bsk.decomposition_level_count(), dec_lc);
+    ///
+    /// default_engine.destroy(lwe_sk)?;
+    /// default_engine.destroy(glwe_sk)?;
+    /// default_engine.destroy(bsk)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn create_lwe_bootstrap_key(
+        &mut self,
+        input_key: &LweSecretKey64,
+        output_key: &GlweSecretKey64,
+        decomposition_base_log: DecompositionBaseLog,
+        decomposition_level_count: DecompositionLevelCount,
+        noise: Variance,
+    ) -> Result<LweBootstrapKey64, LweBootstrapKeyCreationError<Self::EngineError>> {
+        LweBootstrapKeyCreationError::perform_generic_checks(
+            decomposition_base_log,
+            decomposition_level_count,
+            64,
+        )?;
+        Ok(unsafe {
+            self.create_lwe_bootstrap_key_unchecked(
+                input_key,
+                output_key,
+                decomposition_base_log,
+                decomposition_level_count,
+                noise,
+            )
+        })
+    }
+
+    unsafe fn create_lwe_bootstrap_key_unchecked(
+        &mut self,
+        input_key: &LweSecretKey64,
+        output_key: &GlweSecretKey64,
+        decomposition_base_log: DecompositionBaseLog,
+        decomposition_level_count: DecompositionLevelCount,
+        noise: Variance,
+    ) -> LweBootstrapKey64 {
+        let mut key = ImplStandardBootstrapKey::allocate(
+            0,
+            output_key.glwe_dimension().to_glwe_size(),
+            output_key.polynomial_size(),
+            decomposition_level_count,
+            decomposition_base_log,
+            input_key.lwe_dimension(),
+        );
+        key.fill_with_new_key(
+            &input_key.0,
+            &output_key.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+        LweBootstrapKey64(key)
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/lwe_ciphertext_encryption.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/lwe_ciphertext_encryption.rs
@@ -1,0 +1,135 @@
+use concrete_commons::dispersion::Variance;
+
+use crate::backends::aesni::implementation::engines::AesniEngine;
+use crate::prelude::{
+    LweCiphertext32, LweCiphertext64, LweSecretKey32, LweSecretKey64, Plaintext32, Plaintext64,
+};
+use crate::commons::crypto::lwe::LweCiphertext as ImplLweCiphertext;
+use crate::specification::engines::{LweCiphertextEncryptionEngine, LweCiphertextEncryptionError};
+use crate::specification::entities::LweSecretKeyEntity;
+
+/// # Description:
+/// Implementation of [`LweCiphertextEncryptionEngine`] for [`AesniEngine`] that operates on
+/// 32 bits integers.
+impl LweCiphertextEncryptionEngine<LweSecretKey32, Plaintext32, LweCiphertext32> for AesniEngine {
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u32 << 20;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: LweSecretKey32 = aesni_engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    ///
+    /// let ciphertext = aesni_engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;
+    /// #
+    /// assert_eq!(ciphertext.lwe_dimension(), lwe_dimension);
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(plaintext)?;
+    /// default_engine.destroy(ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn encrypt_lwe_ciphertext(
+        &mut self,
+        key: &LweSecretKey32,
+        input: &Plaintext32,
+        noise: Variance,
+    ) -> Result<LweCiphertext32, LweCiphertextEncryptionError<Self::EngineError>> {
+        Ok(unsafe { self.encrypt_lwe_ciphertext_unchecked(key, input, noise) })
+    }
+
+    unsafe fn encrypt_lwe_ciphertext_unchecked(
+        &mut self,
+        key: &LweSecretKey32,
+        input: &Plaintext32,
+        noise: Variance,
+    ) -> LweCiphertext32 {
+        let mut ciphertext = ImplLweCiphertext::allocate(0u32, key.lwe_dimension().to_lwe_size());
+        key.0.encrypt_lwe(
+            &mut ciphertext,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+        LweCiphertext32(ciphertext)
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextEncryptionEngine`] for [`AesniEngine`] that operates on
+/// 64 bits integers.
+impl LweCiphertextEncryptionEngine<LweSecretKey64, Plaintext64, LweCiphertext64> for AesniEngine {
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = 3_u64 << 50;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: LweSecretKey64 = aesni_engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    ///
+    /// let ciphertext = aesni_engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;
+    /// #
+    /// assert_eq!(ciphertext.lwe_dimension(), lwe_dimension);
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(plaintext)?;
+    /// default_engine.destroy(ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn encrypt_lwe_ciphertext(
+        &mut self,
+        key: &LweSecretKey64,
+        input: &Plaintext64,
+        noise: Variance,
+    ) -> Result<LweCiphertext64, LweCiphertextEncryptionError<Self::EngineError>> {
+        Ok(unsafe { self.encrypt_lwe_ciphertext_unchecked(key, input, noise) })
+    }
+
+    unsafe fn encrypt_lwe_ciphertext_unchecked(
+        &mut self,
+        key: &LweSecretKey64,
+        input: &Plaintext64,
+        noise: Variance,
+    ) -> LweCiphertext64 {
+        let mut ciphertext = ImplLweCiphertext::allocate(0u64, key.lwe_dimension().to_lwe_size());
+        key.0.encrypt_lwe(
+            &mut ciphertext,
+            &input.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+        LweCiphertext64(ciphertext)
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/lwe_ciphertext_vector_encryption.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/lwe_ciphertext_vector_encryption.rs
@@ -1,0 +1,153 @@
+use concrete_commons::dispersion::Variance;
+use concrete_commons::parameters::CiphertextCount;
+
+use crate::backends::aesni::implementation::engines::AesniEngine;
+use crate::prelude::{
+    LweCiphertextVector32, LweCiphertextVector64, LweSecretKey32, LweSecretKey64,
+    PlaintextVector32, PlaintextVector64,
+};
+use crate::commons::crypto::lwe::LweList as ImplLweList;
+use crate::specification::engines::{
+    LweCiphertextVectorEncryptionEngine, LweCiphertextVectorEncryptionError,
+};
+use crate::specification::entities::{LweSecretKeyEntity, PlaintextVectorEntity};
+
+/// # Description:
+/// Implementation of [`LweCiphertextVectorEncryptionEngine`] for [`AesniEngine`] that operates on
+/// 32 bits integers.
+impl LweCiphertextVectorEncryptionEngine<LweSecretKey32, PlaintextVector32, LweCiphertextVector32>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(6);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = vec![3_u32 << 20; 3];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: LweSecretKey32 = aesni_engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let plaintext_vector: PlaintextVector32 = default_engine.create_plaintext_vector(&input)?;
+    ///
+    /// let mut ciphertext_vector: LweCiphertextVector32 =
+    ///     aesni_engine.encrypt_lwe_ciphertext_vector(&key, &plaintext_vector, noise)?;
+    /// #
+    /// assert_eq!(ciphertext_vector.lwe_dimension(), lwe_dimension);
+    /// assert_eq!(
+    /// #    ciphertext_vector.lwe_ciphertext_count(),
+    /// #    LweCiphertextCount(3)
+    /// # );
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(plaintext_vector)?;
+    /// default_engine.destroy(ciphertext_vector)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn encrypt_lwe_ciphertext_vector(
+        &mut self,
+        key: &LweSecretKey32,
+        input: &PlaintextVector32,
+        noise: Variance,
+    ) -> Result<LweCiphertextVector32, LweCiphertextVectorEncryptionError<Self::EngineError>> {
+        Ok(unsafe { self.encrypt_lwe_ciphertext_vector_unchecked(key, input, noise) })
+    }
+
+    unsafe fn encrypt_lwe_ciphertext_vector_unchecked(
+        &mut self,
+        key: &LweSecretKey32,
+        input: &PlaintextVector32,
+        noise: Variance,
+    ) -> LweCiphertextVector32 {
+        let mut vector = ImplLweList::allocate(
+            0u32,
+            key.lwe_dimension().to_lwe_size(),
+            CiphertextCount(input.plaintext_count().0),
+        );
+        key.0
+            .encrypt_lwe_list(&mut vector, &input.0, noise, &mut self.encryption_generator);
+        LweCiphertextVector32(vector)
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextVectorEncryptionEngine`] for [`AesniEngine`] that operates on
+/// 64 bits integers.
+impl LweCiphertextVectorEncryptionEngine<LweSecretKey64, PlaintextVector64, LweCiphertextVector64>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(6);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = vec![3_u64 << 50; 3];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: LweSecretKey64 = aesni_engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let plaintext_vector: PlaintextVector64 = default_engine.create_plaintext_vector(&input)?;
+    ///
+    /// let mut ciphertext_vector: LweCiphertextVector64 =
+    ///     aesni_engine.encrypt_lwe_ciphertext_vector(&key, &plaintext_vector, noise)?;
+    /// #
+    /// assert_eq!(ciphertext_vector.lwe_dimension(), lwe_dimension);
+    /// assert_eq!(
+    /// #     ciphertext_vector.lwe_ciphertext_count(),
+    /// #     LweCiphertextCount(3)
+    /// # );
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(plaintext_vector)?;
+    /// default_engine.destroy(ciphertext_vector)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn encrypt_lwe_ciphertext_vector(
+        &mut self,
+        key: &LweSecretKey64,
+        input: &PlaintextVector64,
+        noise: Variance,
+    ) -> Result<LweCiphertextVector64, LweCiphertextVectorEncryptionError<Self::EngineError>> {
+        Ok(unsafe { self.encrypt_lwe_ciphertext_vector_unchecked(key, input, noise) })
+    }
+
+    unsafe fn encrypt_lwe_ciphertext_vector_unchecked(
+        &mut self,
+        key: &LweSecretKey64,
+        input: &PlaintextVector64,
+        noise: Variance,
+    ) -> LweCiphertextVector64 {
+        let mut vector = ImplLweList::allocate(
+            0u64,
+            key.lwe_dimension().to_lwe_size(),
+            CiphertextCount(input.plaintext_count().0),
+        );
+        key.0
+            .encrypt_lwe_list(&mut vector, &input.0, noise, &mut self.encryption_generator);
+        LweCiphertextVector64(vector)
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/lwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/lwe_ciphertext_vector_zero_encryption.rs
@@ -1,0 +1,155 @@
+use concrete_commons::dispersion::Variance;
+use concrete_commons::parameters::{CiphertextCount, LweCiphertextCount, PlaintextCount};
+
+use crate::backends::aesni::implementation::engines::AesniEngine;
+use crate::prelude::{
+    LweCiphertextVector32, LweCiphertextVector64, LweSecretKey32, LweSecretKey64,
+};
+use crate::commons::crypto::encoding::PlaintextList as ImplPlaintextList;
+use crate::commons::crypto::lwe::LweList as ImplLweList;
+use crate::specification::engines::{
+    LweCiphertextVectorZeroEncryptionEngine, LweCiphertextVectorZeroEncryptionError,
+};
+use crate::specification::entities::LweSecretKeyEntity;
+
+/// # Description:
+/// Implementation of [`LweCiphertextVectorZeroEncryptionEngine`] for [`AesniEngine`] that
+/// operates on 32 bits integers.
+impl LweCiphertextVectorZeroEncryptionEngine<LweSecretKey32, LweCiphertextVector32>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// let ciphertext_count = LweCiphertextCount(3);
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: LweSecretKey32 = aesni_engine.create_lwe_secret_key(lwe_dimension)?;
+    ///
+    /// let ciphertext_vector =
+    ///     aesni_engine.zero_encrypt_lwe_ciphertext_vector(&key, noise, ciphertext_count)?;
+    /// #
+    /// assert_eq!(ciphertext_vector.lwe_dimension(), lwe_dimension);
+    /// assert_eq!(ciphertext_vector.lwe_ciphertext_count(), ciphertext_count);
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(ciphertext_vector)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn zero_encrypt_lwe_ciphertext_vector(
+        &mut self,
+        key: &LweSecretKey32,
+        noise: Variance,
+        count: LweCiphertextCount,
+    ) -> Result<LweCiphertextVector32, LweCiphertextVectorZeroEncryptionError<Self::EngineError>>
+    {
+        LweCiphertextVectorZeroEncryptionError::perform_generic_checks(count)?;
+        Ok(unsafe { self.zero_encrypt_lwe_ciphertext_vector_unchecked(key, noise, count) })
+    }
+
+    unsafe fn zero_encrypt_lwe_ciphertext_vector_unchecked(
+        &mut self,
+        key: &LweSecretKey32,
+        noise: Variance,
+        count: LweCiphertextCount,
+    ) -> LweCiphertextVector32 {
+        let mut vector = ImplLweList::allocate(
+            0u32,
+            key.lwe_dimension().to_lwe_size(),
+            CiphertextCount(count.0),
+        );
+        let plaintexts = ImplPlaintextList::allocate(0u32, PlaintextCount(count.0));
+        key.0.encrypt_lwe_list(
+            &mut vector,
+            &plaintexts,
+            noise,
+            &mut self.encryption_generator,
+        );
+        LweCiphertextVector32(vector)
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextVectorZeroEncryptionEngine`] for [`AesniEngine`] that
+/// operates on 64 bits integers.
+impl LweCiphertextVectorZeroEncryptionEngine<LweSecretKey64, LweCiphertextVector64>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// let ciphertext_count = LweCiphertextCount(3);
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: LweSecretKey64 = aesni_engine.create_lwe_secret_key(lwe_dimension)?;
+    ///
+    /// let ciphertext_vector =
+    ///     aesni_engine.zero_encrypt_lwe_ciphertext_vector(&key, noise, ciphertext_count)?;
+    /// #
+    /// assert_eq!(ciphertext_vector.lwe_dimension(), lwe_dimension);
+    /// assert_eq!(ciphertext_vector.lwe_ciphertext_count(), ciphertext_count);
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(ciphertext_vector)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn zero_encrypt_lwe_ciphertext_vector(
+        &mut self,
+        key: &LweSecretKey64,
+        noise: Variance,
+        count: LweCiphertextCount,
+    ) -> Result<LweCiphertextVector64, LweCiphertextVectorZeroEncryptionError<Self::EngineError>>
+    {
+        LweCiphertextVectorZeroEncryptionError::perform_generic_checks(count)?;
+        Ok(unsafe { self.zero_encrypt_lwe_ciphertext_vector_unchecked(key, noise, count) })
+    }
+
+    unsafe fn zero_encrypt_lwe_ciphertext_vector_unchecked(
+        &mut self,
+        key: &LweSecretKey64,
+        noise: Variance,
+        count: LweCiphertextCount,
+    ) -> LweCiphertextVector64 {
+        let mut vector = ImplLweList::allocate(
+            0u64,
+            key.lwe_dimension().to_lwe_size(),
+            CiphertextCount(count.0),
+        );
+        let plaintexts = ImplPlaintextList::allocate(0u64, PlaintextCount(count.0));
+        key.0.encrypt_lwe_list(
+            &mut vector,
+            &plaintexts,
+            noise,
+            &mut self.encryption_generator,
+        );
+        LweCiphertextVector64(vector)
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/lwe_ciphertext_zero_encryption.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/lwe_ciphertext_zero_encryption.rs
@@ -1,0 +1,126 @@
+use concrete_commons::dispersion::Variance;
+
+use crate::backends::aesni::implementation::engines::AesniEngine;
+use crate::prelude::{
+    LweCiphertext32, LweCiphertext64, LweSecretKey32, LweSecretKey64,
+};
+use crate::commons::crypto::encoding::Plaintext as ImplPlaintext;
+use crate::commons::crypto::lwe::LweCiphertext as ImplLweCiphertext;
+use crate::specification::engines::{
+    LweCiphertextZeroEncryptionEngine, LweCiphertextZeroEncryptionError,
+};
+use crate::specification::entities::LweSecretKeyEntity;
+
+/// # Description:
+/// Implementation of [`LweCiphertextZeroEncryptionEngine`] for [`AesniEngine`] that
+/// operates on 32 bits integers.
+impl LweCiphertextZeroEncryptionEngine<LweSecretKey32, LweCiphertext32> for AesniEngine {
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: LweSecretKey32 = aesni_engine.create_lwe_secret_key(lwe_dimension)?;
+    ///
+    /// let ciphertext = aesni_engine.zero_encrypt_lwe_ciphertext(&key, noise)?;
+    /// #
+    /// assert_eq!(ciphertext.lwe_dimension(), lwe_dimension);
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn zero_encrypt_lwe_ciphertext(
+        &mut self,
+        key: &LweSecretKey32,
+        noise: Variance,
+    ) -> Result<LweCiphertext32, LweCiphertextZeroEncryptionError<Self::EngineError>> {
+        Ok(unsafe { self.zero_encrypt_lwe_ciphertext_unchecked(key, noise) })
+    }
+
+    unsafe fn zero_encrypt_lwe_ciphertext_unchecked(
+        &mut self,
+        key: &LweSecretKey32,
+        noise: Variance,
+    ) -> LweCiphertext32 {
+        let mut ciphertext = ImplLweCiphertext::allocate(0u32, key.lwe_dimension().to_lwe_size());
+        key.0.encrypt_lwe(
+            &mut ciphertext,
+            &ImplPlaintext(0u32),
+            noise,
+            &mut self.encryption_generator,
+        );
+        LweCiphertext32(ciphertext)
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextZeroEncryptionEngine`] for [`AesniEngine`] that
+/// operates on 64 bits integers.
+impl LweCiphertextZeroEncryptionEngine<LweSecretKey64, LweCiphertext64> for AesniEngine {
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(2);
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let key: LweSecretKey64 = aesni_engine.create_lwe_secret_key(lwe_dimension)?;
+    ///
+    /// let ciphertext = aesni_engine.zero_encrypt_lwe_ciphertext(&key, noise)?;
+    /// #
+    /// assert_eq!(ciphertext.lwe_dimension(), lwe_dimension);
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn zero_encrypt_lwe_ciphertext(
+        &mut self,
+        key: &LweSecretKey64,
+        noise: Variance,
+    ) -> Result<LweCiphertext64, LweCiphertextZeroEncryptionError<Self::EngineError>> {
+        Ok(unsafe { self.zero_encrypt_lwe_ciphertext_unchecked(key, noise) })
+    }
+
+    unsafe fn zero_encrypt_lwe_ciphertext_unchecked(
+        &mut self,
+        key: &LweSecretKey64,
+        noise: Variance,
+    ) -> LweCiphertext64 {
+        let mut ciphertext = ImplLweCiphertext::allocate(0u64, key.lwe_dimension().to_lwe_size());
+        key.0.encrypt_lwe(
+            &mut ciphertext,
+            &ImplPlaintext(0u64),
+            noise,
+            &mut self.encryption_generator,
+        );
+        LweCiphertext64(ciphertext)
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/lwe_keyswitch_key_creation.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/lwe_keyswitch_key_creation.rs
@@ -1,0 +1,220 @@
+use crate::backends::aesni::engines::AesniEngine;
+use concrete_commons::dispersion::Variance;
+use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+
+use crate::commons::crypto::lwe::LweKeyswitchKey as ImplLweKeyswitchKey;
+use crate::prelude::{LweKeyswitchKey32, LweKeyswitchKey64, LweSecretKey32, LweSecretKey64};
+use crate::specification::engines::{LweKeyswitchKeyCreationEngine, LweKeyswitchKeyCreationError};
+use crate::specification::entities::LweSecretKeyEntity;
+
+/// # Description:
+/// Implementation of [`LweKeyswitchKeyCreationEngine`] for [`AesniEngine`] that
+/// operates on 32 bits integers.
+impl LweKeyswitchKeyCreationEngine<LweSecretKey32, LweSecretKey32, LweKeyswitchKey32>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, LweDimension,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let input_lwe_dimension = LweDimension(6);
+    /// let output_lwe_dimension = LweDimension(3);
+    /// let decomposition_level_count = DecompositionLevelCount(2);
+    /// let decomposition_base_log = DecompositionBaseLog(8);
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let input_key: LweSecretKey32 = aesni_engine.create_lwe_secret_key(input_lwe_dimension)?;
+    /// let output_key: LweSecretKey32 = aesni_engine.create_lwe_secret_key(output_lwe_dimension)?;
+    ///
+    /// let keyswitch_key = aesni_engine.create_lwe_keyswitch_key(
+    ///     &input_key,
+    ///     &output_key,
+    ///     decomposition_level_count,
+    ///     decomposition_base_log,
+    ///     noise,
+    /// )?;
+    /// #
+    /// assert_eq!(
+    /// #     keyswitch_key.decomposition_level_count(),
+    /// #     decomposition_level_count
+    /// # );
+    /// assert_eq!(
+    /// #     keyswitch_key.decomposition_base_log(),
+    /// #     decomposition_base_log
+    /// # );
+    /// assert_eq!(keyswitch_key.input_lwe_dimension(), input_lwe_dimension);
+    /// assert_eq!(keyswitch_key.output_lwe_dimension(), output_lwe_dimension);
+    ///
+    /// default_engine.destroy(input_key)?;
+    /// default_engine.destroy(output_key)?;
+    /// default_engine.destroy(keyswitch_key)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn create_lwe_keyswitch_key(
+        &mut self,
+        input_key: &LweSecretKey32,
+        output_key: &LweSecretKey32,
+        decomposition_level_count: DecompositionLevelCount,
+        decomposition_base_log: DecompositionBaseLog,
+        noise: Variance,
+    ) -> Result<LweKeyswitchKey32, LweKeyswitchKeyCreationError<Self::EngineError>> {
+        LweKeyswitchKeyCreationError::perform_generic_checks(
+            decomposition_level_count,
+            decomposition_base_log,
+            32,
+        )?;
+        Ok(unsafe {
+            self.create_lwe_keyswitch_key_unchecked(
+                input_key,
+                output_key,
+                decomposition_level_count,
+                decomposition_base_log,
+                noise,
+            )
+        })
+    }
+
+    unsafe fn create_lwe_keyswitch_key_unchecked(
+        &mut self,
+        input_key: &LweSecretKey32,
+        output_key: &LweSecretKey32,
+        decomposition_level_count: DecompositionLevelCount,
+        decomposition_base_log: DecompositionBaseLog,
+        noise: Variance,
+    ) -> LweKeyswitchKey32 {
+        let mut ksk = ImplLweKeyswitchKey::allocate(
+            0,
+            decomposition_level_count,
+            decomposition_base_log,
+            input_key.lwe_dimension(),
+            output_key.lwe_dimension(),
+        );
+        ksk.fill_with_keyswitch_key(
+            &input_key.0,
+            &output_key.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+        LweKeyswitchKey32(ksk)
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweKeyswitchKeyCreationEngine`] for [`AesniEngine`] that
+/// operates on 64 bits integers.
+impl LweKeyswitchKeyCreationEngine<LweSecretKey64, LweSecretKey64, LweKeyswitchKey64>
+    for AesniEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, LweDimension,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let input_lwe_dimension = LweDimension(6);
+    /// let output_lwe_dimension = LweDimension(3);
+    /// let decomposition_level_count = DecompositionLevelCount(2);
+    /// let decomposition_base_log = DecompositionBaseLog(8);
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let input_key: LweSecretKey64 = aesni_engine.create_lwe_secret_key(input_lwe_dimension)?;
+    /// let output_key: LweSecretKey64 = aesni_engine.create_lwe_secret_key(output_lwe_dimension)?;
+    ///
+    /// let keyswitch_key = aesni_engine.create_lwe_keyswitch_key(
+    ///     &input_key,
+    ///     &output_key,
+    ///     decomposition_level_count,
+    ///     decomposition_base_log,
+    ///     noise,
+    /// )?;
+    /// #
+    /// assert_eq!(
+    /// #     keyswitch_key.decomposition_level_count(),
+    /// #     decomposition_level_count
+    /// # );
+    /// assert_eq!(
+    /// #     keyswitch_key.decomposition_base_log(),
+    /// #     decomposition_base_log
+    /// # );
+    /// assert_eq!(keyswitch_key.input_lwe_dimension(), input_lwe_dimension);
+    /// assert_eq!(keyswitch_key.output_lwe_dimension(), output_lwe_dimension);
+    ///
+    /// default_engine.destroy(input_key)?;
+    /// default_engine.destroy(output_key)?;
+    /// default_engine.destroy(keyswitch_key)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn create_lwe_keyswitch_key(
+        &mut self,
+        input_key: &LweSecretKey64,
+        output_key: &LweSecretKey64,
+        decomposition_level_count: DecompositionLevelCount,
+        decomposition_base_log: DecompositionBaseLog,
+        noise: Variance,
+    ) -> Result<LweKeyswitchKey64, LweKeyswitchKeyCreationError<Self::EngineError>> {
+        LweKeyswitchKeyCreationError::perform_generic_checks(
+            decomposition_level_count,
+            decomposition_base_log,
+            64,
+        )?;
+        Ok(unsafe {
+            self.create_lwe_keyswitch_key_unchecked(
+                input_key,
+                output_key,
+                decomposition_level_count,
+                decomposition_base_log,
+                noise,
+            )
+        })
+    }
+
+    unsafe fn create_lwe_keyswitch_key_unchecked(
+        &mut self,
+        input_key: &LweSecretKey64,
+        output_key: &LweSecretKey64,
+        decomposition_level_count: DecompositionLevelCount,
+        decomposition_base_log: DecompositionBaseLog,
+        noise: Variance,
+    ) -> LweKeyswitchKey64 {
+        let mut ksk = ImplLweKeyswitchKey::allocate(
+            0,
+            decomposition_level_count,
+            decomposition_base_log,
+            input_key.lwe_dimension(),
+            output_key.lwe_dimension(),
+        );
+        ksk.fill_with_keyswitch_key(
+            &input_key.0,
+            &output_key.0,
+            noise,
+            &mut self.encryption_generator,
+        );
+        LweKeyswitchKey64(ksk)
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/lwe_secret_key_creation.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/lwe_secret_key_creation.rs
@@ -1,0 +1,98 @@
+use crate::backends::aesni::engines::AesniEngine;
+use concrete_commons::parameters::LweDimension;
+
+use crate::commons::crypto::secret::LweSecretKey as ImplLweSecretKey;
+use crate::prelude::{LweSecretKey32, LweSecretKey64};
+use crate::specification::engines::{LweSecretKeyCreationEngine, LweSecretKeyCreationError};
+
+/// # Description:
+/// Implementation of [`LweSecretKeyCreationEngine`] for [`AesniEngine`] that operates on
+/// 32 bits integers.
+impl LweSecretKeyCreationEngine<LweSecretKey32> for AesniEngine {
+    /// # Example:
+    /// ```
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(6);
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let lwe_secret_key: LweSecretKey32 = aesni_engine.create_lwe_secret_key(lwe_dimension)?;
+    /// #
+    /// assert_eq!(lwe_secret_key.lwe_dimension(), lwe_dimension);
+    /// default_engine.destroy(lwe_secret_key)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn create_lwe_secret_key(
+        &mut self,
+        lwe_dimension: LweDimension,
+    ) -> Result<LweSecretKey32, LweSecretKeyCreationError<Self::EngineError>> {
+        LweSecretKeyCreationError::perform_generic_checks(lwe_dimension)?;
+        Ok(unsafe { self.create_lwe_secret_key_unchecked(lwe_dimension) })
+    }
+
+    unsafe fn create_lwe_secret_key_unchecked(
+        &mut self,
+        lwe_dimension: LweDimension,
+    ) -> LweSecretKey32 {
+        LweSecretKey32(ImplLweSecretKey::generate_binary(
+            lwe_dimension,
+            &mut self.secret_generator,
+        ))
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweSecretKeyCreationEngine`] for [`AesniEngine`] that operates on
+/// 64 bits integers.
+impl LweSecretKeyCreationEngine<LweSecretKey64> for AesniEngine {
+    /// # Example:
+    /// ```
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(6);
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut aesni_engine = AesniEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let lwe_secret_key: LweSecretKey64 = aesni_engine.create_lwe_secret_key(lwe_dimension)?;
+    /// #
+    /// assert_eq!(lwe_secret_key.lwe_dimension(), lwe_dimension);
+    /// default_engine.destroy(lwe_secret_key)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn create_lwe_secret_key(
+        &mut self,
+        lwe_dimension: LweDimension,
+    ) -> Result<LweSecretKey64, LweSecretKeyCreationError<Self::EngineError>> {
+        LweSecretKeyCreationError::perform_generic_checks(lwe_dimension)?;
+        Ok(unsafe { self.create_lwe_secret_key_unchecked(lwe_dimension) })
+    }
+
+    unsafe fn create_lwe_secret_key_unchecked(
+        &mut self,
+        lwe_dimension: LweDimension,
+    ) -> LweSecretKey64 {
+        LweSecretKey64(ImplLweSecretKey::generate_binary(
+            lwe_dimension,
+            &mut self.secret_generator,
+        ))
+    }
+}

--- a/concrete-core/src/backends/aesni/implementation/engines/mod.rs
+++ b/concrete-core/src/backends/aesni/implementation/engines/mod.rs
@@ -1,0 +1,71 @@
+//! A module containing the [engines](crate::specification::engines) exposed by the aesni backend.
+
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+use concrete_csprng::generators::AesniRandomGenerator;
+use concrete_csprng::seeders::Seeder;
+
+use crate::commons::crypto::secret::generators::{
+    EncryptionRandomGenerator as ImplEncryptionRandomGenerator,
+    SecretRandomGenerator as ImplSecretRandomGenerator,
+};
+use crate::specification::engines::sealed::AbstractEngineSeal;
+use crate::specification::engines::AbstractEngine;
+
+/// The error which can occur in the execution of FHE operations, due to the aesni implementation.
+///
+/// # Note:
+///
+/// There is currently no such case, as the aesni implementation is not expected to undergo some
+/// major issues unrelated to FHE.
+#[derive(Debug)]
+pub enum AesniError {}
+
+impl Display for AesniError {
+    fn fmt(&self, _f: &mut Formatter<'_>) -> std::fmt::Result {
+        match *self {}
+    }
+}
+
+impl Error for AesniError {}
+
+pub struct AesniEngine {
+    secret_generator: ImplSecretRandomGenerator<AesniRandomGenerator>,
+    encryption_generator: ImplEncryptionRandomGenerator<AesniRandomGenerator>,
+}
+
+impl AbstractEngineSeal for AesniEngine {}
+
+impl AbstractEngine for AesniEngine {
+    type EngineError = AesniError;
+
+    type Parameters = Box<dyn Seeder>;
+
+    fn new(mut parameters: Self::Parameters) -> Result<Self, Self::EngineError> {
+        Ok(AesniEngine {
+            secret_generator: ImplSecretRandomGenerator::new(parameters.seed()),
+            encryption_generator: ImplEncryptionRandomGenerator::new(
+                parameters.seed(),
+                parameters.as_mut(),
+            ),
+        })
+    }
+}
+
+mod glwe_secret_key_creation;
+mod lwe_bootstrap_key_creation;
+mod lwe_keyswitch_key_creation;
+mod lwe_secret_key_creation;
+mod ggsw_ciphertext_scalar_discarding_encryption;
+mod ggsw_ciphertext_scalar_encryption;
+mod glwe_ciphertext_discarding_encryption;
+mod glwe_ciphertext_encryption;
+mod glwe_ciphertext_vector_discarding_encryption;
+mod glwe_ciphertext_vector_encryption;
+mod glwe_ciphertext_vector_zero_encryption;
+mod glwe_ciphertext_zero_encryption;
+mod lwe_ciphertext_encryption;
+mod lwe_ciphertext_vector_encryption;
+mod lwe_ciphertext_vector_zero_encryption;
+mod lwe_ciphertext_zero_encryption;

--- a/concrete-core/src/backends/aesni/implementation/mod.rs
+++ b/concrete-core/src/backends/aesni/implementation/mod.rs
@@ -1,0 +1,1 @@
+pub mod engines;

--- a/concrete-core/src/backends/aesni/mod.rs
+++ b/concrete-core/src/backends/aesni/mod.rs
@@ -1,0 +1,6 @@
+//! A pure-rust backend that benefits from hardware acceleration
+//! on x86_64 architectures with the aesni feature.
+
+mod implementation;
+
+pub use implementation::engines;

--- a/concrete-core/src/backends/mod.rs
+++ b/concrete-core/src/backends/mod.rs
@@ -5,3 +5,6 @@ pub mod default;
 
 #[cfg(feature = "backend_fftw")]
 pub mod fftw;
+
+#[cfg(feature = "backend_x86_64_aesni")]
+pub mod aesni;

--- a/concrete-core/src/prelude.rs
+++ b/concrete-core/src/prelude.rs
@@ -18,6 +18,10 @@ pub use super::backends::fftw::engines::*;
 #[cfg(feature = "backend_fftw")]
 pub use super::backends::fftw::entities::*;
 
+// ----------------------------------------------------------------------------------- AESNI BACKEND
+#[cfg(feature = "backend_x86_64_aesni")]
+pub use super::backends::aesni::engines::*;
+
 // -------------------------------------------------------------------------------- COMMONS REEXPORT
 // Expose concrete_commons types in the prelude. This avoids having to add concrete-commons as a
 // dependency in crates built on top of concrete-core.


### PR DESCRIPTION
### Resolves

zama-ai/concrete-core-internal#170

### Description
This PR introduces an aesni backend to accelerate key generations.
WARNING: it is missing tests since we currently don't have tests for the key creations! There is a follow up issue for that. 
### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] ~Tests for the changes have been added (for bug fixes / features)~
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
