### PR TITLE
refactor(fftw): transfer cmux from fourier bsk to fourier ggsw

### DIFF
--- a/concrete-core/src/backends/fftw/private/crypto/bootstrap/fourier/mod.rs
+++ b/concrete-core/src/backends/fftw/private/crypto/bootstrap/fourier/mod.rs
@@ -447,25 +447,6 @@ where
             })
     }
 
-    // This cmux mutates both ct1 and ct0. The result is in ct0 after the method was called.
-    fn cmux<C0, C1, C2>(
-        &self,
-        ct0: &mut GlweCiphertext<C0>,
-        ct1: &mut GlweCiphertext<C1>,
-        ggsw: &FourierGgswCiphertext<C2, Scalar>,
-        fft_buffers: &mut FftBuffers,
-        rounded_buffer: &mut GlweCiphertext<Vec<Scalar>>,
-    ) where
-        GlweCiphertext<C0>: AsMutTensor<Element = Scalar>,
-        GlweCiphertext<C1>: AsMutTensor<Element = Scalar>,
-        FourierGgswCiphertext<C2, Scalar>: AsRefTensor<Element = Complex64>,
-        Scalar: UnsignedTorus,
-    {
-        ct1.as_mut_tensor()
-            .update_with_wrapping_sub(ct0.as_tensor());
-        ggsw.external_product(ct0, ct1, fft_buffers, rounded_buffer);
-    }
-
     fn blind_rotate<C2>(&self, buffers: &mut FourierBuffers<Scalar>, lwe: &LweCiphertext<C2>)
     where
         LweCiphertext<C2>: AsRefTensor<Element = Scalar>,
@@ -511,10 +492,9 @@ where
                         LutCountLog(0),
                     ));
                 // We perform the cmux.
-                self.cmux(
+                bootstrap_key_ggsw.cmux(
                     ct_0,
                     &mut ct_1,
-                    &bootstrap_key_ggsw,
                     &mut buffers.fft_buffers,
                     &mut buffers.rounded_buffer,
                 );

--- a/concrete-core/src/backends/fftw/private/crypto/bootstrap/fourier/tests.rs
+++ b/concrete-core/src/backends/fftw/private/crypto/bootstrap/fourier/tests.rs
@@ -104,10 +104,9 @@ fn test_cmux_0<T: UnsignedTorus>() {
 
         // compute cmux
         let mut buffers = FourierBuffers::new(fourier_bsk.poly_size, fourier_bsk.glwe_size);
-        fourier_bsk.cmux(
+        rgsw.cmux(
             &mut ciphertext0,
             &mut ciphertext1,
-            &rgsw,
             &mut buffers.fft_buffers,
             &mut buffers.rounded_buffer,
         );
@@ -215,10 +214,9 @@ fn test_cmux_1<T: UnsignedTorus>() {
 
         // compute cmux
         let mut buffers = FourierBuffers::new(fourier_bsk.poly_size, fourier_bsk.glwe_size);
-        fourier_bsk.cmux(
+        rgsw.cmux(
             &mut ciphertext0,
             &mut ciphertext1,
-            &rgsw,
             &mut buffers.fft_buffers,
             &mut buffers.rounded_buffer,
         );

--- a/concrete-core/src/backends/fftw/private/crypto/ggsw/fourier.rs
+++ b/concrete-core/src/backends/fftw/private/crypto/ggsw/fourier.rs
@@ -690,6 +690,24 @@ impl<Cont, Scalar> FourierGgswCiphertext<Cont, Scalar> {
             }
         }
     }
+
+    // This cmux mutates both ct1 and ct0. The result is in ct0 after the method was called.
+    pub fn cmux<C0, C1>(
+        &self,
+        ct0: &mut GlweCiphertext<C0>,
+        ct1: &mut GlweCiphertext<C1>,
+        fft_buffers: &mut FftBuffers,
+        rounded_buffer: &mut GlweCiphertext<Vec<Scalar>>,
+    ) where
+        Self: AsRefTensor<Element = Complex64>,
+        GlweCiphertext<C0>: AsMutTensor<Element = Scalar>,
+        GlweCiphertext<C1>: AsMutTensor<Element = Scalar>,
+        Scalar: UnsignedTorus,
+    {
+        ct1.as_mut_tensor()
+            .update_with_wrapping_sub(ct0.as_tensor());
+        self.external_product(ct0, ct1, fft_buffers, rounded_buffer);
+    }
 }
 
 impl<Element, Cont, Scalar> AsRefTensor for FourierGgswCiphertext<Cont, Scalar>


### PR DESCRIPTION
### Resolves:

https://github.com/zama-ai/concrete-core-internal/issues/151

### Description

This PR transfers the private implementation of cmux in the FFTW backend from the Fourier bootstrapping key to the Fourier GGSW ciphertext.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
