### PR TITLE
docs(core): add formal def. for seeded LWE ciphertext vector encryption

### DIFF
--- a/concrete-core/src/specification/engines/lwe_seeded_ciphertext_encryption.rs
+++ b/concrete-core/src/specification/engines/lwe_seeded_ciphertext_encryption.rs
@@ -19,7 +19,7 @@ engine_error! {
 ///
 /// # Formal Definition
 ///
-/// ## LWE Encryption
+/// ## Seeded LWE Encryption
 /// ###### inputs:
 /// - $\mathsf{pt}\in\mathbb{Z}\_q$: a plaintext
 /// - $\vec{s}\in\mathbb{Z}\_q^n$: a secret key

--- a/concrete-core/src/specification/engines/lwe_seeded_ciphertext_vector_encryption.rs
+++ b/concrete-core/src/specification/engines/lwe_seeded_ciphertext_vector_encryption.rs
@@ -19,7 +19,29 @@ engine_error! {
 ///
 /// # Formal Definition
 ///
-/// cf [`here`](`crate::specification::engines::LweSeededCiphertextEncryptionEngine`)
+/// ## Seeded LWE vector encryption
+/// ###### inputs:
+/// - $\vec{\mathsf{pt}}\in\mathbb{Z}\_q^t$: a plaintext vector
+/// - $\vec{s}\in\mathbb{Z}\_q^n$: a secret key
+/// - $\mathsf{seed} \in\mathcal{S}$: a public seed
+/// - $G$: a CSPRNG working with seeds from $\mathcal{S}$
+/// - $\mathcal{D}\_{\sigma^2,\mu}$: a normal distribution of variance $\sigma^2$ and mean $\mu$
+///
+/// ###### outputs:
+/// - $\vec{\tilde{\mathsf{ct}}} = \left( \mathsf{seed} , \vec{b}\right) \in
+///   \mathsf{SeededLWEVector}^{n, t}\_{\vec{s}, G}(
+///  \vec{\mathsf{pt}})\subseteq \mathcal{S}\times \mathbb{Z}\_q^t$: a seeded LWE ciphertext vector
+///
+/// ###### algorithm:
+/// 1. let $\vec{b} \in \mathbb{Z}\_q^t$
+/// 2. Seed $G$ with the seed $\mathsf{seed}\in\mathcal{S}$
+/// 3. for each $(b\_i, \mathsf{pt\_i})$ in $(\vec{b}, \vec{\mathsf{pt}})$
+///     - uniformly sample $n$ integers in $\mathbb{Z}\_q$ from $G$ and store them in
+/// $\vec{a}\in\mathbb{Z}^n\_q$
+///     - sample an integer error term $e \hookleftarrow\mathcal{D}\_{\sigma^2,\mu}$
+///     - compute $b\_i = \left\langle \vec{a} , \vec{s} \right\rangle + \mathsf{pt\_i} + e
+/// \in\mathbb{Z}\_q$
+/// 4. output $\left( \mathsf{seed} , \vec{b}\right)$
 pub trait LweSeededCiphertextVectorEncryptionEngine<SecretKey, PlaintextVector, CiphertextVector>:
     AbstractEngine
 where

--- a/concrete-core/src/specification/engines/lwe_seeded_ciphertext_vector_to_lwe_ciphertext_vector_transformation.rs
+++ b/concrete-core/src/specification/engines/lwe_seeded_ciphertext_vector_to_lwe_ciphertext_vector_transformation.rs
@@ -18,7 +18,26 @@ engine_error! {
 /// # Formal Definition
 ///
 /// ## LWE seeded ciphertext vector to LWE ciphertext vector transformation
-/// cf [`here`](`crate::specification::engines::LweSeededCiphertextToLweCiphertextTransformationEngine`)
+/// ###### inputs:
+/// - $G$: a CSPRNG working with seeds from $\mathcal{S}$
+/// - $\vec{\tilde{\mathsf{ct}}} = \left( \mathsf{seed} , \vec{\tilde{b}}\right) \in
+///   \mathsf{SeededLWEVector}^{n, t}\_{\vec{s}, G}( \vec{\mathsf{pt}})\subseteq \mathcal{S}\times
+///   \mathbb{Z}\_q^t$: a seeded LWE ciphertext vector
+///
+/// ###### outputs:
+/// - $\vec{\mathsf{ct}} = \vec{\left( \vec{a} , b\right)} \in \mathsf{LWEVector}^{n,t}\_{\vec{s}}(
+///   \mathsf{pt} )\subseteq {\mathbb{Z}\_q^{(n+1)}}^t$: an LWE ciphertext vector
+///
+/// ###### algorithm:
+/// 1. let $\vec{\mathsf{ct}} = \vec{\left( \vec{a} , b\right)} \in
+/// \mathsf{LWEVector}^{n,t}\_{\vec{s}}(   \mathsf{pt} )\subseteq {\mathbb{Z}\_q^{(n+1)}}^t$
+/// 2. Seed $G$ with the seed $\mathsf{seed}\in\mathcal{S}$
+/// 3. for each $(\left(\vec{a\_i}, b\_i\right), \tilde{b\_i})$ in $(\vec{\left( \vec{a} ,
+/// b\right)}, \vec{\tilde{b}})$
+///     - uniformly sample $n$ integers in $\mathbb{Z}\_q$ from $G$ and store them in
+///       $\vec{a}\_i\in\mathbb{Z}^n\_q$
+///     - set $b\_i = \tilde{b\_i}$
+/// 4. output $\vec{\left( \vec{a} , b\right)}$
 pub trait LweSeededCiphertextVectorToLweCiphertextVectorTransformationEngine<
     InputCiphertextVector,
     OutputCiphertextVector,


### PR DESCRIPTION
### Resolves:

refs https://github.com/zama-ai/concrete-core-internal/issues/296

### Description

Some formal defs are missing for seeded entities, this is a PR to complete the definitions, this one is for the seeded LWE ciphertext vector.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
