### PR TITLE
Fixture: place the prototype key transmutation in dedicated traits

### DIFF
--- a/concrete-core-fixture/src/fixture/glwe_to_lwe_secret_key_transmutation.rs
+++ b/concrete-core-fixture/src/fixture/glwe_to_lwe_secret_key_transmutation.rs
@@ -1,5 +1,7 @@
 use crate::fixture::Fixture;
-use crate::generation::prototyping::PrototypesGlweSecretKey;
+use crate::generation::prototyping::{
+    PrototypesGlweSecretKey, TransmutesLweToGlweSecretKeyPrototype,
+};
 use crate::generation::synthesizing::{SynthesizesGlweSecretKey, SynthesizesLweSecretKey};
 use crate::generation::{IntegerPrecision, Maker};
 use concrete_commons::parameters::{GlweDimension, LweDimension, PolynomialSize};
@@ -24,7 +26,8 @@ where
     Engine: GlweToLweSecretKeyTransmutationEngine<InputSecretKey, OutputSecretKey>,
     InputSecretKey: GlweSecretKeyEntity,
     OutputSecretKey: LweSecretKeyEntity<KeyDistribution = InputSecretKey::KeyDistribution>,
-    Maker: SynthesizesLweSecretKey<Precision, OutputSecretKey>
+    Maker: TransmutesLweToGlweSecretKeyPrototype<Precision, OutputSecretKey::KeyDistribution>
+        + SynthesizesLweSecretKey<Precision, OutputSecretKey>
         + SynthesizesGlweSecretKey<Precision, InputSecretKey>,
 {
     type Parameters = GlweToLweSecretKeyTransmutationParameters;

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_1.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_1.rs
@@ -2,7 +2,7 @@ use crate::fixture::Fixture;
 use crate::generation::prototyping::{
     PrototypesGlweCiphertext, PrototypesGlweSecretKey, PrototypesLweBootstrapKey,
     PrototypesLweCiphertext, PrototypesLweSecretKey, PrototypesPlaintext,
-    PrototypesPlaintextVector,
+    PrototypesPlaintextVector, TransmutesGlweToLweSecretKeyPrototype,
 };
 use crate::generation::synthesizing::{
     SynthesizesGlweCiphertext, SynthesizesLweBootstrapKey, SynthesizesLweCiphertext,
@@ -56,7 +56,8 @@ where
         InputKeyDistribution = InputCiphertext::KeyDistribution,
         OutputKeyDistribution = OutputCiphertext::KeyDistribution,
     >,
-    Maker: SynthesizesLweBootstrapKey<Precision, BootstrapKey>
+    Maker: TransmutesGlweToLweSecretKeyPrototype<Precision, OutputCiphertext::KeyDistribution>
+        + SynthesizesLweBootstrapKey<Precision, BootstrapKey>
         + SynthesizesGlweCiphertext<Precision, Accumulator>
         + SynthesizesLweCiphertext<Precision, InputCiphertext>
         + SynthesizesLweCiphertext<Precision, OutputCiphertext>,

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_2.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_2.rs
@@ -2,7 +2,7 @@ use crate::fixture::Fixture;
 use crate::generation::prototyping::{
     PrototypesGlweCiphertext, PrototypesGlweSecretKey, PrototypesLweBootstrapKey,
     PrototypesLweCiphertext, PrototypesLweSecretKey, PrototypesPlaintext,
-    PrototypesPlaintextVector,
+    PrototypesPlaintextVector, TransmutesGlweToLweSecretKeyPrototype,
 };
 use crate::generation::synthesizing::{
     SynthesizesGlweCiphertext, SynthesizesLweBootstrapKey, SynthesizesLweCiphertext,
@@ -50,7 +50,8 @@ where
         InputKeyDistribution = InputCiphertext::KeyDistribution,
         OutputKeyDistribution = OutputCiphertext::KeyDistribution,
     >,
-    Maker: SynthesizesLweBootstrapKey<Precision, BootstrapKey>
+    Maker: TransmutesGlweToLweSecretKeyPrototype<Precision, OutputCiphertext::KeyDistribution>
+        + SynthesizesLweBootstrapKey<Precision, BootstrapKey>
         + SynthesizesGlweCiphertext<Precision, Accumulator>
         + SynthesizesLweCiphertext<Precision, InputCiphertext>
         + SynthesizesLweCiphertext<Precision, OutputCiphertext>,

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_extraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_extraction.rs
@@ -1,7 +1,7 @@
 use crate::fixture::Fixture;
 use crate::generation::prototyping::{
     PrototypesGlweCiphertext, PrototypesGlweSecretKey, PrototypesLweCiphertext,
-    PrototypesPlaintext, PrototypesPlaintextVector,
+    PrototypesPlaintext, PrototypesPlaintextVector, TransmutesGlweToLweSecretKeyPrototype,
 };
 use crate::generation::synthesizing::{SynthesizesGlweCiphertext, SynthesizesLweCiphertext};
 use crate::generation::{IntegerPrecision, Maker};
@@ -33,7 +33,8 @@ where
     Engine: LweCiphertextDiscardingExtractionEngine<GlweCiphertext, LweCiphertext>,
     GlweCiphertext: GlweCiphertextEntity,
     LweCiphertext: LweCiphertextEntity<KeyDistribution = GlweCiphertext::KeyDistribution>,
-    Maker: SynthesizesLweCiphertext<Precision, LweCiphertext>
+    Maker: TransmutesGlweToLweSecretKeyPrototype<Precision, GlweCiphertext::KeyDistribution>
+        + SynthesizesLweCiphertext<Precision, LweCiphertext>
         + SynthesizesGlweCiphertext<Precision, GlweCiphertext>,
 {
     type Parameters = LweCiphertextDiscardingExtractionParameters;

--- a/concrete-core-fixture/src/fixture/lwe_to_glwe_secret_key_transmutation.rs
+++ b/concrete-core-fixture/src/fixture/lwe_to_glwe_secret_key_transmutation.rs
@@ -1,5 +1,7 @@
 use crate::fixture::Fixture;
-use crate::generation::prototyping::{PrototypesGlweSecretKey, PrototypesLweSecretKey};
+use crate::generation::prototyping::{
+    PrototypesLweSecretKey, TransmutesGlweToLweSecretKeyPrototype,
+};
 use crate::generation::synthesizing::{SynthesizesGlweSecretKey, SynthesizesLweSecretKey};
 use crate::generation::{IntegerPrecision, Maker};
 use concrete_commons::parameters::{GlweDimension, LweDimension, PolynomialSize};
@@ -24,7 +26,8 @@ where
     Engine: LweToGlweSecretKeyTransmutationEngine<InputSecretKey, OutputSecretKey>,
     InputSecretKey: LweSecretKeyEntity,
     OutputSecretKey: GlweSecretKeyEntity<KeyDistribution = InputSecretKey::KeyDistribution>,
-    Maker: SynthesizesGlweSecretKey<Precision, OutputSecretKey>
+    Maker: TransmutesGlweToLweSecretKeyPrototype<Precision, OutputSecretKey::KeyDistribution>
+        + SynthesizesGlweSecretKey<Precision, OutputSecretKey>
         + SynthesizesLweSecretKey<Precision, InputSecretKey>,
 {
     type Parameters = LweToGlweSecretKeyTransmutationParameters;

--- a/concrete-core-fixture/src/generation/prototyping/glwe_secret_key.rs
+++ b/concrete-core-fixture/src/generation/prototyping/glwe_secret_key.rs
@@ -6,16 +6,13 @@ use crate::generation::prototyping::PrototypesLweSecretKey;
 use crate::generation::{IntegerPrecision, Maker, Precision32, Precision64};
 use concrete_commons::parameters::{GlweDimension, PolynomialSize};
 use concrete_core::prelude::markers::{BinaryKeyDistribution, KeyDistributionMarker};
-use concrete_core::prelude::{
-    GlweSecretKeyCreationEngine, GlweToLweSecretKeyTransmutationEngine,
-    LweToGlweSecretKeyTransmutationEngine,
-};
+use concrete_core::prelude::{GlweSecretKeyCreationEngine, GlweToLweSecretKeyTransmutationEngine};
 
 /// A trait allowing to manipulate GLWE secret key prototypes.
 pub trait PrototypesGlweSecretKey<
     Precision: IntegerPrecision,
     KeyDistribution: KeyDistributionMarker,
->: PrototypesLweSecretKey<Precision, KeyDistribution>
+>
 {
     type GlweSecretKeyProto: GlweSecretKeyPrototype<
         Precision = Precision,
@@ -24,17 +21,6 @@ pub trait PrototypesGlweSecretKey<
     fn new_glwe_secret_key(
         &mut self,
         glwe_dimension: GlweDimension,
-        polynomial_size: PolynomialSize,
-    ) -> Self::GlweSecretKeyProto;
-    // Due to issues with cyclic imports, transmutations between LWE and GLWE secret key is made
-    // available here.
-    fn transmute_glwe_secret_key_to_lwe_secret_key(
-        &mut self,
-        glwe_key: &Self::GlweSecretKeyProto,
-    ) -> Self::LweSecretKeyProto;
-    fn transmute_lwe_secret_key_to_glwe_secret_key(
-        &mut self,
-        lwe_key: &Self::LweSecretKeyProto,
         polynomial_size: PolynomialSize,
     ) -> Self::GlweSecretKeyProto;
 }
@@ -50,29 +36,6 @@ impl PrototypesGlweSecretKey<Precision32, BinaryKeyDistribution> for Maker {
         ProtoBinaryGlweSecretKey32(
             self.default_engine
                 .create_glwe_secret_key(glwe_dimension, polynomial_size)
-                .unwrap(),
-        )
-    }
-
-    fn transmute_glwe_secret_key_to_lwe_secret_key(
-        &mut self,
-        glwe_key: &Self::GlweSecretKeyProto,
-    ) -> Self::LweSecretKeyProto {
-        ProtoBinaryLweSecretKey32(
-            self.default_engine
-                .transmute_glwe_secret_key_to_lwe_secret_key(glwe_key.0.to_owned())
-                .unwrap(),
-        )
-    }
-
-    fn transmute_lwe_secret_key_to_glwe_secret_key(
-        &mut self,
-        lwe_key: &Self::LweSecretKeyProto,
-        polynomial_size: PolynomialSize,
-    ) -> Self::GlweSecretKeyProto {
-        ProtoBinaryGlweSecretKey32(
-            self.default_engine
-                .transmute_lwe_secret_key_to_glwe_secret_key(lwe_key.0.to_owned(), polynomial_size)
                 .unwrap(),
         )
     }
@@ -92,7 +55,36 @@ impl PrototypesGlweSecretKey<Precision64, BinaryKeyDistribution> for Maker {
                 .unwrap(),
         )
     }
+}
 
+/// A trait allowing to transmute GLWE secret key prototypes to LWE secret key prototypes.
+pub trait TransmutesGlweToLweSecretKeyPrototype<
+    Precision: IntegerPrecision,
+    KeyDistribution: KeyDistributionMarker,
+>:
+    PrototypesGlweSecretKey<Precision, KeyDistribution>
+    + PrototypesLweSecretKey<Precision, KeyDistribution>
+{
+    fn transmute_glwe_secret_key_to_lwe_secret_key(
+        &mut self,
+        glwe_key: &Self::GlweSecretKeyProto,
+    ) -> Self::LweSecretKeyProto;
+}
+
+impl TransmutesGlweToLweSecretKeyPrototype<Precision32, BinaryKeyDistribution> for Maker {
+    fn transmute_glwe_secret_key_to_lwe_secret_key(
+        &mut self,
+        glwe_key: &Self::GlweSecretKeyProto,
+    ) -> Self::LweSecretKeyProto {
+        ProtoBinaryLweSecretKey32(
+            self.default_engine
+                .transmute_glwe_secret_key_to_lwe_secret_key(glwe_key.0.to_owned())
+                .unwrap(),
+        )
+    }
+}
+
+impl TransmutesGlweToLweSecretKeyPrototype<Precision64, BinaryKeyDistribution> for Maker {
     fn transmute_glwe_secret_key_to_lwe_secret_key(
         &mut self,
         glwe_key: &Self::GlweSecretKeyProto,
@@ -100,18 +92,6 @@ impl PrototypesGlweSecretKey<Precision64, BinaryKeyDistribution> for Maker {
         ProtoBinaryLweSecretKey64(
             self.default_engine
                 .transmute_glwe_secret_key_to_lwe_secret_key(glwe_key.0.to_owned())
-                .unwrap(),
-        )
-    }
-
-    fn transmute_lwe_secret_key_to_glwe_secret_key(
-        &mut self,
-        lwe_key: &Self::LweSecretKeyProto,
-        polynomial_size: PolynomialSize,
-    ) -> Self::GlweSecretKeyProto {
-        ProtoBinaryGlweSecretKey64(
-            self.default_engine
-                .transmute_lwe_secret_key_to_glwe_secret_key(lwe_key.0.to_owned(), polynomial_size)
                 .unwrap(),
         )
     }

--- a/concrete-core-fixture/src/generation/prototyping/lwe_secret_key.rs
+++ b/concrete-core-fixture/src/generation/prototyping/lwe_secret_key.rs
@@ -1,10 +1,14 @@
 use crate::generation::prototypes::{
-    LweSecretKeyPrototype, ProtoBinaryLweSecretKey32, ProtoBinaryLweSecretKey64,
+    LweSecretKeyPrototype, ProtoBinaryGlweSecretKey32, ProtoBinaryGlweSecretKey64,
+    ProtoBinaryLweSecretKey32, ProtoBinaryLweSecretKey64,
 };
+use crate::generation::prototyping::PrototypesGlweSecretKey;
 use crate::generation::{IntegerPrecision, Maker, Precision32, Precision64};
 use concrete_commons::parameters::LweDimension;
 use concrete_core::prelude::markers::{BinaryKeyDistribution, KeyDistributionMarker};
-use concrete_core::prelude::LweSecretKeyCreationEngine;
+use concrete_core::prelude::{
+    LweSecretKeyCreationEngine, LweToGlweSecretKeyTransmutationEngine, PolynomialSize,
+};
 
 /// A trait allowing to manipulate lwe secret key prototypes.
 pub trait PrototypesLweSecretKey<
@@ -40,6 +44,48 @@ impl PrototypesLweSecretKey<Precision64, BinaryKeyDistribution> for Maker {
         ProtoBinaryLweSecretKey64(
             self.default_engine
                 .create_lwe_secret_key(lwe_dimension)
+                .unwrap(),
+        )
+    }
+}
+/// A trait allowing to transmute LWE secret key prototypes to GLWE secret key prototypes.
+pub trait TransmutesLweToGlweSecretKeyPrototype<
+    Precision: IntegerPrecision,
+    KeyDistribution: KeyDistributionMarker,
+>:
+    PrototypesLweSecretKey<Precision, KeyDistribution>
+    + PrototypesGlweSecretKey<Precision, KeyDistribution>
+{
+    fn transmute_lwe_secret_key_to_glwe_secret_key(
+        &mut self,
+        lwe_key: &Self::LweSecretKeyProto,
+        polynomial_size: PolynomialSize,
+    ) -> Self::GlweSecretKeyProto;
+}
+
+impl TransmutesLweToGlweSecretKeyPrototype<Precision32, BinaryKeyDistribution> for Maker {
+    fn transmute_lwe_secret_key_to_glwe_secret_key(
+        &mut self,
+        lwe_key: &Self::LweSecretKeyProto,
+        polynomial_size: PolynomialSize,
+    ) -> Self::GlweSecretKeyProto {
+        ProtoBinaryGlweSecretKey32(
+            self.default_engine
+                .transmute_lwe_secret_key_to_glwe_secret_key(lwe_key.0.to_owned(), polynomial_size)
+                .unwrap(),
+        )
+    }
+}
+
+impl TransmutesLweToGlweSecretKeyPrototype<Precision64, BinaryKeyDistribution> for Maker {
+    fn transmute_lwe_secret_key_to_glwe_secret_key(
+        &mut self,
+        lwe_key: &Self::LweSecretKeyProto,
+        polynomial_size: PolynomialSize,
+    ) -> Self::GlweSecretKeyProto {
+        ProtoBinaryGlweSecretKey64(
+            self.default_engine
+                .transmute_lwe_secret_key_to_glwe_secret_key(lwe_key.0.to_owned(), polynomial_size)
                 .unwrap(),
         )
     }


### PR DESCRIPTION
### Resolves: zama-ai/concrete-core-internal#202

### Description
 This PR changes the logic for prototyping GLWE & LWE secret keys via a transmutation. It is necessary to implement the tensor product fixture.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
