### PR TITLE
feat(core_fixture): add a DefaultParallelEngine in the Maker

### DIFF
--- a/concrete-core-fixture/Cargo.toml
+++ b/concrete-core-fixture/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "BSD-3-Clause-Clear"
 
 [dependencies]
-concrete-core = { path = "../concrete-core" }
+concrete-core = { path = "../concrete-core", features = ["parallel"] }
 concrete-csprng = { path = "../concrete-csprng", features = ["seeder_unix"] }
 concrete-commons = { path = "../concrete-commons" }
 concrete-npe = { path = "../concrete-npe" }

--- a/concrete-core-fixture/src/generation/mod.rs
+++ b/concrete-core-fixture/src/generation/mod.rs
@@ -54,6 +54,8 @@ impl IntegerPrecision for Precision64 {
 /// fixture.
 pub struct Maker {
     default_engine: concrete_core::backends::default::engines::DefaultEngine,
+    default_parallel_engine:
+        concrete_core::backends::default::engines::parallel::DefaultParallelEngine,
     #[cfg(feature = "backend_fftw")]
     fftw_engine: concrete_core::backends::fftw::engines::FftwEngine,
 }
@@ -65,6 +67,11 @@ impl Default for Maker {
                 Box::new(UnixSeeder::new(0)),
             )
             .unwrap(),
+            default_parallel_engine:
+                concrete_core::backends::default::engines::parallel::DefaultParallelEngine::new(
+                    Box::new(UnixSeeder::new(0)),
+                )
+                .unwrap(),
             #[cfg(feature = "backend_fftw")]
             fftw_engine: concrete_core::backends::fftw::engines::FftwEngine::new(()).unwrap(),
         }

--- a/concrete-core-fixture/src/generation/prototyping/lwe_bootstrap_key.rs
+++ b/concrete-core-fixture/src/generation/prototyping/lwe_bootstrap_key.rs
@@ -48,7 +48,7 @@ impl PrototypesLweBootstrapKey<Precision32, BinaryKeyDistribution, BinaryKeyDist
         noise: Variance,
     ) -> Self::LweBootstrapKeyProto {
         ProtoBinaryBinaryLweBootstrapKey32(
-            self.default_engine
+            self.default_parallel_engine
                 .create_lwe_bootstrap_key(
                     &input_key.0,
                     &output_key.0,
@@ -75,7 +75,7 @@ impl PrototypesLweBootstrapKey<Precision64, BinaryKeyDistribution, BinaryKeyDist
         noise: Variance,
     ) -> Self::LweBootstrapKeyProto {
         ProtoBinaryBinaryLweBootstrapKey64(
-            self.default_engine
+            self.default_parallel_engine
                 .create_lwe_bootstrap_key(
                     &input_key.0,
                     &output_key.0,


### PR DESCRIPTION
### Resolves:

closes https://github.com/zama-ai/concrete-core-internal/issues/185

### Description

allows to benefit from the parallel algorithms in the
DefaultParallelEngine, so currently only bootstrap key, though as it's the
most costly it could prove to be a nice improvement (hopefully)

has to wait on https://github.com/zama-ai/concrete-core/pull/40

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

~~* [ ] Tests for the changes have been added (for bug fixes / features)~~
~~* [ ] Docs have been added / updated (for bug fixes / features)~~
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
~~* [ ] The draft release description has been updated~~
~~* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]~~

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
