### PR TITLE
chore(concrete_core): raise the `DefaultParallelEngine` in super module

### DIFF
--- a/concrete-core/src/backends/default/implementation/engines/mod.rs
+++ b/concrete-core/src/backends/default/implementation/engines/mod.rs
@@ -62,7 +62,7 @@ impl AbstractEngine for DefaultEngine {
 }
 
 #[cfg(feature = "parallel")]
-pub mod parallel {
+mod parallel {
     use std::error::Error;
     use std::fmt::{Display, Formatter};
 
@@ -120,6 +120,8 @@ pub mod parallel {
         }
     }
 }
+#[cfg(feature = "parallel")]
+pub use parallel::*;
 
 mod cleartext_creation;
 mod cleartext_discarding_retrieval;

--- a/concrete-core/src/prelude.rs
+++ b/concrete-core/src/prelude.rs
@@ -5,8 +5,6 @@ pub use super::specification::engines::*;
 pub use super::specification::entities::*;
 
 // --------------------------------------------------------------------------------- DEFAULT BACKEND
-#[cfg(all(feature = "backend_default", feature = "parallel"))]
-pub use super::backends::default::engines::parallel::*;
 #[cfg(feature = "backend_default")]
 pub use super::backends::default::engines::*;
 #[cfg(feature = "backend_default")]


### PR DESCRIPTION
### Resolves:

closes zama-ai/concrete-core-internal#227

### Description

When the DefaultParallelEngine was added, it was inside of a parallel module, and as such, it is not at the same level in the modules as the DefaultEngine.

This commit solves it.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* ~[ ] Tests for the changes have been added (for bug fixes / features)~
* ~[ ] Docs have been added / updated (for bug fixes / features)~
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* ~[ ] The draft release description has been updated~
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
