### PR TITLE
feat(cuda): fix benchmark for the amortized PBS

### DIFF
--- a/concrete-core-bench/src/main.rs
+++ b/concrete-core-bench/src/main.rs
@@ -27,6 +27,8 @@ fn main() {
     fftw::bench();
     #[cfg(all(feature = "backend_cuda", not(feature = "_ci_do_not_compile")))]
     cuda::bench();
+    #[cfg(all(feature = "backend_cuda", not(feature = "_ci_do_not_compile")))]
+    cuda::bench_amortized();
 
     // We launch the benchmarks.
     criterion::Criterion::default()


### PR DESCRIPTION
### Resolves: fix a bug in which the benchmarks for the amortized PBS were not being executed.

### Description
There was a line missing in concrete-core-bench for the amortized PBS.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
