### PR TITLE
fix(ci): use available context var on workflow dispatch

### DIFF
--- a/.github/workflows/aws_tests_slab_beta.yml
+++ b/.github/workflows/aws_tests_slab_beta.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   run-tests-linux:
     concurrency:
-      group: ${{ github.head_ref }}
+      group: ${{ github.ref }}
       cancel-in-progress: true
     name: Test code in EC2
     runs-on: ${{ github.event.inputs.runner_name }}


### PR DESCRIPTION
### Resolves: `<link_your_issue_here>`

### Description

`github.head_ref` context variable is not available for `workflow_dispatch` event. However, in this event `github.ref` is usable and appears to have the same content than `head_ref`.

### Checklist 

~~* [ ] Tests for the changes have been added (for bug fixes / features)~~
~~* [ ] Docs have been added / updated (for bug fixes / features)~~
~~* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)~~
~~* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)~~
~~* [ ] The draft release description has been updated~~
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]


[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
