### PR TITLE
chore(ci): add slack notification when using ci-bot

### DIFF
--- a/.github/workflows/aws_tests_slab_beta.yml
+++ b/.github/workflows/aws_tests_slab_beta.yml
@@ -19,6 +19,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   run-tests-linux:
@@ -50,3 +51,15 @@ jobs:
           override: true
       - name: Run concrete tests
         run: cargo xtask test
+
+      - name: Slack Notification
+        if: ${{ always() }}
+        continue-on-error: true
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7
+        env:
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+          SLACK_ICON: https://pbs.twimg.com/profile_images/1274014582265298945/OjBKP9kn_400x400.png
+          SLACK_MESSAGE: "(Slab ci-bot beta) AWS tests finished with status ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Description

Send Slack notifications through the workflow file instead of Slab directly. This is done to speed up ealry usage of the CI bot without messing with the current data flow.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* ~~[ ] Tests for the changes have been added (for bug fixes / features)~~
* ~~[ ] Docs have been added / updated (for bug fixes / features)~~
* ~~[ ] The PR description links to the related issue (to link an issue, use '#XXX'.)~~
* ~~[ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)~~
* ~~[ ] The draft release description has been updated~~
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]


[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
