### PR TITLE
chore(core_fixture): remove the default_backend feature

### DIFF
--- a/concrete-core-bench/Cargo.toml
+++ b/concrete-core-bench/Cargo.toml
@@ -5,13 +5,16 @@ edition = "2021"
 license = "BSD-3-Clause-Clear"
 
 [dependencies]
-concrete-core = { path="../concrete-core" }
-concrete-csprng = { path = "../concrete-csprng"}
-concrete-core-fixture = { path="../concrete-core-fixture" }
+concrete-core = { path = "../concrete-core" }
+concrete-csprng = { path = "../concrete-csprng" }
+concrete-core-fixture = { path = "../concrete-core-fixture" }
 paste = "1.0"
 criterion = "0.3.5"
 
 [features]
-backend_default = ["concrete-core/backend_default", "concrete-core-fixture/backend_default"]
-backend_fftw = ["concrete-core/backend_fftw", "concrete-core-fixture/backend_fftw"]
+backend_default = ["concrete-core/backend_default"]
+backend_fftw = [
+    "concrete-core/backend_fftw",
+    "concrete-core-fixture/backend_fftw",
+]
 parallel = ["concrete-core/parallel", "concrete-core-fixture/parallel"]

--- a/concrete-core-fixture/Cargo.toml
+++ b/concrete-core-fixture/Cargo.toml
@@ -5,14 +5,17 @@ edition = "2021"
 license = "BSD-3-Clause-Clear"
 
 [dependencies]
-concrete-core = { path="../concrete-core" }
-concrete-csprng = { path = "../concrete-csprng", features = ["seeder_unix", "generator_x86_64_aesni"]}
-concrete-commons = { path="../concrete-commons" }
-concrete-npe = { path="../concrete-npe" }
+concrete-core = { path = "../concrete-core" }
+concrete-csprng = { path = "../concrete-csprng", features = [
+    "seeder_unix",
+    "generator_x86_64_aesni",
+] }
+concrete-commons = { path = "../concrete-commons" }
+concrete-npe = { path = "../concrete-npe" }
 kolmogorov_smirnov = "1.1.0"
 paste = "1.0"
 
 [features]
-backend_default = []
+# No backend_default feature as it's required for all tests to work, so always enabled
 backend_fftw = ["concrete-core/backend_fftw"]
 parallel = ["concrete-core/parallel"]

--- a/concrete-core-fixture/src/generation/synthesizing/cleartext.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/cleartext.rs
@@ -13,7 +13,6 @@ where
     fn destroy_cleartext(&mut self, entity: Cleartext);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{ProtoCleartext32, ProtoCleartext64};
     use crate::generation::synthesizing::SynthesizesCleartext;

--- a/concrete-core-fixture/src/generation/synthesizing/cleartext_vector.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/cleartext_vector.rs
@@ -19,7 +19,6 @@ where
     fn destroy_cleartext_vector(&mut self, entity: CleartextVector);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{ProtoCleartextVector32, ProtoCleartextVector64};
     use crate::generation::synthesizing::SynthesizesCleartextVector;

--- a/concrete-core-fixture/src/generation/synthesizing/container.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/container.rs
@@ -12,7 +12,6 @@ where
     fn destroy_container(&mut self, container: Container);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{ProtoVec32, ProtoVec64};
     use crate::generation::synthesizing::SynthesizesContainer;

--- a/concrete-core-fixture/src/generation/synthesizing/ggsw_ciphertext.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/ggsw_ciphertext.rs
@@ -17,7 +17,6 @@ where
     fn destroy_ggsw_ciphertext(&mut self, entity: GgswCiphertext);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{ProtoBinaryGgswCiphertext32, ProtoBinaryGgswCiphertext64};
     use crate::generation::synthesizing::SynthesizesGgswCiphertext;

--- a/concrete-core-fixture/src/generation/synthesizing/glwe_ciphertext.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/glwe_ciphertext.rs
@@ -17,7 +17,6 @@ where
     fn destroy_glwe_ciphertext(&mut self, entity: GlweCiphertext);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{ProtoBinaryGlweCiphertext32, ProtoBinaryGlweCiphertext64};
     use crate::generation::synthesizing::SynthesizesGlweCiphertext;

--- a/concrete-core-fixture/src/generation/synthesizing/glwe_ciphertext_vector.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/glwe_ciphertext_vector.rs
@@ -19,7 +19,6 @@ where
     fn destroy_glwe_ciphertext_vector(&mut self, entity: GlweCiphertextVector);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{
         ProtoBinaryGlweCiphertextVector32, ProtoBinaryGlweCiphertextVector64,

--- a/concrete-core-fixture/src/generation/synthesizing/glwe_secret_key.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/glwe_secret_key.rs
@@ -14,7 +14,6 @@ where
     fn destroy_glwe_secret_key(&mut self, entity: GlweSecretKey);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{ProtoBinaryGlweSecretKey32, ProtoBinaryGlweSecretKey64};
     use crate::generation::synthesizing::SynthesizesGlweSecretKey;

--- a/concrete-core-fixture/src/generation/synthesizing/lwe_bootstrap_key.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/lwe_bootstrap_key.rs
@@ -23,7 +23,6 @@ where
     fn destroy_lwe_bootstrap_key(&mut self, entity: LweBootstrapKey);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{
         ProtoBinaryBinaryLweBootstrapKey32, ProtoBinaryBinaryLweBootstrapKey64,

--- a/concrete-core-fixture/src/generation/synthesizing/lwe_ciphertext.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/lwe_ciphertext.rs
@@ -13,7 +13,6 @@ where
     fn destroy_lwe_ciphertext(&mut self, entity: LweCiphertext);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{ProtoBinaryLweCiphertext32, ProtoBinaryLweCiphertext64};
     use crate::generation::synthesizing::SynthesizesLweCiphertext;

--- a/concrete-core-fixture/src/generation/synthesizing/lwe_ciphertext_vector.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/lwe_ciphertext_vector.rs
@@ -19,7 +19,6 @@ where
     fn destroy_lwe_ciphertext_vector(&mut self, entity: LweCiphertextVector);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{
         ProtoBinaryLweCiphertextVector32, ProtoBinaryLweCiphertextVector64,

--- a/concrete-core-fixture/src/generation/synthesizing/lwe_ciphertext_vector_glwe_ciphertext_packing_keyswitch_key.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/lwe_ciphertext_vector_glwe_ciphertext_packing_keyswitch_key.rs
@@ -22,7 +22,6 @@ where
     fn destroy_packing_keyswitch_key(&mut self, entity: PackingKeyswitchKey);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{
         ProtoBinaryBinaryPackingKeyswitchKey32, ProtoBinaryBinaryPackingKeyswitchKey64,

--- a/concrete-core-fixture/src/generation/synthesizing/lwe_keyswitch_key.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/lwe_keyswitch_key.rs
@@ -22,7 +22,6 @@ where
     fn destroy_lwe_keyswitch_key(&mut self, entity: LweKeyswitchKey);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{
         ProtoBinaryBinaryLweKeyswitchKey32, ProtoBinaryBinaryLweKeyswitchKey64,

--- a/concrete-core-fixture/src/generation/synthesizing/lwe_secret_key.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/lwe_secret_key.rs
@@ -13,7 +13,6 @@ where
     fn destroy_lwe_secret_key(&mut self, entity: LweSecretKey);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{ProtoBinaryLweSecretKey32, ProtoBinaryLweSecretKey64};
     use crate::generation::synthesizing::SynthesizesLweSecretKey;

--- a/concrete-core-fixture/src/generation/synthesizing/plaintext.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/plaintext.rs
@@ -13,7 +13,6 @@ where
     fn destroy_plaintext(&mut self, entity: Plaintext);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{ProtoPlaintext32, ProtoPlaintext64};
     use crate::generation::synthesizing::SynthesizesPlaintext;

--- a/concrete-core-fixture/src/generation/synthesizing/plaintext_vector.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/plaintext_vector.rs
@@ -19,7 +19,6 @@ where
     fn destroy_plaintext_vector(&mut self, entity: PlaintextVector);
 }
 
-#[cfg(feature = "backend_default")]
 mod backend_default {
     use crate::generation::prototypes::{ProtoPlaintextVector32, ProtoPlaintextVector64};
     use crate::generation::synthesizing::SynthesizesPlaintextVector;

--- a/concrete-core-test/Cargo.toml
+++ b/concrete-core-test/Cargo.toml
@@ -5,11 +5,14 @@ edition = "2021"
 license = "BSD-3-Clause-Clear"
 
 [dependencies]
-concrete-core = { path="../concrete-core" }
-concrete-csprng = { path = "../concrete-csprng", features = ["seeder_unix"]}
-concrete-core-fixture = { path="../concrete-core-fixture" }
+concrete-core = { path = "../concrete-core" }
+concrete-csprng = { path = "../concrete-csprng", features = ["seeder_unix"] }
+concrete-core-fixture = { path = "../concrete-core-fixture" }
 paste = "1.0"
 
 [features]
-backend_default = ["concrete-core/backend_default", "concrete-core-fixture/backend_default"]
-backend_fftw = ["concrete-core/backend_fftw", "concrete-core-fixture/backend_fftw"]
+backend_default = ["concrete-core/backend_default"]
+backend_fftw = [
+    "concrete-core/backend_fftw",
+    "concrete-core-fixture/backend_fftw",
+]


### PR DESCRIPTION
### Resolves:

closes https://github.com/zama-ai/concrete-core-internal/issues/189

### Description

- as default_backend is used to create all test entities prototypes it is
required to have the default_backend feature enabled at all times on
concrete-core-fixture, remove corresponding feature-gating and feature

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

~~* [ ] Tests for the changes have been added (for bug fixes / features)~~
~~* [ ] Docs have been added / updated (for bug fixes / features)~~
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
~~* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)~~
~~* [ ] The draft release description has been updated~~
~~* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]~~

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
