### PR TITLE
feat(core): update fill_with_backward_fourier for FourierGlweCiphertext

### DIFF
--- a/concrete-core/src/backends/fftw/implementation/engines/glwe_ciphertext_conversion.rs
+++ b/concrete-core/src/backends/fftw/implementation/engines/glwe_ciphertext_conversion.rs
@@ -263,8 +263,9 @@ impl GlweCiphertextConversionEngine<FftwFourierGlweCiphertext32, GlweCiphertext3
             input.polynomial_size(),
             input.glwe_dimension().to_glwe_size(),
         );
-        let mut input_ = input.0.clone();
-        input_.fill_with_backward_fourier(&mut output, buffers);
+        input
+            .0
+            .fill_glwe_with_backward_fourier(&mut output, buffers);
         GlweCiphertext32(output)
     }
 }
@@ -348,8 +349,9 @@ impl GlweCiphertextConversionEngine<FftwFourierGlweCiphertext64, GlweCiphertext6
             input.polynomial_size(),
             input.glwe_dimension().to_glwe_size(),
         );
-        let mut input_ = input.0.clone();
-        input_.fill_with_backward_fourier(&mut output, buffers);
+        input
+            .0
+            .fill_glwe_with_backward_fourier(&mut output, buffers);
         GlweCiphertext64(output)
     }
 }

--- a/concrete-core/src/commons/math/polynomial/list.rs
+++ b/concrete-core/src/commons/math/polynomial/list.rs
@@ -21,7 +21,7 @@ use concrete_commons::parameters::{MonomialDegree, PolynomialCount, PolynomialSi
 /// assert_eq!(list.polynomial_count(), PolynomialCount(4));
 /// assert_eq!(list.polynomial_size(), PolynomialSize(2));
 /// ```
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub struct PolynomialList<Cont> {
     pub(crate) tensor: Tensor<Cont>,
     pub(crate) poly_size: PolynomialSize,

--- a/concrete-core/src/commons/math/polynomial/monomial.rs
+++ b/concrete-core/src/commons/math/polynomial/monomial.rs
@@ -16,7 +16,7 @@ use concrete_commons::parameters::MonomialDegree;
 /// assert_eq!(*mono.get_coefficient(), 1u8);
 /// assert_eq!(mono.degree(), MonomialDegree(5));
 /// ```
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub struct Monomial<Cont> {
     tensor: Tensor<Cont>,
     degree: MonomialDegree,

--- a/concrete-core/src/commons/math/polynomial/polynomial.rs
+++ b/concrete-core/src/commons/math/polynomial/polynomial.rs
@@ -25,7 +25,7 @@ const KARATUSBA_STOP: usize = 32;
 /// let poly = Polynomial::allocate(0 as u32, PolynomialSize(100));
 /// assert_eq!(poly.polynomial_size(), PolynomialSize(100));
 /// ```
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Polynomial<Cont> {
     pub(crate) tensor: Tensor<Cont>,
 }


### PR DESCRIPTION
### Resolves:

closes https://github.com/zama-ai/concrete-core-internal/issues/215

### Description

now allows to call the function on an immutable ciphertext

if we need a version that does not perform copies and is okay to thrash the original ciphertext we can add it back, but I could not find other callsites, so I think this is ok for now

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

~~* [ ] Tests for the changes have been added (for bug fixes / features)~~
~~* [ ] Docs have been added / updated (for bug fixes / features)~~
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
~~* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]~~

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
