### PR TITLE
chore(tasks): no need for features when using cargo fmt

### DIFF
--- a/concrete-tasks/src/chore.rs
+++ b/concrete-tasks/src/chore.rs
@@ -3,10 +3,7 @@ use crate::{cmd, format_latex_doc};
 use std::io::Error;
 
 pub fn format() -> Result<(), Error> {
-    cmd!(&format!(
-        "cargo {} fmt --features=_ci_do_not_compile",
-        get_nightly_toolchain()?
-    ))
+    cmd!(&format!("cargo {} fmt", get_nightly_toolchain()?))
 }
 
 pub fn format_latex_doc() -> Result<(), Error> {


### PR DESCRIPTION
### Description

cargo fmt does not accept features the way it was done. It also does not run any compilation, so we can safely run it without arguments with the latest nightly toolchains

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
