### PR TITLE
chore(ci): add frozen toolchain installation for xtask in GPU workflows

### DIFF
--- a/.github/workflows/aws_tests_gpu.yml
+++ b/.github/workflows/aws_tests_gpu.yml
@@ -77,6 +77,9 @@ jobs:
         toolchain: nightly
         override: true
         components: rustfmt, clippy
+    - name: Install Rust for tasks
+      run: |
+        make install_tasks_rust_toolchain
     - name: Clippy on cuda backend
       if: ${{ !cancelled() }}
       run: |

--- a/.github/workflows/aws_tests_gpu_slab_beta.yml
+++ b/.github/workflows/aws_tests_gpu_slab_beta.yml
@@ -6,16 +6,16 @@ on:
   workflow_dispatch:
     inputs:
       instance_id:
-        description: 'AWS instance ID'
+        description: "AWS instance ID"
         type: string
       instance_image_id:
-        description: 'AWS instance AMI ID'
+        description: "AWS instance AMI ID"
         type: string
       instance_type:
-        description: 'AWS EC2 instance product type'
+        description: "AWS EC2 instance product type"
         type: string
       runner_name:
-        description: 'Action runner name'
+        description: "Action runner name"
         type: string
 
 env:
@@ -70,13 +70,16 @@ jobs:
           toolchain: nightly
           override: true
           components: rustfmt, clippy
+      - name: Install Rust for tasks
+        run: |
+          make install_tasks_rust_toolchain
       - name: Clippy on cuda backend
         run: |
           cargo xtask check_clippy_cuda
 
       - name: Test concrete-core with cuda backend
         run: |
-         cargo xtask test_cuda
+          cargo xtask test_cuda
 
       - name: Slack Notification
         if: ${{ always() }}


### PR DESCRIPTION
### Resolves:

### Description

Add the installation of the frozen toolchain required for xtask calls

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
