### PR TITLE
feat(core): glwe ciphertext backwards conversion

### DIFF
--- a/concrete-core-bench/src/fftw.rs
+++ b/concrete-core-bench/src/fftw.rs
@@ -39,5 +39,7 @@ bench! {
     (LweCiphertextDiscardingBootstrapFixture1, (FftwFourierLweBootstrapKey, GlweCiphertextView, LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextDiscardingBootstrapFixture2, (FftwFourierLweBootstrapKey, GlweCiphertextView, LweCiphertextView, LweCiphertextMutView)),
     (GlweCiphertextGgswCiphertextExternalProductFixture, (GlweCiphertext, FftwFourierGgswCiphertext, GlweCiphertext)),
-    (GlweCiphertextGgswCiphertextDiscardingExternalProductFixture, (GlweCiphertext, FftwFourierGgswCiphertext, GlweCiphertext))
+    (GlweCiphertextGgswCiphertextDiscardingExternalProductFixture, (GlweCiphertext, FftwFourierGgswCiphertext, GlweCiphertext)),
+    (GlweCiphertextConversionFixture, (GlweCiphertext, FftwFourierGlweCiphertext)),
+    (GlweCiphertextConversionFixture, (FftwFourierGlweCiphertext, GlweCiphertext))
 }

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_conversion.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_conversion.rs
@@ -1,0 +1,172 @@
+use concrete_commons::dispersion::Variance;
+use concrete_commons::parameters::{GlweDimension, PolynomialSize};
+use concrete_core::prelude::{GlweCiphertextConversionEngine, GlweCiphertextEntity};
+
+use crate::fixture::Fixture;
+use crate::generation::prototyping::{
+    PrototypesGlweCiphertext, PrototypesGlweSecretKey, PrototypesPlaintextVector,
+};
+use crate::generation::synthesizing::SynthesizesGlweCiphertext;
+use crate::generation::{IntegerPrecision, Maker};
+use crate::raw::generation::RawUnsignedIntegers;
+use crate::raw::statistical_test::assert_noise_distribution;
+
+/// A fixture for the types implementing the `GlweCiphertextConversionEngine` trait.
+pub struct GlweCiphertextConversionFixture;
+
+#[derive(Debug)]
+pub struct GlweCiphertextConversionParameters {
+    pub noise: Variance,
+    pub glwe_dimension: GlweDimension,
+    pub polynomial_size: PolynomialSize,
+}
+
+impl<Precision, Engine, InputCiphertext, OutputCiphertext>
+    Fixture<Precision, Engine, (InputCiphertext, OutputCiphertext)>
+    for GlweCiphertextConversionFixture
+where
+    Precision: IntegerPrecision,
+    Engine: GlweCiphertextConversionEngine<InputCiphertext, OutputCiphertext>,
+    InputCiphertext: GlweCiphertextEntity,
+    OutputCiphertext: GlweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
+    Maker: SynthesizesGlweCiphertext<Precision, InputCiphertext>
+        + SynthesizesGlweCiphertext<Precision, OutputCiphertext>,
+{
+    type Parameters = GlweCiphertextConversionParameters;
+    type RepetitionPrototypes = (
+        <Maker as PrototypesGlweSecretKey<Precision, InputCiphertext::KeyDistribution>>::GlweSecretKeyProto,
+    );
+    type SamplePrototypes = (
+        <Maker as PrototypesGlweCiphertext<
+            Precision,
+            InputCiphertext::KeyDistribution,
+        >>::GlweCiphertextProto,
+    );
+    type PreExecutionContext = (InputCiphertext,);
+    type PostExecutionContext = (InputCiphertext, OutputCiphertext);
+    type Criteria = (Variance,);
+    type Outcome = (Vec<Precision::Raw>, Vec<Precision::Raw>);
+
+    fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
+        Box::new(
+            vec![
+                GlweCiphertextConversionParameters {
+                    noise: Variance(0.00000001),
+                    glwe_dimension: GlweDimension(2),
+                    polynomial_size: PolynomialSize(512),
+                },
+                GlweCiphertextConversionParameters {
+                    noise: Variance(0.00000001),
+                    glwe_dimension: GlweDimension(1),
+                    polynomial_size: PolynomialSize(1024),
+                },
+                GlweCiphertextConversionParameters {
+                    noise: Variance(0.00000001),
+                    glwe_dimension: GlweDimension(1),
+                    polynomial_size: PolynomialSize(2048),
+                },
+            ]
+            .into_iter(),
+        )
+    }
+
+    fn generate_random_repetition_prototypes(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+    ) -> Self::RepetitionPrototypes {
+        let proto_secret_key =
+            maker.new_glwe_secret_key(parameters.glwe_dimension, parameters.polynomial_size);
+        (proto_secret_key,)
+    }
+
+    fn generate_random_sample_prototypes(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::SamplePrototypes {
+        let (key,) = repetition_proto;
+
+        let raw_plaintext_vector = Precision::Raw::uniform_vec(parameters.polynomial_size.0);
+        let proto_plaintext_vector =
+            maker.transform_raw_vec_to_plaintext_vector(raw_plaintext_vector.as_slice());
+        let proto_ciphertext_vector = maker.encrypt_plaintext_vector_to_glwe_ciphertext(
+            key,
+            &proto_plaintext_vector,
+            parameters.noise,
+        );
+        (proto_ciphertext_vector,)
+    }
+
+    fn prepare_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+    ) -> Self::PreExecutionContext {
+        let (proto_ciphertext,) = sample_proto;
+        (<Maker as SynthesizesGlweCiphertext<
+            Precision,
+            InputCiphertext,
+        >>::synthesize_glwe_ciphertext(
+            maker, proto_ciphertext
+        ),)
+    }
+
+    fn execute_engine(
+        _parameters: &Self::Parameters,
+        engine: &mut Engine,
+        context: Self::PreExecutionContext,
+    ) -> Self::PostExecutionContext {
+        let (input_ciphertext,) = context;
+        let output_ciphertext =
+            unsafe { engine.convert_glwe_ciphertext_unchecked(&input_ciphertext) };
+        (input_ciphertext, output_ciphertext)
+    }
+
+    fn process_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+        context: Self::PostExecutionContext,
+    ) -> Self::Outcome {
+        let (key,) = repetition_proto;
+        let (proto_ciphertext,) = sample_proto;
+        let (input_ciphertext, output_ciphertext) = context;
+        let proto_output_ciphertext = <Maker as SynthesizesGlweCiphertext<
+            Precision,
+            OutputCiphertext,
+        >>::unsynthesize_glwe_ciphertext(
+            maker, output_ciphertext
+        );
+
+        let proto_plaintext_vector =
+            maker.decrypt_glwe_ciphertext_to_plaintext_vector(key, proto_ciphertext);
+        let proto_output_plaintext_vector = <Maker as PrototypesGlweCiphertext<
+            Precision,
+            InputCiphertext::KeyDistribution,
+        >>::decrypt_glwe_ciphertext_to_plaintext_vector(
+            maker, key, &proto_output_ciphertext
+        );
+        maker.destroy_glwe_ciphertext(input_ciphertext);
+        (
+            maker.transform_plaintext_vector_to_raw_vec(&proto_plaintext_vector),
+            maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),
+        )
+    }
+
+    fn compute_criteria(
+        parameters: &Self::Parameters,
+        _maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::Criteria {
+        (parameters.noise,)
+    }
+
+    fn verify(criteria: &Self::Criteria, outputs: &[Self::Outcome]) -> bool {
+        let (means, actual): (Vec<_>, Vec<_>) = outputs.iter().cloned().unzip();
+        let means: Vec<Precision::Raw> = means.into_iter().flatten().collect();
+        let actual: Vec<Precision::Raw> = actual.into_iter().flatten().collect();
+        assert_noise_distribution(actual.as_slice(), means.as_slice(), criteria.0)
+    }
+}

--- a/concrete-core-fixture/src/fixture/mod.rs
+++ b/concrete-core-fixture/src/fixture/mod.rs
@@ -434,3 +434,6 @@ pub use lwe_bootstrap_key_discarding_conversion::*;
 
 mod lwe_ciphertext_vector_glwe_ciphertext_discarding_packing_keyswitch;
 pub use lwe_ciphertext_vector_glwe_ciphertext_discarding_packing_keyswitch::*;
+
+mod glwe_ciphertext_conversion;
+pub use glwe_ciphertext_conversion::*;

--- a/concrete-core-fixture/src/generation/synthesizing/glwe_ciphertext.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/glwe_ciphertext.rs
@@ -254,3 +254,62 @@ mod backend_default {
         }
     }
 }
+
+#[cfg(feature = "backend_fftw")]
+mod backend_fftw {
+    use crate::generation::prototypes::{ProtoBinaryGlweCiphertext32, ProtoBinaryGlweCiphertext64};
+    use crate::generation::synthesizing::SynthesizesGlweCiphertext;
+    use crate::generation::{Maker, Precision32, Precision64};
+    use concrete_core::prelude::{
+        DestructionEngine, FftwFourierGlweCiphertext32, FftwFourierGlweCiphertext64,
+        GlweCiphertextConversionEngine,
+    };
+
+    impl SynthesizesGlweCiphertext<Precision32, FftwFourierGlweCiphertext32> for Maker {
+        fn synthesize_glwe_ciphertext(
+            &mut self,
+            prototype: &Self::GlweCiphertextProto,
+        ) -> FftwFourierGlweCiphertext32 {
+            self.fftw_engine
+                .convert_glwe_ciphertext(&prototype.0)
+                .unwrap()
+        }
+
+        fn unsynthesize_glwe_ciphertext(
+            &mut self,
+            entity: FftwFourierGlweCiphertext32,
+        ) -> Self::GlweCiphertextProto {
+            let proto = self.fftw_engine.convert_glwe_ciphertext(&entity).unwrap();
+            self.fftw_engine.destroy(entity).unwrap();
+            ProtoBinaryGlweCiphertext32(proto)
+        }
+
+        fn destroy_glwe_ciphertext(&mut self, entity: FftwFourierGlweCiphertext32) {
+            self.fftw_engine.destroy(entity).unwrap();
+        }
+    }
+
+    impl SynthesizesGlweCiphertext<Precision64, FftwFourierGlweCiphertext64> for Maker {
+        fn synthesize_glwe_ciphertext(
+            &mut self,
+            prototype: &Self::GlweCiphertextProto,
+        ) -> FftwFourierGlweCiphertext64 {
+            self.fftw_engine
+                .convert_glwe_ciphertext(&prototype.0)
+                .unwrap()
+        }
+
+        fn unsynthesize_glwe_ciphertext(
+            &mut self,
+            entity: FftwFourierGlweCiphertext64,
+        ) -> Self::GlweCiphertextProto {
+            let proto = self.fftw_engine.convert_glwe_ciphertext(&entity).unwrap();
+            self.fftw_engine.destroy(entity).unwrap();
+            ProtoBinaryGlweCiphertext64(proto)
+        }
+
+        fn destroy_glwe_ciphertext(&mut self, entity: FftwFourierGlweCiphertext64) {
+            self.fftw_engine.destroy(entity).unwrap();
+        }
+    }
+}

--- a/concrete-core-test/src/fftw.rs
+++ b/concrete-core-test/src/fftw.rs
@@ -37,5 +37,7 @@ test! {
     (LweCiphertextDiscardingBootstrapFixture1, (FftwFourierLweBootstrapKey, GlweCiphertextView, LweCiphertextView, LweCiphertextMutView)),
     (LweCiphertextDiscardingBootstrapFixture2, (FftwFourierLweBootstrapKey, GlweCiphertextView, LweCiphertextView, LweCiphertextMutView)),
     (GlweCiphertextGgswCiphertextExternalProductFixture, (GlweCiphertext, FftwFourierGgswCiphertext, GlweCiphertext)),
-    (GlweCiphertextGgswCiphertextDiscardingExternalProductFixture, (GlweCiphertext, FftwFourierGgswCiphertext, GlweCiphertext))
+    (GlweCiphertextGgswCiphertextDiscardingExternalProductFixture, (GlweCiphertext, FftwFourierGgswCiphertext, GlweCiphertext)),
+    (GlweCiphertextConversionFixture, (GlweCiphertext, FftwFourierGlweCiphertext)),
+    (GlweCiphertextConversionFixture, (FftwFourierGlweCiphertext, GlweCiphertext))
 }

--- a/concrete-core/src/backends/fftw/implementation/engines/glwe_ciphertext_conversion.rs
+++ b/concrete-core/src/backends/fftw/implementation/engines/glwe_ciphertext_conversion.rs
@@ -2,6 +2,7 @@ use crate::backends::fftw::engines::{FftwEngine, FftwError};
 use crate::backends::fftw::entities::{FftwFourierGlweCiphertext32, FftwFourierGlweCiphertext64};
 use crate::backends::fftw::private::crypto::glwe::FourierGlweCiphertext;
 use crate::backends::fftw::private::math::fft::{Complex64, ALLOWED_POLY_SIZE};
+use crate::commons::crypto::glwe::GlweCiphertext;
 use crate::prelude::{GlweCiphertext32, GlweCiphertext64};
 use crate::specification::engines::{
     GlweCiphertextConversionEngine, GlweCiphertextConversionError,
@@ -180,5 +181,175 @@ where
 
     unsafe fn convert_glwe_ciphertext_unchecked(&mut self, input: &Ciphertext) -> Ciphertext {
         (*input).clone()
+    }
+}
+
+/// # Description:
+/// Implementation of [`GlweCiphertextConversionEngine`] for [`FftwEngine`] that operates on
+/// 32 bits integers. It converts a GLWE ciphertext from the Fourier to the standard domain.
+impl GlweCiphertextConversionEngine<FftwFourierGlweCiphertext32, GlweCiphertext32> for FftwEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = vec![3_u32 << 20; 256];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fftw_engine = FftwEngine::new(())?;
+    /// let key: GlweSecretKey32 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext_vector = default_engine.create_plaintext_vector(&input)?;
+    ///
+    /// // We encrypt a GLWE ciphertext in the standard domain
+    /// let ciphertext = default_engine.encrypt_glwe_ciphertext(&key, &plaintext_vector, noise)?;
+    ///
+    /// // Then we convert it to the Fourier domain.
+    /// let fourier_ciphertext: FftwFourierGlweCiphertext32 =
+    ///     fftw_engine.convert_glwe_ciphertext(&ciphertext)?;
+    /// #
+    /// // Then we convert it back to the standard domain.
+    /// let ciphertext_out: GlweCiphertext32 =
+    ///     fftw_engine.convert_glwe_ciphertext(&fourier_ciphertext)?;
+    ///
+    /// assert_eq!(ciphertext_out.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(ciphertext_out.polynomial_size(), polynomial_size);
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(plaintext_vector)?;
+    /// default_engine.destroy(ciphertext)?;
+    /// default_engine.destroy(ciphertext_out)?;
+    /// fftw_engine.destroy(fourier_ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn convert_glwe_ciphertext(
+        &mut self,
+        input: &FftwFourierGlweCiphertext32,
+    ) -> Result<GlweCiphertext32, GlweCiphertextConversionError<Self::EngineError>> {
+        if !ALLOWED_POLY_SIZE.contains(&input.polynomial_size().0) {
+            return Err(GlweCiphertextConversionError::from(
+                FftwError::UnsupportedPolynomialSize,
+            ));
+        }
+
+        Ok(unsafe { self.convert_glwe_ciphertext_unchecked(input) })
+    }
+
+    unsafe fn convert_glwe_ciphertext_unchecked(
+        &mut self,
+        input: &FftwFourierGlweCiphertext32,
+    ) -> GlweCiphertext32 {
+        let mut output = GlweCiphertext::allocate(
+            0_u32,
+            input.polynomial_size(),
+            input.glwe_dimension().to_glwe_size(),
+        );
+        let buffers = self.get_fourier_u32_buffer(
+            input.polynomial_size(),
+            input.glwe_dimension().to_glwe_size(),
+        );
+        let mut input_ = input.0.clone();
+        input_.fill_with_backward_fourier(&mut output, buffers);
+        GlweCiphertext32(output)
+    }
+}
+
+/// # Description:
+/// Implementation of [`GlweCiphertextConversionEngine`] for [`FftwEngine`] that operates on
+/// 64 bits integers. It converts a GLWE ciphertext from the Fourier to the standard domain.
+impl GlweCiphertextConversionEngine<FftwFourierGlweCiphertext64, GlweCiphertext64> for FftwEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = vec![3_u64 << 50; 256];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fftw_engine = FftwEngine::new(())?;
+    /// let key: GlweSecretKey64 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext_vector = default_engine.create_plaintext_vector(&input)?;
+    ///
+    /// // We encrypt a GLWE ciphertext in the standard domain
+    /// let ciphertext = default_engine.encrypt_glwe_ciphertext(&key, &plaintext_vector, noise)?;
+    ///
+    /// // Then we convert it to the Fourier domain.
+    /// let fourier_ciphertext: FftwFourierGlweCiphertext64 =
+    ///     fftw_engine.convert_glwe_ciphertext(&ciphertext)?;
+    /// #
+    /// // Then we convert it back to the standard domain.
+    /// let ciphertext_out: GlweCiphertext64 =
+    ///     fftw_engine.convert_glwe_ciphertext(&fourier_ciphertext)?;
+    ///
+    /// assert_eq!(ciphertext_out.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(ciphertext_out.polynomial_size(), polynomial_size);
+    ///
+    /// default_engine.destroy(key)?;
+    /// default_engine.destroy(plaintext_vector)?;
+    /// default_engine.destroy(ciphertext)?;
+    /// default_engine.destroy(ciphertext_out)?;
+    /// fftw_engine.destroy(fourier_ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn convert_glwe_ciphertext(
+        &mut self,
+        input: &FftwFourierGlweCiphertext64,
+    ) -> Result<GlweCiphertext64, GlweCiphertextConversionError<Self::EngineError>> {
+        if !ALLOWED_POLY_SIZE.contains(&input.polynomial_size().0) {
+            return Err(GlweCiphertextConversionError::from(
+                FftwError::UnsupportedPolynomialSize,
+            ));
+        }
+
+        Ok(unsafe { self.convert_glwe_ciphertext_unchecked(input) })
+    }
+
+    unsafe fn convert_glwe_ciphertext_unchecked(
+        &mut self,
+        input: &FftwFourierGlweCiphertext64,
+    ) -> GlweCiphertext64 {
+        let mut output = GlweCiphertext::allocate(
+            0_u64,
+            input.polynomial_size(),
+            input.glwe_dimension().to_glwe_size(),
+        );
+        let buffers = self.get_fourier_u64_buffer(
+            input.polynomial_size(),
+            input.glwe_dimension().to_glwe_size(),
+        );
+        let mut input_ = input.0.clone();
+        input_.fill_with_backward_fourier(&mut output, buffers);
+        GlweCiphertext64(output)
     }
 }


### PR DESCRIPTION
### Resolves: 
[`concrete-core-internal/issues/179`](https://github.com/zama-ai/concrete-core-internal/issues/179)

### Description
This adds the engine for GLWE ciphertext backwards conversion (from FFT to standard domain), including fixtures, tests and benches.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
