### PR TITLE
chore(tasks): update main.rs to use undeprecated clap functions

### DIFF
--- a/concrete-tasks/src/main.rs
+++ b/concrete-tasks/src/main.rs
@@ -105,7 +105,7 @@ fn main() -> Result<(), std::io::Error> {
         .get_matches();
 
     // We initialize the logger with proper verbosity
-    let verb = if matches.is_present("verbose") {
+    let verb = if matches.contains_id("verbose") {
         LevelFilter::Debug
     } else {
         LevelFilter::Info
@@ -119,7 +119,7 @@ fn main() -> Result<(), std::io::Error> {
     .unwrap();
 
     // We set the dry-run mode if present
-    if matches.is_present("dry-run") {
+    if matches.contains_id("dry-run") {
         DRY_RUN.store(true, Relaxed);
     }
 


### PR DESCRIPTION
### Resolves:

closes https://github.com/zama-ai/concrete-core-internal/issues/228

### Description

clap deprecated new things in their latest version it seems, this fixes the clippy checks, we may want to freeze the deps in concrete-tasks or have a Cargo.lock as it's a binary

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

~~* [ ] Tests for the changes have been added (for bug fixes / features)~~
~~* [ ] Docs have been added / updated (for bug fixes / features)~~
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
~~* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)~~
~~* [ ] The draft release description has been updated~~
~~* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]~~

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
