### PR TITLE
test(csprng): update test_bounded_none_should_panic to catch right panic

### DIFF
--- a/concrete-csprng/src/generators/implem/aesni/generator.rs
+++ b/concrete-csprng/src/generators/implem/aesni/generator.rs
@@ -103,7 +103,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "expected test panic")]
     fn test_bounded_panic() {
         generator_generic_test::test_bounded_none_should_panic::<AesniRandomGenerator>();
     }

--- a/concrete-csprng/src/generators/implem/soft/generator.rs
+++ b/concrete-csprng/src/generators/implem/soft/generator.rs
@@ -103,7 +103,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "expected test panic")]
     fn test_bounded_panic() {
         generator_generic_test::test_bounded_none_should_panic::<SoftwareRandomGenerator>();
     }

--- a/concrete-csprng/src/generators/mod.rs
+++ b/concrete-csprng/src/generators/mod.rs
@@ -206,10 +206,16 @@ pub mod generator_generic_test {
             for _ in 0..n_bytes.0 {
                 bounded.next().unwrap();
             }
+
+            // Assert we are at the bound
+            assert!(bounded.next().is_none());
         }
     }
 
     /// Checks that a bounded prng returns none when exceeding the allowed number of bytes.
+    ///
+    /// To properly check for panic use `#[should_panic(expected = "expected test panic")]` as an
+    /// attribute on the test function.
     pub fn test_bounded_none_should_panic<G: RandomGenerator>() {
         let ((seed, n_children), n_bytes) = any_seed()
             .zip(some_children_count())
@@ -219,8 +225,11 @@ pub mod generator_generic_test {
         let mut gen = G::new(seed);
         let mut bounded = gen.try_fork(n_children, n_bytes).unwrap().next().unwrap();
         assert_eq!(bounded.remaining_bytes(), ByteCount(n_bytes.0 as u128));
-        for _ in 0..(n_bytes.0 + 1) {
-            bounded.next().unwrap();
+        for _ in 0..n_bytes.0 {
+            assert!(bounded.next().is_some());
         }
+
+        // One call too many, should panic
+        bounded.next().ok_or("expected test panic").unwrap();
     }
 }


### PR DESCRIPTION
### Resolves:

closes https://github.com/zama-ai/concrete-core-internal/issues/186

### Description

Change the test a little bit to be sure we catch the panic when
unwrapping on the last None value, None is mapped to a specific string
that can be expected to check the test panics in the right place

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
~~* [ ] The draft release description has been updated~~
~~* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]~~

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
