### PR TITLE
Chore/aws tests notify slack

### DIFF
--- a/.github/workflows/aws_tests.yml
+++ b/.github/workflows/aws_tests.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   start-runner:
@@ -65,6 +66,18 @@ jobs:
       if: ${{ !cancelled() }}
       run: cargo xtask test
 
+    - name: Slack Notification
+      if: ${{ always() }}
+      continue-on-error: true
+      uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7
+      env:
+        SLACK_COLOR: ${{ job.status }}
+        SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+        SLACK_ICON: https://pbs.twimg.com/profile_images/1274014582265298945/OjBKP9kn_400x400.png
+        SLACK_MESSAGE: "AWS tests finished with status ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+        SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
   stop-runner:
     name: Stop EC2 runner
     needs:
@@ -86,6 +99,7 @@ jobs:
           label: ${{ needs.start-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
           mode: stop
+
   remove_label:
     name: Remove aws_test label
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Resolves:

closes https://github.com/zama-ai/concrete-core-internal/issues/164

### Description

Send a slack notification on AWS tests completion

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

~~* [ ] Tests for the changes have been added (for bug fixes / features)~~
~~* [ ] Docs have been added / updated (for bug fixes / features)~~
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
~~* [ ] The draft release description has been updated~~
~~* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]~~

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
