### PR TITLE
fix(ci): fix workflow file format and concurrency for aws gpu tests

### DIFF
--- a/.github/workflows/aws_tests_gpu_slab_beta.yml
+++ b/.github/workflows/aws_tests_gpu_slab_beta.yml
@@ -67,17 +67,16 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
-      - name: Run concrete tests
-        run: cargo xtask test
+          components: rustfmt, clippy
+      - name: Clippy on cuda backend
+        run: |
+          cargo xtask check_clippy_cuda
 
-      - name: Test concrete-cuda
+      - name: Test concrete-core with cuda backend
         run: |
-          cargo test --release -p concrete-cuda
-      - name: Run concrete tests
-        run: |
-          RUSTFLAGS="-Ctarget-cpu=native" cargo test --release --no-fail-fast --features=backend_cuda -p concrete-core-test -- --test-threads 1
+         cargo xtask test_cuda
 
       - name: Slack Notification
         if: ${{ always() }}

--- a/.github/workflows/aws_tests_gpu_slab_beta.yml
+++ b/.github/workflows/aws_tests_gpu_slab_beta.yml
@@ -1,6 +1,7 @@
 # Compile and test project on an AWS instance
-name: AWS tests
+name: AWS tests on GPU
 
+# This workflow is meant to be run via Zama CI bot Slab.
 on:
   workflow_dispatch:
     inputs:
@@ -24,7 +25,7 @@ env:
 jobs:
   run-tests-linux:
     concurrency:
-      group: ${{ github.ref }}
+      group: ${{ github.ref }}_${{ github.event.inputs.instance_image_id }}_${{ github.event.inputs.instance_type }}
       cancel-in-progress: true
     name: Test code in EC2
     runs-on: ${{ github.event.inputs.runner_name }}
@@ -50,19 +51,19 @@ jobs:
       - name: Set up home
         run: |
           echo "HOME=/home/ubuntu" >> "${GITHUB_ENV}"
-    - name: Export CUDA variables
-      run: |
-        echo "CUDA_PATH=$CUDA_PATH" >> $GITHUB_ENV
-        echo "$CUDA_PATH/bin" >> $GITHUB_PATH
-        echo "LD_LIBRARY_PATH=$CUDA_PATH/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-    # Specify the correct host compilers
-    - name: Export gcc and g++ variables
-      run: |
-        echo "CC=/usr/bin/gcc-${{ matrix.gcc }}" >> $GITHUB_ENV
-        echo "CXX=/usr/bin/g++-${{ matrix.gcc }}" >> $GITHUB_ENV
-        echo "CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }}" >> $GITHUB_ENV
-        echo "CUDACXX=/usr/local/cuda-${{ matrix.cuda }}/bin/nvcc" >> $GITHUB_ENV
-        echo "HOME=/home/ubuntu" >> $GITHUB_ENV
+      - name: Export CUDA variables
+        run: |
+          echo "CUDA_PATH=$CUDA_PATH" >> $GITHUB_ENV
+          echo "$CUDA_PATH/bin" >> $GITHUB_PATH
+          echo "LD_LIBRARY_PATH=$CUDA_PATH/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+      # Specify the correct host compilers
+      - name: Export gcc and g++ variables
+        run: |
+          echo "CC=/usr/bin/gcc-${{ matrix.gcc }}" >> $GITHUB_ENV
+          echo "CXX=/usr/bin/g++-${{ matrix.gcc }}" >> $GITHUB_ENV
+          echo "CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }}" >> $GITHUB_ENV
+          echo "CUDACXX=/usr/local/cuda-${{ matrix.cuda }}/bin/nvcc" >> $GITHUB_ENV
+          echo "HOME=/home/ubuntu" >> $GITHUB_ENV
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -77,6 +78,7 @@ jobs:
       - name: Run concrete tests
         run: |
           RUSTFLAGS="-Ctarget-cpu=native" cargo test --release --no-fail-fast --features=backend_cuda -p concrete-core-test -- --test-threads 1
+
       - name: Slack Notification
         if: ${{ always() }}
         continue-on-error: true
@@ -85,6 +87,6 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
           SLACK_ICON: https://pbs.twimg.com/profile_images/1274014582265298945/OjBKP9kn_400x400.png
-          SLACK_MESSAGE: "(Slab ci-bot beta) AWS tests finished with status ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_MESSAGE: "(Slab ci-bot beta) AWS tests GPU finished with status ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
           SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/aws_tests_slab_beta.yml
+++ b/.github/workflows/aws_tests_slab_beta.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   run-tests-linux:
     concurrency:
-      group: ${{ github.ref }}
+      group: ${{ github.ref }}_${{ github.event.inputs.instance_image_id }}_${{ github.event.inputs.instance_type }}
       cancel-in-progress: true
     name: Test code in EC2
     runs-on: ${{ github.event.inputs.runner_name }}


### PR DESCRIPTION
### Description

Some under indented sections made that workflow impossible to be remotely triggered.

Also the concurrency group name has been enhanced to be able to run GPU and CPU in parallel. Now only a run with the git ref and the same AWS AMI would cancel any previous on-going run.

### Checklist 

~~* [ ] Tests for the changes have been added (for bug fixes / features)~~
~~* [ ] Docs have been added / updated (for bug fixes / features)~~
~~* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)~~
~~* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)~~
~~* [ ] The draft release description has been updated~~
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
