### PR TITLE
chore(core): apply underscore escaping to all the documentation

### DIFF
--- a/concrete-commons/src/dispersion.rs
+++ b/concrete-commons/src/dispersion.rs
@@ -29,7 +29,7 @@ pub trait DispersionParameter: Copy {
     /// Returns the variance of the distribution, i.e. $\sigma^2 = 2^{2p}$.
     fn get_variance(&self) -> f64;
     /// Returns base 2 logarithm of the standard deviation of the distribution, i.e.
-    /// $\log_2(\sigma)=p$
+    /// $\log\_2(\sigma)=p$
     fn get_log_standard_dev(&self) -> f64;
     /// For a `Uint` type representing $\mathbb{Z}/2^q\mathbb{Z}$, we return $2^{q-p}$.
     fn get_modular_standard_dev<Uint>(&self) -> f64

--- a/concrete-commons/src/parameters.rs
+++ b/concrete-commons/src/parameters.rs
@@ -109,7 +109,7 @@ impl GlweDimension {
 
 /// The number of coefficients of a polynomial.
 ///
-/// Assuming a polynomial $a_0 + a_1X + /dots + a_{N-1}X^{N-1}$, this returns $N$.
+/// Assuming a polynomial $a\_0 + a\_1X + /dots + a\_{N-1}X^{N-1}$, this returns $N$.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct PolynomialSize(pub usize);
@@ -123,7 +123,7 @@ impl PolynomialSize {
 
 /// The logarithm of the number of coefficients of a polynomial.
 ///
-/// Assuming a polynomial $a_0 + a_1X + /dots + a_{N-1}X^{N-1}$, this returns $\log_2(N)$.
+/// Assuming a polynomial $a\_0 + a\_1X + /dots + a\_{N-1}X^{N-1}$, this returns $\log\_2(N)$.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct PolynomialSizeLog(pub usize);

--- a/concrete-core/src/backends/fftw/private/math/fft/polynomial.rs
+++ b/concrete-core/src/backends/fftw/private/math/fft/polynomial.rs
@@ -134,7 +134,7 @@ impl<Cont> FourierPolynomial<Cont> {
     /// Adds the result of the element-wise product of two polynomials to $(self.len()/2)+2$
     /// elements of the current polynomial:
     /// $$
-    /// self\[i\] = self\[i\] + poly_1\[i\] * poly_2\[i\]
+    /// self\[i\] = self\[i\] + poly\_1\[i\] * poly\_2\[i\]
     /// $$
     ///
     /// # Example
@@ -176,7 +176,7 @@ impl<Cont> FourierPolynomial<Cont> {
     /// of the element-wise product of `poly_3` with `poly_4`, to $(self.len()/2)+2$ elements of
     /// the current polynomial:
     /// $$
-    /// self\[i\] = self\[i\] + poly_1\[i\] * poly_2\[i\] + poly_3\[i\] * poly_4\[i\]
+    /// self\[i\] = self\[i\] + poly\_1\[i\] * poly\_2\[i\] + poly\_3\[i\] * poly\_4\[i\]
     /// $$
     ///
     /// # Example
@@ -229,8 +229,9 @@ impl<Cont> FourierPolynomial<Cont> {
     /// Updates two polynomials with the following operation:
     ///
     /// $$
-    /// result_1\[i\]=result_1\[i\]+poly_{a_1}\[i\]*poly_b\[i\]+poly_{c_1}\[i\]*poly_d\[i\]\\\\
-    /// result_2\[i\]=result_2\[i\]+poly_{a_2}\[i\]*poly_b\[i\]+poly_{c_2}\[i\]*poly_d\[i\]
+    /// result\_1\[i\]
+    /// =result\_1\[i\]+poly\_{a\_1}\[i\]*poly\_b\[i\]+poly\_{c\_1}\[i\]*poly\_d\[i\]\\\\
+    /// result\_2\[i\]=result\_2\[i\]+poly\_{a\_2}\[i\]*poly\_b\[i\]+poly\_{c\_2}\[i\]*poly\_d\[i\]
     /// $$
     ///
     /// # Example

--- a/concrete-core/src/commons/crypto/lwe/ciphertext.rs
+++ b/concrete-core/src/commons/crypto/lwe/ciphertext.rs
@@ -316,7 +316,7 @@ impl<Cont> LweCiphertext<Cont> {
     ///
     /// Said differently, this function fills `self` with:
     /// $$
-    /// bias + \sum_i input_list\[i\] * weights\[i\]
+    /// bias + \sum\_i input\_list\[i\] * weights\[i\]
     /// $$
     ///
     /// # Example

--- a/concrete-core/src/commons/crypto/lwe/keyswitch.rs
+++ b/concrete-core/src/commons/crypto/lwe/keyswitch.rs
@@ -23,12 +23,12 @@ use serde::{Deserialize, Serialize};
 /// A keyswitching key allows to change the key of a cipher text. Lets assume the following
 /// elements:
 ///
-/// + The input key $s_{in}$ is composed of $n$ bits
-/// + The output key $s_{out}$ is composed of $m$ bits
+/// + The input key $s\_{in}$ is composed of $n$ bits
+/// + The output key $s\_{out}$ is composed of $m$ bits
 ///
-/// The keyswitch key will be composed of $m$ encryptions of each bits of the $s_{out}$ key, under
-/// the key $s_{in}$; encryptions which will be stored as their decomposition over a given basis
-/// $B_{ks}\in\mathbb{N}$, up to a level $l_{ks}\in\mathbb{N}$.
+/// The keyswitch key will be composed of $m$ encryptions of each bits of the $s\_{out}$ key, under
+/// the key $s\_{in}$; encryptions which will be stored as their decomposition over a given basis
+/// $B\_{ks}\in\mathbb{N}$, up to a level $l\_{ks}\in\mathbb{N}$.
 #[cfg_attr(feature = "__commons_serialization", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweKeyswitchKey<Cont> {

--- a/concrete-core/src/commons/crypto/lwe/list.rs
+++ b/concrete-core/src/commons/crypto/lwe/list.rs
@@ -341,7 +341,7 @@ impl<Cont> LweList<Cont> {
     ///
     /// Said differently, this function fills `self` with:
     /// $$
-    /// bias\[i\] + \sum_j input_list\[i\]\[j\] * weights\[i\]\[j\]
+    /// bias\[i\] + \sum\_j input\_list\[i\]\[j\] * weights\[i\]\[j\]
     /// $$
     ///
     /// # Example

--- a/concrete-core/src/commons/math/decomposition/decomposer.rs
+++ b/concrete-core/src/commons/math/decomposition/decomposer.rs
@@ -144,7 +144,7 @@ where
     ///
     /// # Warning
     ///
-    /// The returned iterator yields the terms $\tilde{\theta}_i$ in order of decreasing $i$.
+    /// The returned iterator yields the terms $\tilde{\theta}\_i$ in order of decreasing $i$.
     ///
     /// # Example
     ///
@@ -176,8 +176,8 @@ where
 
     /// Recomposes a decomposed value by summing all the terms.
     ///
-    /// If the input iterator yields $\tilde{\theta}_i$, this returns
-    /// $\sum_{i=1}^l\tilde{\theta}_i\frac{q}{B^i}$.
+    /// If the input iterator yields $\tilde{\theta}\_i$, this returns
+    /// $\sum\_{i=1}^l\tilde{\theta}\_i\frac{q}{B^i}$.
     ///
     /// # Example
     ///
@@ -206,8 +206,8 @@ where
     ///
     /// # Warning
     ///
-    /// The returned iterator yields the terms $(\tilde{\theta}^{(a)}_i)_{a\in\mathbb{N}}$ in order
-    /// of decreasing $i$.
+    /// The returned iterator yields the terms $(\tilde{\theta}^{(a)}\_i)\_{a\in\mathbb{N}}$ in
+    /// order of decreasing $i$.
     ///
     /// # Example
     ///

--- a/concrete-core/src/commons/math/decomposition/mod.rs
+++ b/concrete-core/src/commons/math/decomposition/mod.rs
@@ -11,9 +11,9 @@
 //! given base $B=2^{b}$ and a number of levels $l$ such that $B^l\leq q$, such a $\theta$ can be
 //! approximately decomposed as:
 //! $$
-//!     \theta \approx \sum_{i=1}^l\tilde{\theta}_i\frac{q}{B^i}
+//!     \theta \approx \sum\_{i=1}^l\tilde{\theta}\_i\frac{q}{B^i}
 //! $$
-//! With the $\tilde{\theta}_i\in[-\frac{B}{2}, \frac{B}{2}-1]$. When $B^l = q$, the decomposition
+//! With the $\tilde{\theta}\_i\in[-\frac{B}{2}, \frac{B}{2}-1]$. When $B^l = q$, the decomposition
 //! is no longer an approximation, and becomes exact. The rationale behind using an approximate
 //! decomposition like that, is that when using this decomposition the approximation error will be
 //! located in the least significant bits, which are already erroneous.

--- a/concrete-core/src/commons/math/decomposition/term.rs
+++ b/concrete-core/src/commons/math/decomposition/term.rs
@@ -8,8 +8,8 @@ use std::fmt::Debug;
 
 /// A member of the decomposition.
 ///
-/// If we decompose a value $\theta$ as a sum $\sum_{i=1}^l\tilde{\theta}_i\frac{q}{B^i}$, this
-/// represents a $\tilde{\theta}_i$.
+/// If we decompose a value $\theta$ as a sum $\sum\_{i=1}^l\tilde{\theta}\_i\frac{q}{B^i}$, this
+/// represents a $\tilde{\theta}\_i$.
 #[cfg_attr(feature = "__commons_serialization", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DecompositionTerm<T>
@@ -40,8 +40,8 @@ where
 
     /// Turns this term into a summand.
     ///
-    /// If our member represents one $\tilde{\theta}_i$ of the decomposition, this method returns
-    /// $\tilde{\theta}_i\frac{q}{B^i}$.
+    /// If our member represents one $\tilde{\theta}\_i$ of the decomposition, this method returns
+    /// $\tilde{\theta}\_i\frac{q}{B^i}$.
     ///
     /// # Example
     ///
@@ -60,7 +60,7 @@ where
 
     /// Returns the value of the term.
     ///
-    /// If our member represents one $\tilde{\theta}_i$, this returns its actual value.
+    /// If our member represents one $\tilde{\theta}\_i$, this returns its actual value.
     ///
     /// # Example
     ///
@@ -78,7 +78,7 @@ where
 
     /// Returns the level of the term.
     ///
-    /// If our member represents one $\tilde{\theta}_i$, this returns the value of $i$.
+    /// If our member represents one $\tilde{\theta}\_i$, this returns the value of $i$.
     ///
     /// # Example
     ///
@@ -97,9 +97,9 @@ where
 
 /// A tensor whose elements are the terms of the decomposition of another tensor.
 ///
-/// If we decompose each elements of a set of values $(\theta^{(a)})_{a\in\mathbb{N}}$ as a set of
-/// sums $(\sum_{i=1}^l\tilde{\theta}^{(a)}_i\frac{q}{B^i})_{a\in\mathbb{N}}$, this represents a set
-/// of $(\tilde{\theta}^{(a)}_i)_{a\in\mathbb{N}}$.
+/// If we decompose each elements of a set of values $(\theta^{(a)})\_{a\in\mathbb{N}}$ as a set of
+/// sums $(\sum\_{i=1}^l\tilde{\theta}^{(a)}\_i\frac{q}{B^i})\_{a\in\mathbb{N}}$, this represents a
+/// set of $(\tilde{\theta}^{(a)}\_i)\_{a\in\mathbb{N}}$.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DecompositionTermTensor<'a, Scalar>
 where
@@ -129,9 +129,9 @@ where
 
     /// Fills the output tensor with the terms turned to summands.
     ///
-    /// If our term tensor represents a set of $(\tilde{\theta}^{(a)}_i)_{a\in\mathbb{N}}$ of the
+    /// If our term tensor represents a set of $(\tilde{\theta}^{(a)}\_i)\_{a\in\mathbb{N}}$ of the
     /// decomposition, this method fills the output tensor with a set of
-    /// $(\tilde{\theta}^{(a)}_i\frac{q}{B^i})_{a\in\mathbb{N}}$.
+    /// $(\tilde{\theta}^{(a)}\_i\frac{q}{B^i})\_{a\in\mathbb{N}}$.
     ///
     /// # Example
     ///

--- a/concrete-core/src/commons/math/polynomial/polynomial.rs
+++ b/concrete-core/src/commons/math/polynomial/polynomial.rs
@@ -14,7 +14,7 @@ const KARATUSBA_STOP: usize = 32;
 
 /// A dense polynomial.
 ///
-/// This type represent a dense polynomial in $\mathbb{Z}_{2^q}\[X\] / <X^N + 1>$, composed of $N$
+/// This type represent a dense polynomial in $\mathbb{Z}\_{2^q}\[X\] / <X^N + 1>$, composed of $N$
 /// integer coefficients encoded on $q$ bits.
 ///
 ///  # Example:
@@ -400,10 +400,10 @@ impl<Cont> Polynomial<Cont> {
     /// Adds the sum of the element-wise product between two lists of integer polynomial to the
     /// current polynomial.
     ///
-    /// I.e., if the current polynomial is $C(X)$, for a collection of polynomials $(P_i(X)))_i$
-    /// and another collection of polynomials $(B_i(X))_i$ we perform the operation:
+    /// I.e., if the current polynomial is $C(X)$, for a collection of polynomials $(P\_i(X)))\_i$
+    /// and another collection of polynomials $(B\_i(X))\_i$ we perform the operation:
     /// $$
-    /// C(X) := C(X) + \sum_i P_i(X) \times B_i(X) mod (X^N + 1)
+    /// C(X) := C(X) + \sum\_i P\_i(X) \times B\_i(X) mod (X^N + 1)
     /// $$
     ///
     /// # Example
@@ -448,10 +448,10 @@ impl<Cont> Polynomial<Cont> {
     /// Subtracts the sum of the element-wise product between two lists of integer polynomials,
     /// to the current polynomial.
     ///
-    /// I.e., if the current polynomial is $C(X)$, for two lists of polynomials $(P_i(X)))_i$ and
-    /// $(B_i(X))_i$ we perform the operation:
+    /// I.e., if the current polynomial is $C(X)$, for two lists of polynomials $(P\_i(X)))\_i$ and
+    /// $(B\_i(X))\_i$ we perform the operation:
     /// $$
-    /// C(X) := C(X) + \sum_i P_i(X) \times B_i(X) mod (X^N + 1)
+    /// C(X) := C(X) + \sum\_i P\_i(X) \times B\_i(X) mod (X^N + 1)
     /// $$
     ///
     /// # Example

--- a/concrete-npe/src/key_dispersion.rs
+++ b/concrete-npe/src/key_dispersion.rs
@@ -148,7 +148,7 @@ pub trait KeyDispersion: KeyKind {
 
     /// Returns the variance of the
     /// coefficients of a polynomial key resulting from the multiplication of two polynomial keys
-    /// of the same key kind ($S_i \cdot S_j$ with $i,j$ different).
+    /// of the same key kind ($S\_i \cdot S\_j$ with $i,j$ different).
     /// # Example
     ///```rust
     /// use concrete_commons::dispersion::*;
@@ -172,7 +172,7 @@ pub trait KeyDispersion: KeyKind {
 
     /// Returns the mean expectation of
     /// the coefficients of a polynomial key resulting from the multiplication of two polynomial
-    /// keys of the same key kind ($S_i \cdot S_j$ with $i,j$ different).
+    /// keys of the same key kind ($S\_i \cdot S\_j$ with $i,j$ different).
     /// # Example
     ///```rust
     /// use concrete_commons::dispersion::*;

--- a/concrete-npe/src/lib.rs
+++ b/concrete-npe/src/lib.rs
@@ -13,9 +13,9 @@
 //! Chillotti, Damien Ligier, Jean-Baptiste Orfila and Samuel Tap*.
 //!
 //! # Quick Example
-//! The following piece of code shows how to obtain the variance $\sigma_{add}$ of the noise
+//! The following piece of code shows how to obtain the variance $\sigma\_{add}$ of the noise
 //! after a simulated homomorphic addition between two ciphertexts which have variances
-//! $\sigma_{ct_1}$ and $\sigma_{ct_2}$, respectively.
+//! $\sigma\_{ct\_1}$ and $\sigma\_{ct\_2}$, respectively.
 //!
 //! # Example:
 //! ```rust

--- a/concrete-npe/src/operators.rs
+++ b/concrete-npe/src/operators.rs
@@ -83,8 +83,8 @@ where
 }
 
 /// Computes the dispersion of a multisum between
-/// uncorrelated ciphertexts and scalar weights $w_i$ i.e.,  $\sigma_{out}^2 = \sum_i w_i^2 *
-/// \sigma_i^2$.
+/// uncorrelated ciphertexts and scalar weights $w\_i$ i.e.,  $\sigma\_{out}^2 = \sum\_i w\_i^2 *
+/// \sigma\_i^2$.
 /// # Example
 /// ```rust
 /// use concrete_commons::dispersion::Variance;


### PR DESCRIPTION
### Resolves:

### Description

This PR applies the underscore escaping to all the latex in docs comments in concrete-core, it makes writing formal defs easier as we don't have changes coming from other parts of the code base when applying the underscores

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
