### PR TITLE
fix(fixture): fix the LWE ciphertext conversoin fixture

### DIFF
--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_conversion.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_conversion.rs
@@ -152,9 +152,13 @@ where
     ) -> Self::Outcome {
         let (key,) = repetition_proto;
         let (proto_ciphertext_vector,) = sample_proto;
-        let (output_ciphertext_vector, input_ciphertext_vector) = context;
-        let proto_output_ciphertext_vector =
-            maker.unsynthesize_lwe_ciphertext_vector(output_ciphertext_vector);
+        let (input_ciphertext_vector, output_ciphertext_vector) = context;
+        let proto_output_ciphertext_vector = <Maker as SynthesizesLweCiphertextVector<
+            Precision,
+            OutputCiphertextVector,
+        >>::unsynthesize_lwe_ciphertext_vector(
+            maker, output_ciphertext_vector
+        );
         let proto_plaintext_vector =
             maker.decrypt_lwe_ciphertext_vector_to_plaintext_vector(key, proto_ciphertext_vector);
         let proto_output_plaintext_vector = <Maker as PrototypesLweCiphertextVector<


### PR DESCRIPTION
### Resolves: zama-ai/concrete-core-internal#191

### Description
The current fixture is bugged (the input and output are swapped in the processing of the context)
### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
