### PR TITLE
chore(tasks): make tasks usable on M1 macs

### DIFF
--- a/concrete-tasks/src/build.rs
+++ b/concrete-tasks/src/build.rs
@@ -1,4 +1,4 @@
-use crate::utils::Environment;
+use crate::utils::{get_nightly_toolchain, Environment};
 use crate::{cmd, ENV_TARGET_NATIVE};
 use std::collections::HashMap;
 use std::io::Error;
@@ -50,7 +50,8 @@ pub mod debug {
     }
 
     pub fn doctests() -> Result<(), Error> {
-        cmd!(<ENV_DOCTEST> "cargo +nightly test --doc --all-features")
+        cmd!(<ENV_DOCTEST>
+            &format!("cargo {} test --doc --all-features", get_nightly_toolchain()?))
     }
 }
 
@@ -70,7 +71,8 @@ pub mod release {
     }
 
     pub fn doctests() -> Result<(), Error> {
-        cmd!(<ENV_DOCTEST> "cargo +nightly test --release --doc --all-features")
+        cmd!(<ENV_DOCTEST>
+            &format!("cargo {} test --release --doc --all-features", get_nightly_toolchain()?))
     }
 }
 
@@ -109,9 +111,11 @@ pub mod simd {
 
     pub fn doctests() -> Result<(), Error> {
         if cfg!(target_os = "linux") {
-            cmd!(<ENV_DOCTEST_SIMD> "cargo +nightly test --release --doc --all-features")
+            cmd!(<ENV_DOCTEST_SIMD>
+                &format!("cargo {} test --release --doc --all-features", get_nightly_toolchain()?))
         } else if cfg!(target_os = "macos") {
-            cmd!(<ENV_DOCTEST_NATIVE> "cargo +nightly test --release --doc --all-features")
+            cmd!(<ENV_DOCTEST_NATIVE>
+                &format!("cargo {} test --release --doc --all-features", get_nightly_toolchain()?))
         } else {
             unreachable!()
         }

--- a/concrete-tasks/src/check.rs
+++ b/concrete-tasks/src/check.rs
@@ -1,5 +1,5 @@
 use crate::cmd;
-use crate::utils::Environment;
+use crate::utils::{get_nightly_toolchain, Environment};
 use std::collections::HashMap;
 use std::io::Error;
 
@@ -12,13 +12,19 @@ lazy_static! {
 }
 
 pub fn doc() -> Result<(), Error> {
-    cmd!(<ENV_DOC_KATEX> "cargo +nightly doc --features=doc --no-deps")
+    cmd!(<ENV_DOC_KATEX> &format!("cargo {} doc --features=doc --no-deps", get_nightly_toolchain()?))
 }
 
 pub fn clippy() -> Result<(), Error> {
-    cmd!("cargo +nightly clippy --all-targets --all-features -- --no-deps -D warnings")
+    cmd!(&format!(
+        "cargo {} clippy --all-targets --all-features -- --no-deps -D warnings",
+        get_nightly_toolchain()?
+    ))
 }
 
 pub fn fmt() -> Result<(), Error> {
-    cmd!("cargo +nightly fmt --all -- --check")
+    cmd!(&format!(
+        "cargo {} fmt --all -- --check",
+        get_nightly_toolchain()?
+    ))
 }

--- a/concrete-tasks/src/chore.rs
+++ b/concrete-tasks/src/chore.rs
@@ -1,8 +1,9 @@
+use crate::utils::get_nightly_toolchain;
 use crate::{cmd, format_latex_doc};
 use std::io::Error;
 
 pub fn format() -> Result<(), Error> {
-    cmd!("cargo +nightly fmt")
+    cmd!(&format!("cargo {} fmt", get_nightly_toolchain()?))
 }
 
 pub fn format_latex_doc() -> Result<(), Error> {

--- a/concrete-tasks/src/main.rs
+++ b/concrete-tasks/src/main.rs
@@ -35,11 +35,11 @@ lazy_static! {
 
 #[macro_export]
 macro_rules! cmd {
-    ($cmd: literal) => {
-        $crate::utils::execute($cmd, None, Some(&*$crate::ROOT_DIR))
-    };
-    (<$env: ident> $cmd: literal) => {
+    (<$env: ident> $cmd: expr) => {
         $crate::utils::execute($cmd, Some(&*$env), Some(&*$crate::ROOT_DIR))
+    };
+    ($cmd: expr) => {
+        $crate::utils::execute($cmd, None, Some(&*$crate::ROOT_DIR))
     };
 }
 

--- a/concrete-tasks/src/main.rs
+++ b/concrete-tasks/src/main.rs
@@ -105,7 +105,7 @@ fn main() -> Result<(), std::io::Error> {
         .get_matches();
 
     // We initialize the logger with proper verbosity
-    let verb = if matches.is_present("verbose") {
+    let verb = if matches.contains_id("verbose") {
         LevelFilter::Debug
     } else {
         LevelFilter::Info
@@ -119,7 +119,7 @@ fn main() -> Result<(), std::io::Error> {
     .unwrap();
 
     // We set the dry-run mode if present
-    if matches.is_present("dry-run") {
+    if matches.contains_id("dry-run") {
         DRY_RUN.store(true, Relaxed);
     }
 

--- a/concrete-tasks/src/test.rs
+++ b/concrete-tasks/src/test.rs
@@ -1,4 +1,4 @@
-use crate::utils::Environment;
+use crate::utils::{get_nightly_toolchain, Environment};
 use crate::{cmd, ENV_TARGET_NATIVE};
 use std::collections::HashMap;
 use std::io::Error;
@@ -47,5 +47,6 @@ pub fn crates() -> Result<(), Error> {
 }
 
 pub fn cov_crates() -> Result<(), Error> {
-    cmd!(<ENV_COVERAGE> "cargo +nightly test --release --no-fail-fast --all-features")
+    cmd!(<ENV_COVERAGE>
+        &format!("cargo {} test --release --no-fail-fast --all-features", get_nightly_toolchain()?))
 }

--- a/concrete-tasks/src/utils.rs
+++ b/concrete-tasks/src/utils.rs
@@ -47,3 +47,40 @@ pub fn project_root() -> PathBuf {
         .unwrap()
         .to_path_buf()
 }
+
+pub fn get_nightly_toolchain() -> Result<&'static str, Error> {
+    if cfg!(target_os = "macos") {
+        // Here we are on mac OS, but we don't yet know if it's an x86 or M1 CPU.
+        // The issue is that with the toolchain override recommended to build concrete, we need to
+        // check with uname at runtime if we are running on an M1 CPU as rosetta2 fakes CPU
+        // informations (for good reasons)
+        let mut command = Command::new("sh");
+        command.arg("-c").arg("uname -a");
+        let output = command.output()?;
+        if !output.status.success() {
+            Err(Error::new(
+                ErrorKind::Other,
+                "Command exited with nonzero status.",
+            ))
+        } else {
+            let uname_output_as_str = std::str::from_utf8(&output.stdout).unwrap();
+            let uname_output_lower = uname_output_as_str.to_lowercase();
+
+            // See here for M1 sample uname output:
+            // https://developer.apple.com/forums/thread/668206
+            // The ARM64 part is present both under rosetta2 and native calls.
+
+            let is_arm64 = uname_output_lower.contains("arm64");
+
+            // For now we don't support native M1 compilation, so ask to use the x86_64 toolchain.
+            if is_arm64 {
+                Ok("+nightly-x86_64-apple-darwin")
+            } else {
+                // Otherwise it's an x86 mac so just keep the default nightly toolchain
+                Ok("+nightly")
+            }
+        }
+    } else {
+        Ok("+nightly")
+    }
+}


### PR DESCRIPTION
### Resolves:

closes https://github.com/zama-ai/concrete-core-internal/issues/219

### Description

Add a uname call and some small parsing to be able to determine the CPU on mac OS.

The uname call is required to be able to work no matter the toolchain used on mac OS as we encourage devs to override it.

I have an alternative version of this PR where we don't crash if we fail to get infos on mac OS, here we stop if encounter an error.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

~~* [ ] Tests for the changes have been added (for bug fixes / features)~~
~~* [ ] Docs have been added / updated (for bug fixes / features)~~
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
~~* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)~~
~~* [ ] The draft release description has been updated~~
~~* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]~~

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
