### PR TITLE
Implement conversions between GlweCiphertextView64 and CudaGlweCiphertext64

### DIFF
--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/glwe_ciphertext_conversion.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/glwe_ciphertext_conversion.rs
@@ -3,7 +3,7 @@ use crate::backends::cuda::implementation::entities::{CudaGlweCiphertext32, Cuda
 use crate::backends::cuda::private::crypto::glwe::ciphertext::CudaGlweCiphertext;
 use crate::commons::crypto::glwe::GlweCiphertext;
 use crate::commons::math::tensor::{AsRefSlice, AsRefTensor};
-use crate::prelude::{GlweCiphertext32, GlweCiphertext64};
+use crate::prelude::{GlweCiphertext32, GlweCiphertext64, GlweCiphertextView64};
 use crate::specification::engines::{
     GlweCiphertextConversionEngine, GlweCiphertextConversionError,
 };
@@ -276,5 +276,83 @@ impl GlweCiphertextConversionEngine<CudaGlweCiphertext64, GlweCiphertext64> for 
             output,
             input.polynomial_size(),
         ))
+    }
+}
+
+/// # Description
+/// Convert a view of a GLWE ciphertext with 64 bits of precision from CPU to GPU 0.
+impl GlweCiphertextConversionEngine<GlweCiphertextView64<'_>, CudaGlweCiphertext64> for CudaEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{GlweCiphertextCount, GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// use std::task::Poll;
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(3);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = vec![3_u64 << 20; 3];
+    /// let noise = Variance(2_f64.powf(-50.));
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let h_key: GlweSecretKey64 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let h_plaintext_vector: PlaintextVector64 = default_engine.create_plaintext_vector(&input)?;
+    /// let mut h_ciphertext: GlweCiphertext64 =
+    ///     default_engine.encrypt_glwe_ciphertext(&h_key, &h_plaintext_vector, noise)?;
+    /// let h_raw_ciphertext: Vec<u64> =
+    ///     default_engine.consume_retrieve_glwe_ciphertext(h_ciphertext)?;
+    /// let mut h_view_ciphertext: GlweCiphertextView64 =
+    ///     default_engine.create_glwe_ciphertext(h_raw_ciphertext.as_slice(), polynomial_size)?;
+    ///
+    /// let mut cuda_engine = CudaEngine::new(())?;
+    /// let d_ciphertext: CudaGlweCiphertext64 =
+    ///     cuda_engine.convert_glwe_ciphertext(&h_view_ciphertext)?;
+    /// let h_output_ciphertext: GlweCiphertext64 =
+    ///     cuda_engine.convert_glwe_ciphertext(&d_ciphertext)?;
+    ///
+    /// // Extracts the internal container
+    /// let h_raw_output_ciphertext: Vec<u64> =
+    ///     default_engine.consume_retrieve_glwe_ciphertext(h_output_ciphertext)?;
+    ///
+    /// assert_eq!(d_ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(d_ciphertext.polynomial_size(), polynomial_size);
+    /// assert_eq!(h_raw_ciphertext, h_raw_output_ciphertext);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn convert_glwe_ciphertext(
+        &mut self,
+        input: &GlweCiphertextView64,
+    ) -> Result<CudaGlweCiphertext64, GlweCiphertextConversionError<CudaError>> {
+        let stream = &self.streams[0];
+        let data_per_gpu = input.glwe_dimension().to_glwe_size().0 * input.polynomial_size().0;
+        let size = data_per_gpu as u64 * std::mem::size_of::<u64>() as u64;
+        stream.check_device_memory(size)?;
+        Ok(unsafe { self.convert_glwe_ciphertext_unchecked(input) })
+    }
+
+    unsafe fn convert_glwe_ciphertext_unchecked(
+        &mut self,
+        input: &GlweCiphertextView64,
+    ) -> CudaGlweCiphertext64 {
+        // Copy the entire input vector over all GPUs
+        let data_per_gpu = input.glwe_dimension().to_glwe_size().0 * input.polynomial_size().0;
+        let stream = &self.streams[0];
+        let mut vec = stream.malloc::<u64>(data_per_gpu as u32);
+        let input_slice = input.0.as_tensor().as_slice();
+        stream.copy_to_gpu::<u64>(&mut vec, input_slice);
+        CudaGlweCiphertext64(CudaGlweCiphertext::<u64> {
+            d_vec: vec,
+            glwe_dimension: input.glwe_dimension(),
+            polynomial_size: input.polynomial_size(),
+        })
     }
 }

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/glwe_ciphertext_discarding_conversion.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/glwe_ciphertext_discarding_conversion.rs
@@ -1,0 +1,82 @@
+use crate::backends::cuda::engines::{CudaEngine, CudaError};
+use crate::backends::cuda::implementation::entities::CudaGlweCiphertext64;
+use crate::prelude::{GlweCiphertextDiscardingConversionError, GlweCiphertextMutView64};
+use crate::specification::engines::GlweCiphertextDiscardingConversionEngine;
+
+/// # Description
+/// Convert a GLWE ciphertext vector with 64 bits of precision from GPU 0 to a view on the CPU.
+impl GlweCiphertextDiscardingConversionEngine<CudaGlweCiphertext64, GlweCiphertextMutView64<'_>>
+    for CudaEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{GlweCiphertextCount, GlweDimension, PolynomialSize};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// use std::borrow::{Borrow, BorrowMut};
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// use concrete_commons::numeric::CastInto;
+    /// use std::task::Poll;
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(3);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = vec![3_u64 << 20; 3];
+    /// let noise = Variance(2_f64.powf(-50.));
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let h_key: GlweSecretKey64 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let h_plaintext_vector: PlaintextVector64 = default_engine.create_plaintext_vector(&input)?;
+    /// let mut h_ciphertext: GlweCiphertext64 =
+    ///     default_engine.encrypt_glwe_ciphertext(&h_key, &h_plaintext_vector, noise)?;
+    ///
+    /// let mut cuda_engine = CudaEngine::new(())?;
+    /// let d_ciphertext: CudaGlweCiphertext64 = cuda_engine.convert_glwe_ciphertext(&h_ciphertext)?;
+    ///
+    /// let mut h_raw_output_ciphertext =
+    ///     vec![0_u64; glwe_dimension.to_glwe_size().0 * polynomial_size.0];
+    /// let mut h_view_output_ciphertext: GlweCiphertextMutView64 = default_engine
+    ///     .create_glwe_ciphertext(h_raw_output_ciphertext.as_mut_slice(), polynomial_size)?;
+    ///
+    /// cuda_engine
+    ///     .discard_convert_glwe_ciphertext(h_view_output_ciphertext.borrow_mut(), &d_ciphertext)?;
+    ///
+    /// // Extracts the internal container
+    /// let h_raw_ciphertext: Vec<u64> =
+    ///     default_engine.consume_retrieve_glwe_ciphertext(h_ciphertext)?;
+    /// let h_raw_output_ciphertext: &[u64] =
+    ///     default_engine.consume_retrieve_glwe_ciphertext(h_view_output_ciphertext)?;
+    ///
+    /// assert_eq!(d_ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(d_ciphertext.polynomial_size(), polynomial_size);
+    ///
+    /// assert_eq!(h_raw_ciphertext, h_raw_output_ciphertext.to_vec());
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_convert_glwe_ciphertext(
+        &mut self,
+        output: &mut GlweCiphertextMutView64,
+        input: &CudaGlweCiphertext64,
+    ) -> Result<(), GlweCiphertextDiscardingConversionError<CudaError>> {
+        GlweCiphertextDiscardingConversionError::perform_generic_checks(output, input)?;
+        unsafe { self.discard_convert_glwe_ciphertext_unchecked(output, input) };
+        Ok(())
+    }
+
+    unsafe fn discard_convert_glwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut GlweCiphertextMutView64,
+        input: &CudaGlweCiphertext64,
+    ) {
+        // Copy the data from GPU 0 back to the CPU
+        let stream = &self.streams[0];
+        stream.copy_to_cpu::<u64>(output.0.tensor.as_mut_container(), &input.0.d_vec);
+    }
+}

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/mod.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/mod.rs
@@ -91,6 +91,7 @@ macro_rules! check_poly_size {
 }
 
 mod glwe_ciphertext_conversion;
+mod glwe_ciphertext_discarding_conversion;
 mod glwe_ciphertext_vector_conversion;
 mod lwe_bootstrap_key_conversion;
 mod lwe_ciphertext_conversion;


### PR DESCRIPTION
### Resolves: [Issue 320](https://github.com/zama-ai/concrete-core-internal/issues/320)

### Description
Implements: 

- Conversion from GlweCiphertextView64 to CudaGlweCiphertext64,
- Discarding conversion from CudaGlweCiphertext64 to GlweCiphertextMutView64

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
