### PR TITLE
refactor(concrete_core): add automatic memory management to cuda backend

### DIFF
--- a/concrete-core-test/src/cuda.rs
+++ b/concrete-core-test/src/cuda.rs
@@ -41,6 +41,8 @@ test! {
     (LweCiphertextConversionFixture, (CudaLweCiphertext, LweCiphertext)),
     (LweCiphertextVectorDiscardingKeyswitchFixture, (CudaLweKeyswitchKey, CudaLweCiphertextVector,
         CudaLweCiphertextVector)),
+    (LweCiphertextDiscardingKeyswitchFixture, (CudaLweKeyswitchKey, CudaLweCiphertext,
+        CudaLweCiphertext)),
     (LweCiphertextDiscardingBootstrapFixture1, (CudaFourierLweBootstrapKey,
         CudaGlweCiphertext,
         CudaLweCiphertext, CudaLweCiphertext)),

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_amortized_engine/mod.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_amortized_engine/mod.rs
@@ -1,7 +1,7 @@
 use crate::backends::cuda::engines::CudaError;
 use crate::backends::cuda::private::device::{CudaStream, GpuIndex};
 use crate::prelude::sealed::AbstractEngineSeal;
-use crate::prelude::AbstractEngine;
+use crate::prelude::{AbstractEngine, SharedMemoryAmount};
 use concrete_cuda::cuda_bind::cuda_get_number_of_gpus;
 
 /// A variant of CudaEngine exposed by the cuda backend.
@@ -51,8 +51,8 @@ impl AmortizedCudaEngine {
         &self.streams
     }
     /// Get the size of the shared memory (on device 0)
-    pub fn get_cuda_shared_memory(&self) -> usize {
-        self.max_shared_memory
+    pub fn get_cuda_shared_memory(&self) -> SharedMemoryAmount {
+        SharedMemoryAmount(self.max_shared_memory)
     }
 }
 

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/destruction.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/destruction.rs
@@ -5,195 +5,136 @@ use crate::backends::cuda::implementation::entities::{
     CudaLweCiphertext32, CudaLweCiphertext64, CudaLweCiphertextVector32, CudaLweCiphertextVector64,
     CudaLweKeyswitchKey32, CudaLweKeyswitchKey64,
 };
-use crate::backends::cuda::private::device::GpuIndex;
 use crate::specification::engines::{DestructionEngine, DestructionError};
-
-macro_rules! drop_entity {
-    ($s:ident, $e:ident) => {
-        for gpu_index in 0..$s.get_number_of_gpus() {
-            $s.streams[gpu_index]
-                .drop($e.0.get_ptr(GpuIndex(gpu_index as u32)).0)
-                .unwrap();
-        }
-    };
-}
 
 impl DestructionEngine<CudaLweCiphertext32> for CudaEngine {
     fn destroy(
         &mut self,
-        mut entity: CudaLweCiphertext32,
+        _entity: CudaLweCiphertext32,
     ) -> Result<(), DestructionError<Self::EngineError>> {
-        unsafe { self.destroy_unchecked(&mut entity) };
         Ok(())
     }
 
-    unsafe fn destroy_unchecked(&mut self, entity: &mut CudaLweCiphertext32) {
-        // Here deallocate the Cuda memory
-        self.streams[0].drop(entity.0.get_ptr().0).unwrap();
-    }
+    unsafe fn destroy_unchecked(&mut self, _entity: &mut CudaLweCiphertext32) {}
 }
 
 impl DestructionEngine<CudaLweCiphertext64> for CudaEngine {
     fn destroy(
         &mut self,
-        mut entity: CudaLweCiphertext64,
+        _entity: CudaLweCiphertext64,
     ) -> Result<(), DestructionError<Self::EngineError>> {
-        unsafe { self.destroy_unchecked(&mut entity) };
         Ok(())
     }
 
-    unsafe fn destroy_unchecked(&mut self, entity: &mut CudaLweCiphertext64) {
-        // Here deallocate the Cuda memory
-        self.streams[0].drop(entity.0.get_ptr().0).unwrap();
-    }
+    unsafe fn destroy_unchecked(&mut self, _entity: &mut CudaLweCiphertext64) {}
 }
 
 impl DestructionEngine<CudaGlweCiphertext32> for CudaEngine {
     fn destroy(
         &mut self,
-        mut entity: CudaGlweCiphertext32,
+        _entity: CudaGlweCiphertext32,
     ) -> Result<(), DestructionError<Self::EngineError>> {
-        unsafe { self.destroy_unchecked(&mut entity) };
         Ok(())
     }
 
-    unsafe fn destroy_unchecked(&mut self, entity: &mut CudaGlweCiphertext32) {
-        // Here deallocate the Cuda memory
-        self.streams[0].drop(entity.0.get_ptr().0).unwrap();
-    }
+    unsafe fn destroy_unchecked(&mut self, _entity: &mut CudaGlweCiphertext32) {}
 }
 
 impl DestructionEngine<CudaGlweCiphertext64> for CudaEngine {
     fn destroy(
         &mut self,
-        mut entity: CudaGlweCiphertext64,
+        _entity: CudaGlweCiphertext64,
     ) -> Result<(), DestructionError<Self::EngineError>> {
-        unsafe { self.destroy_unchecked(&mut entity) };
         Ok(())
     }
 
-    unsafe fn destroy_unchecked(&mut self, entity: &mut CudaGlweCiphertext64) {
-        // Here deallocate the Cuda memory
-        self.streams[0].drop(entity.0.get_ptr().0).unwrap();
-    }
+    unsafe fn destroy_unchecked(&mut self, _entity: &mut CudaGlweCiphertext64) {}
 }
 
 impl DestructionEngine<CudaLweCiphertextVector32> for CudaEngine {
     fn destroy(
         &mut self,
-        mut entity: CudaLweCiphertextVector32,
+        _entity: CudaLweCiphertextVector32,
     ) -> Result<(), DestructionError<Self::EngineError>> {
-        unsafe { self.destroy_unchecked(&mut entity) };
         Ok(())
     }
 
-    unsafe fn destroy_unchecked(&mut self, entity: &mut CudaLweCiphertextVector32) {
-        // Here deallocate the Cuda memory
-        drop_entity!(self, entity);
-    }
+    unsafe fn destroy_unchecked(&mut self, _entity: &mut CudaLweCiphertextVector32) {}
 }
 
 impl DestructionEngine<CudaLweCiphertextVector64> for CudaEngine {
     fn destroy(
         &mut self,
-        mut entity: CudaLweCiphertextVector64,
+        _entity: CudaLweCiphertextVector64,
     ) -> Result<(), DestructionError<Self::EngineError>> {
-        unsafe { self.destroy_unchecked(&mut entity) };
         Ok(())
     }
 
-    unsafe fn destroy_unchecked(&mut self, entity: &mut CudaLweCiphertextVector64) {
-        // Here deallocate the Cuda memory
-        drop_entity!(self, entity);
-    }
+    unsafe fn destroy_unchecked(&mut self, _entity: &mut CudaLweCiphertextVector64) {}
 }
 
 impl DestructionEngine<CudaGlweCiphertextVector32> for CudaEngine {
     fn destroy(
         &mut self,
-        mut entity: CudaGlweCiphertextVector32,
+        _entity: CudaGlweCiphertextVector32,
     ) -> Result<(), DestructionError<Self::EngineError>> {
-        unsafe { self.destroy_unchecked(&mut entity) };
         Ok(())
     }
 
-    unsafe fn destroy_unchecked(&mut self, entity: &mut CudaGlweCiphertextVector32) {
-        // Here deallocate the Cuda memory
-        drop_entity!(self, entity);
-    }
+    unsafe fn destroy_unchecked(&mut self, _entity: &mut CudaGlweCiphertextVector32) {}
 }
 
 impl DestructionEngine<CudaGlweCiphertextVector64> for CudaEngine {
     fn destroy(
         &mut self,
-        mut entity: CudaGlweCiphertextVector64,
+        _entity: CudaGlweCiphertextVector64,
     ) -> Result<(), DestructionError<Self::EngineError>> {
-        unsafe { self.destroy_unchecked(&mut entity) };
         Ok(())
     }
 
-    unsafe fn destroy_unchecked(&mut self, entity: &mut CudaGlweCiphertextVector64) {
-        // Here deallocate the Cuda memory
-        drop_entity!(self, entity);
-    }
+    unsafe fn destroy_unchecked(&mut self, _entity: &mut CudaGlweCiphertextVector64) {}
 }
 
 impl DestructionEngine<CudaFourierLweBootstrapKey32> for CudaEngine {
     fn destroy(
         &mut self,
-        mut entity: CudaFourierLweBootstrapKey32,
+        _entity: CudaFourierLweBootstrapKey32,
     ) -> Result<(), DestructionError<Self::EngineError>> {
-        unsafe { self.destroy_unchecked(&mut entity) };
         Ok(())
     }
 
-    unsafe fn destroy_unchecked(&mut self, entity: &mut CudaFourierLweBootstrapKey32) {
-        // Here deallocate the Cuda memory
-        drop_entity!(self, entity);
-    }
+    unsafe fn destroy_unchecked(&mut self, _entity: &mut CudaFourierLweBootstrapKey32) {}
 }
 
 impl DestructionEngine<CudaFourierLweBootstrapKey64> for CudaEngine {
     fn destroy(
         &mut self,
-        mut entity: CudaFourierLweBootstrapKey64,
+        _entity: CudaFourierLweBootstrapKey64,
     ) -> Result<(), DestructionError<Self::EngineError>> {
-        unsafe { self.destroy_unchecked(&mut entity) };
         Ok(())
     }
 
-    unsafe fn destroy_unchecked(&mut self, entity: &mut CudaFourierLweBootstrapKey64) {
-        // Here deallocate the Cuda memory
-        drop_entity!(self, entity);
-    }
+    unsafe fn destroy_unchecked(&mut self, _entity: &mut CudaFourierLweBootstrapKey64) {}
 }
 
 impl DestructionEngine<CudaLweKeyswitchKey32> for CudaEngine {
     fn destroy(
         &mut self,
-        mut entity: CudaLweKeyswitchKey32,
+        _entity: CudaLweKeyswitchKey32,
     ) -> Result<(), DestructionError<Self::EngineError>> {
-        unsafe { self.destroy_unchecked(&mut entity) };
         Ok(())
     }
 
-    unsafe fn destroy_unchecked(&mut self, entity: &mut CudaLweKeyswitchKey32) {
-        // Here deallocate the Cuda memory
-        drop_entity!(self, entity);
-    }
+    unsafe fn destroy_unchecked(&mut self, _entity: &mut CudaLweKeyswitchKey32) {}
 }
 
 impl DestructionEngine<CudaLweKeyswitchKey64> for CudaEngine {
     fn destroy(
         &mut self,
-        mut entity: CudaLweKeyswitchKey64,
+        _entity: CudaLweKeyswitchKey64,
     ) -> Result<(), DestructionError<Self::EngineError>> {
-        unsafe { self.destroy_unchecked(&mut entity) };
         Ok(())
     }
 
-    unsafe fn destroy_unchecked(&mut self, entity: &mut CudaLweKeyswitchKey64) {
-        // Here deallocate the Cuda memory
-        drop_entity!(self, entity);
-    }
+    unsafe fn destroy_unchecked(&mut self, _entity: &mut CudaLweKeyswitchKey64) {}
 }

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_discarding_keyswitch.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_discarding_keyswitch.rs
@@ -3,11 +3,10 @@ use crate::backends::cuda::implementation::engines::CudaEngine;
 use crate::backends::cuda::implementation::entities::{
     CudaLweCiphertext32, CudaLweCiphertext64, CudaLweKeyswitchKey32, CudaLweKeyswitchKey64,
 };
-use crate::backends::cuda::private::device::GpuIndex;
+use crate::backends::cuda::private::device::NumberOfSamples;
 use crate::specification::engines::{
     LweCiphertextDiscardingKeyswitchEngine, LweCiphertextDiscardingKeyswitchError,
 };
-use crate::specification::entities::LweCiphertextEntity;
 
 impl From<CudaError> for LweCiphertextDiscardingKeyswitchError<CudaError> {
     fn from(err: CudaError) -> Self {
@@ -119,14 +118,14 @@ impl
         let stream = &self.streams[0];
 
         stream.discard_keyswitch_lwe_ciphertext_vector_32(
-            output.0.get_ptr().0,
-            input.0.get_ptr().0,
-            input.lwe_dimension().0 as u32,
-            output.lwe_dimension().0 as u32,
-            ksk.0.get_ptr(GpuIndex(0)).0,
-            ksk.0.decomposition_base_log().0 as u32,
-            ksk.0.decomposition_level_count().0 as u32,
-            1,
+            &mut output.0.d_vec,
+            &input.0.d_vec,
+            input.0.lwe_dimension,
+            output.0.lwe_dimension,
+            ksk.0.d_vecs.first().unwrap(),
+            ksk.0.decomposition_base_log(),
+            ksk.0.decomposition_level_count(),
+            NumberOfSamples(1),
         );
     }
 }
@@ -235,14 +234,14 @@ impl
         let stream = &self.streams[0];
 
         stream.discard_keyswitch_lwe_ciphertext_vector_64(
-            output.0.get_ptr().0,
-            input.0.get_ptr().0,
-            input.lwe_dimension().0 as u32,
-            output.lwe_dimension().0 as u32,
-            ksk.0.get_ptr(GpuIndex(0)).0,
-            ksk.0.decomposition_base_log().0 as u32,
-            ksk.0.decomposition_level_count().0 as u32,
-            1,
+            &mut output.0.d_vec,
+            &input.0.d_vec,
+            input.0.lwe_dimension,
+            output.0.lwe_dimension,
+            ksk.0.d_vecs.first().unwrap(),
+            ksk.0.decomposition_base_log(),
+            ksk.0.decomposition_level_count(),
+            NumberOfSamples(1),
         );
     }
 }

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_vector_conversion.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_vector_conversion.rs
@@ -3,8 +3,6 @@ use crate::backends::cuda::implementation::entities::{
     CudaLweCiphertextVector32, CudaLweCiphertextVector64,
 };
 use crate::backends::cuda::private::crypto::lwe::list::CudaLweList;
-use crate::backends::cuda::private::device::GpuIndex;
-use crate::backends::cuda::private::pointers::CudaLweCiphertextVectorPointer;
 use crate::commons::crypto::lwe::LweList;
 use crate::commons::math::tensor::{AsRefSlice, AsRefTensor};
 use crate::prelude::{LweCiphertextVector32, LweCiphertextVector64};
@@ -72,8 +70,7 @@ impl LweCiphertextVectorConversionEngine<LweCiphertextVector32, CudaLweCiphertex
         input: &LweCiphertextVector32,
     ) -> Result<CudaLweCiphertextVector32, LweCiphertextVectorConversionError<CudaError>> {
         let samples_per_gpu = input.lwe_ciphertext_count().0 / self.get_number_of_gpus() as usize;
-        for gpu_index in 0..self.get_number_of_gpus() {
-            let stream = &self.streams[gpu_index];
+        for (gpu_index, stream) in self.streams.iter().enumerate() {
             let samples = self.compute_number_of_samples_lwe_ciphertext_vector(
                 samples_per_gpu,
                 input.lwe_ciphertext_count().0,
@@ -94,28 +91,27 @@ impl LweCiphertextVectorConversionEngine<LweCiphertextVector32, CudaLweCiphertex
         let samples_per_gpu = input.lwe_ciphertext_count().0 / self.get_number_of_gpus() as usize;
         let data_per_gpu = samples_per_gpu * input.lwe_dimension().to_lwe_size().0;
         let input_slice = input.0.as_tensor().as_slice();
-        let mut d_ptr_vec = Vec::with_capacity(self.get_number_of_gpus() as usize);
+        let mut vecs = Vec::with_capacity(self.get_number_of_gpus() as usize);
         for (gpu_index, chunk) in input_slice.chunks_exact(data_per_gpu).enumerate() {
             let stream = &self.streams[gpu_index];
             let mut alloc_size = data_per_gpu as u32;
             if gpu_index == self.get_number_of_gpus() - 1 {
                 alloc_size += input_slice.chunks_exact(data_per_gpu).remainder().len() as u32;
-                let d_ptr = stream.malloc::<u32>(alloc_size);
-                d_ptr_vec.push(CudaLweCiphertextVectorPointer(d_ptr));
+                let mut d_vec = stream.malloc::<u32>(alloc_size);
                 let chunk_and_remainder =
                     [chunk, input_slice.chunks_exact(data_per_gpu).remainder()].concat();
-                stream.copy_to_gpu::<u32>(d_ptr, chunk_and_remainder.as_slice());
+                stream.copy_to_gpu::<u32>(&mut d_vec, chunk_and_remainder.as_slice());
+                vecs.push(d_vec);
             } else {
-                let d_ptr = stream.malloc::<u32>(alloc_size);
-                d_ptr_vec.push(CudaLweCiphertextVectorPointer(d_ptr));
-                stream.copy_to_gpu::<u32>(d_ptr, chunk);
+                let mut d_vec = stream.malloc::<u32>(alloc_size);
+                stream.copy_to_gpu::<u32>(&mut d_vec, chunk);
+                vecs.push(d_vec);
             }
         }
         CudaLweCiphertextVector32(CudaLweList::<u32> {
-            d_ptr_vec,
+            d_vecs: vecs,
             lwe_ciphertext_count: input.lwe_ciphertext_count(),
             lwe_dimension: input.lwe_dimension(),
-            _phantom: Default::default(),
         })
     }
 }
@@ -188,17 +184,11 @@ impl LweCiphertextVectorConversionEngine<CudaLweCiphertextVector32, LweCiphertex
             vec![0u32; input.lwe_dimension().to_lwe_size().0 * input.lwe_ciphertext_count().0];
         for (gpu_index, chunks) in output.chunks_exact_mut(data_per_gpu).enumerate() {
             let stream = &self.streams[gpu_index];
-            stream.copy_to_cpu::<u32>(chunks, input.0.get_ptr(GpuIndex(gpu_index as u32)).0);
+            stream.copy_to_cpu::<u32>(chunks, input.0.d_vecs.get(gpu_index).unwrap());
         }
         let last_chunk = output.chunks_exact_mut(data_per_gpu).into_remainder();
-        let stream = &self.streams[self.get_number_of_gpus() - 1];
-        stream.copy_to_cpu::<u32>(
-            last_chunk,
-            input
-                .0
-                .get_ptr(GpuIndex(self.get_number_of_gpus() as u32 - 1))
-                .0,
-        );
+        let last_stream = &self.streams.last().unwrap();
+        last_stream.copy_to_cpu::<u32>(last_chunk, input.0.d_vecs.last().unwrap());
 
         LweCiphertextVector32(LweList::from_container(
             output,
@@ -282,28 +272,27 @@ impl LweCiphertextVectorConversionEngine<LweCiphertextVector64, CudaLweCiphertex
         let samples_per_gpu = input.lwe_ciphertext_count().0 / self.get_number_of_gpus() as usize;
         let data_per_gpu = samples_per_gpu * input.lwe_dimension().to_lwe_size().0;
         let input_slice = input.0.as_tensor().as_slice();
-        let mut d_ptr_vec = Vec::with_capacity(self.get_number_of_gpus() as usize);
+        let mut vecs = Vec::with_capacity(self.get_number_of_gpus() as usize);
         for (gpu_index, chunk) in input_slice.chunks_exact(data_per_gpu).enumerate() {
             let stream = &self.streams[gpu_index];
             let mut alloc_size = data_per_gpu as u32;
             if gpu_index == self.get_number_of_gpus() - 1 {
                 alloc_size += input_slice.chunks_exact(data_per_gpu).remainder().len() as u32;
-                let d_ptr = stream.malloc::<u64>(alloc_size);
-                d_ptr_vec.push(CudaLweCiphertextVectorPointer(d_ptr));
+                let mut d_vec = stream.malloc::<u64>(alloc_size);
                 let chunk_and_remainder =
                     [chunk, input_slice.chunks_exact(data_per_gpu).remainder()].concat();
-                stream.copy_to_gpu::<u64>(d_ptr, chunk_and_remainder.as_slice());
+                stream.copy_to_gpu::<u64>(&mut d_vec, chunk_and_remainder.as_slice());
+                vecs.push(d_vec);
             } else {
-                let d_ptr = stream.malloc::<u64>(alloc_size);
-                d_ptr_vec.push(CudaLweCiphertextVectorPointer(d_ptr));
-                stream.copy_to_gpu::<u64>(d_ptr, chunk);
+                let mut d_vec = stream.malloc::<u64>(alloc_size);
+                stream.copy_to_gpu::<u64>(&mut d_vec, chunk);
+                vecs.push(d_vec);
             }
         }
         CudaLweCiphertextVector64(CudaLweList::<u64> {
-            d_ptr_vec,
+            d_vecs: vecs,
             lwe_ciphertext_count: input.lwe_ciphertext_count(),
             lwe_dimension: input.lwe_dimension(),
-            _phantom: Default::default(),
         })
     }
 }
@@ -376,17 +365,11 @@ impl LweCiphertextVectorConversionEngine<CudaLweCiphertextVector64, LweCiphertex
             vec![0u64; input.lwe_dimension().to_lwe_size().0 * input.lwe_ciphertext_count().0];
         for (gpu_index, chunks) in output.chunks_exact_mut(data_per_gpu).enumerate() {
             let stream = &self.streams[gpu_index];
-            stream.copy_to_cpu::<u64>(chunks, input.0.get_ptr(GpuIndex(gpu_index as u32)).0);
+            stream.copy_to_cpu::<u64>(chunks, input.0.d_vecs.get(gpu_index).unwrap());
         }
         let last_chunk = output.chunks_exact_mut(data_per_gpu).into_remainder();
         let stream = &self.streams[self.get_number_of_gpus() - 1];
-        stream.copy_to_cpu::<u64>(
-            last_chunk,
-            input
-                .0
-                .get_ptr(GpuIndex(self.get_number_of_gpus() as u32 - 1))
-                .0,
-        );
+        stream.copy_to_cpu::<u64>(last_chunk, input.0.d_vecs.last().unwrap());
 
         LweCiphertextVector64(LweList::from_container(
             output,

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_vector_discarding_bootstrap.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_vector_discarding_bootstrap.rs
@@ -4,11 +4,12 @@ use crate::backends::cuda::implementation::entities::{
     CudaFourierLweBootstrapKey32, CudaFourierLweBootstrapKey64, CudaGlweCiphertextVector32,
     CudaGlweCiphertextVector64, CudaLweCiphertextVector32, CudaLweCiphertextVector64,
 };
-use crate::backends::cuda::private::device::GpuIndex;
+use crate::backends::cuda::private::device::NumberOfSamples;
 use crate::specification::engines::{
     LweCiphertextVectorDiscardingBootstrapEngine, LweCiphertextVectorDiscardingBootstrapError,
 };
 use crate::specification::entities::{LweBootstrapKeyEntity, LweCiphertextVectorEntity};
+use concrete_commons::parameters::LweCiphertextIndex;
 
 /// # Description
 /// A discard bootstrap on a vector of input ciphertext vectors with 32 bits of precision.
@@ -145,39 +146,34 @@ impl
         let samples_per_gpu = input.0.lwe_ciphertext_count().0 / self.get_number_of_gpus();
 
         for gpu_index in 0..self.get_number_of_gpus() {
-            let mut samples: u32 = samples_per_gpu as u32;
+            let mut samples = samples_per_gpu;
             if gpu_index == self.get_number_of_gpus() - 1
                 && input.lwe_ciphertext_count().0 % self.get_number_of_gpus() as usize != 0
             {
-                samples += (input.lwe_ciphertext_count().0
-                    - samples_per_gpu * self.get_number_of_gpus())
-                    as u32;
+                samples +=
+                    input.lwe_ciphertext_count().0 - samples_per_gpu * self.get_number_of_gpus();
             }
             let stream = &self.streams[gpu_index];
             // FIXME this is hard set at the moment because concrete-default does not support a more
             //   general API for the bootstrap
-            let mut test_vector_indexes = Vec::with_capacity(samples as usize);
-            for i in 0..samples {
-                test_vector_indexes.push(i);
-            }
-            let d_test_vector_indexes = stream.malloc::<u32>(samples);
-            stream.copy_to_gpu(d_test_vector_indexes, &test_vector_indexes);
+            let test_vector_indexes = (0..samples as u32).collect::<Vec<u32>>();
+            let mut d_test_vector_indexes = stream.malloc::<u32>(samples as u32);
+            stream.copy_to_gpu(&mut d_test_vector_indexes, &test_vector_indexes);
 
             stream.discard_bootstrap_low_latency_lwe_ciphertext_vector_32(
-                output.0.get_ptr(GpuIndex(gpu_index as u32)).0,
-                acc.0.get_ptr(GpuIndex(gpu_index as u32)).0,
-                d_test_vector_indexes,
-                input.0.get_ptr(GpuIndex(gpu_index as u32)).0,
-                bsk.0.get_ptr(GpuIndex(gpu_index as u32)).0,
-                input.lwe_dimension().0 as u32,
-                bsk.polynomial_size().0 as u32,
-                bsk.decomposition_base_log().0 as u32,
-                bsk.decomposition_level_count().0 as u32,
-                samples as u32,
-                (samples_per_gpu * gpu_index) as u32,
-                self.get_cuda_shared_memory() as u32,
+                output.0.d_vecs.get_mut(gpu_index).unwrap(),
+                acc.0.d_vecs.get(gpu_index).unwrap(),
+                &d_test_vector_indexes,
+                input.0.d_vecs.get(gpu_index).unwrap(),
+                bsk.0.d_vecs.get(gpu_index).unwrap(),
+                input.0.lwe_dimension,
+                bsk.0.polynomial_size,
+                bsk.decomposition_base_log(),
+                bsk.decomposition_level_count(),
+                NumberOfSamples(samples),
+                LweCiphertextIndex(samples_per_gpu * gpu_index),
+                self.get_cuda_shared_memory(),
             );
-            stream.drop(d_test_vector_indexes).unwrap();
         }
     }
 }
@@ -317,39 +313,34 @@ impl
         let samples_per_gpu = input.0.lwe_ciphertext_count().0 / self.get_number_of_gpus();
 
         for gpu_index in 0..self.get_number_of_gpus() {
-            let mut samples: u32 = samples_per_gpu as u32;
+            let mut samples = samples_per_gpu;
             if gpu_index == self.get_number_of_gpus() - 1
                 && input.lwe_ciphertext_count().0 % self.get_number_of_gpus() as usize != 0
             {
-                samples += (input.lwe_ciphertext_count().0
-                    - samples_per_gpu * self.get_number_of_gpus())
-                    as u32;
+                samples +=
+                    input.lwe_ciphertext_count().0 - samples_per_gpu * self.get_number_of_gpus();
             }
             let stream = &self.streams[gpu_index];
             // FIXME this is hard set at the moment because concrete-default does not support a more
             //   general API for the bootstrap
-            let mut test_vector_indexes = Vec::with_capacity(samples as usize);
-            for i in 0..samples {
-                test_vector_indexes.push(i);
-            }
-            let d_test_vector_indexes = stream.malloc::<u32>(samples);
-            stream.copy_to_gpu(d_test_vector_indexes, &test_vector_indexes);
+            let test_vector_indexes = (0..samples as u32).collect::<Vec<u32>>();
+            let mut d_test_vector_indexes = stream.malloc::<u32>(samples as u32);
+            stream.copy_to_gpu(&mut d_test_vector_indexes, test_vector_indexes.as_slice());
 
             stream.discard_bootstrap_low_latency_lwe_ciphertext_vector_64(
-                output.0.get_ptr(GpuIndex(gpu_index as u32)).0,
-                acc.0.get_ptr(GpuIndex(gpu_index as u32)).0,
-                d_test_vector_indexes,
-                input.0.get_ptr(GpuIndex(gpu_index as u32)).0,
-                bsk.0.get_ptr(GpuIndex(gpu_index as u32)).0,
-                input.lwe_dimension().0 as u32,
-                bsk.polynomial_size().0 as u32,
-                bsk.decomposition_base_log().0 as u32,
-                bsk.decomposition_level_count().0 as u32,
-                samples as u32,
-                (samples_per_gpu * gpu_index) as u32,
-                self.get_cuda_shared_memory() as u32,
+                output.0.d_vecs.get_mut(gpu_index).unwrap(),
+                acc.0.d_vecs.get(gpu_index).unwrap(),
+                &d_test_vector_indexes,
+                input.0.d_vecs.get(gpu_index).unwrap(),
+                bsk.0.d_vecs.get(gpu_index).unwrap(),
+                input.0.lwe_dimension,
+                bsk.0.polynomial_size,
+                bsk.decomposition_base_log(),
+                bsk.decomposition_level_count(),
+                NumberOfSamples(samples),
+                LweCiphertextIndex(samples_per_gpu * gpu_index),
+                self.get_cuda_shared_memory(),
             );
-            stream.drop(d_test_vector_indexes).unwrap();
         }
     }
 }

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/mod.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/mod.rs
@@ -1,7 +1,7 @@
 use crate::backends::cuda::engines::CudaError;
 use crate::backends::cuda::private::device::{CudaStream, GpuIndex};
 use crate::prelude::sealed::AbstractEngineSeal;
-use crate::prelude::AbstractEngine;
+use crate::prelude::{AbstractEngine, SharedMemoryAmount};
 use concrete_cuda::cuda_bind::cuda_get_number_of_gpus;
 
 /// The main engine exposed by the cuda backend.
@@ -57,8 +57,8 @@ impl CudaEngine {
         &self.streams
     }
     /// Get the size of the shared memory (on device 0)
-    pub fn get_cuda_shared_memory(&self) -> usize {
-        self.max_shared_memory
+    pub fn get_cuda_shared_memory(&self) -> SharedMemoryAmount {
+        SharedMemoryAmount(self.max_shared_memory)
     }
 
     fn compute_number_of_samples_lwe_ciphertext_vector(

--- a/concrete-core/src/backends/cuda/implementation/engines/mod.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/mod.rs
@@ -12,6 +12,9 @@ pub use cuda_engine::*;
 mod cuda_amortized_engine;
 pub use cuda_amortized_engine::*;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SharedMemoryAmount(pub usize);
+
 #[derive(Debug)]
 pub enum CudaError {
     DeviceNotFound,

--- a/concrete-core/src/backends/cuda/implementation/entities/glwe_ciphertext.rs
+++ b/concrete-core/src/backends/cuda/implementation/entities/glwe_ciphertext.rs
@@ -8,7 +8,7 @@ use crate::specification::entities::{AbstractEntity, GlweCiphertextEntity};
 
 /// A structure representing a vector of GLWE ciphertexts with 32 bits of precision on the GPU.
 /// It is used as input to the Cuda bootstrap for the array of lookup tables.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct CudaGlweCiphertext32(pub(crate) CudaGlweCiphertext<u32>);
 
 impl AbstractEntity for CudaGlweCiphertext32 {
@@ -29,7 +29,7 @@ impl GlweCiphertextEntity for CudaGlweCiphertext32 {
 
 /// A structure representing a vector of GLWE ciphertexts with 64 bits of precision on the GPU.
 /// It is used as input to the Cuda bootstrap for the array of lookup tables.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct CudaGlweCiphertext64(pub(crate) CudaGlweCiphertext<u64>);
 
 impl AbstractEntity for CudaGlweCiphertext64 {

--- a/concrete-core/src/backends/cuda/implementation/entities/glwe_ciphertext_vector.rs
+++ b/concrete-core/src/backends/cuda/implementation/entities/glwe_ciphertext_vector.rs
@@ -8,7 +8,7 @@ use crate::specification::entities::{AbstractEntity, GlweCiphertextVectorEntity}
 
 /// A structure representing a vector of GLWE ciphertexts with 32 bits of precision on the GPU.
 /// It is used as input to the Cuda bootstrap for the array of lookup tables.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct CudaGlweCiphertextVector32(pub(crate) CudaGlweList<u32>);
 
 impl AbstractEntity for CudaGlweCiphertextVector32 {
@@ -33,7 +33,7 @@ impl GlweCiphertextVectorEntity for CudaGlweCiphertextVector32 {
 
 /// A structure representing a vector of GLWE ciphertexts with 64 bits of precision on the GPU.
 /// It is used as input to the Cuda bootstrap for the array of lookup tables.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct CudaGlweCiphertextVector64(pub(crate) CudaGlweList<u64>);
 
 impl AbstractEntity for CudaGlweCiphertextVector64 {

--- a/concrete-core/src/backends/cuda/implementation/entities/lwe_bootstrap_key.rs
+++ b/concrete-core/src/backends/cuda/implementation/entities/lwe_bootstrap_key.rs
@@ -7,7 +7,7 @@ use crate::specification::entities::markers::{BinaryKeyDistribution, LweBootstra
 use crate::specification::entities::{AbstractEntity, LweBootstrapKeyEntity};
 
 /// A structure representing a Fourier bootstrap key for 32 bits precision ciphertexts on the GPU.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct CudaFourierLweBootstrapKey32(pub(crate) CudaBootstrapKey<u32>);
 
 impl AbstractEntity for CudaFourierLweBootstrapKey32 {
@@ -40,7 +40,7 @@ impl LweBootstrapKeyEntity for CudaFourierLweBootstrapKey32 {
 }
 
 /// A structure representing a Fourier bootstrap key for 64 bits precision ciphertexts on the GPU.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct CudaFourierLweBootstrapKey64(pub(crate) CudaBootstrapKey<u64>);
 
 impl AbstractEntity for CudaFourierLweBootstrapKey64 {

--- a/concrete-core/src/backends/cuda/implementation/entities/lwe_ciphertext.rs
+++ b/concrete-core/src/backends/cuda/implementation/entities/lwe_ciphertext.rs
@@ -7,7 +7,7 @@ use crate::specification::entities::markers::{BinaryKeyDistribution, LweCipherte
 use crate::specification::entities::{AbstractEntity, LweCiphertextEntity};
 
 /// A structure representing a vector of LWE ciphertexts with 32 bits of precision on the GPU.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct CudaLweCiphertext32(pub(crate) CudaLweCiphertext<u32>);
 
 impl AbstractEntity for CudaLweCiphertext32 {
@@ -23,7 +23,7 @@ impl LweCiphertextEntity for CudaLweCiphertext32 {
 }
 
 /// A structure representing a vector of LWE ciphertexts with 64 bits of precision on the GPU.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct CudaLweCiphertext64(pub(crate) CudaLweCiphertext<u64>);
 
 impl AbstractEntity for CudaLweCiphertext64 {

--- a/concrete-core/src/backends/cuda/implementation/entities/lwe_ciphertext_vector.rs
+++ b/concrete-core/src/backends/cuda/implementation/entities/lwe_ciphertext_vector.rs
@@ -7,7 +7,7 @@ use crate::specification::entities::markers::{BinaryKeyDistribution, LweCipherte
 use crate::specification::entities::{AbstractEntity, LweCiphertextVectorEntity};
 
 /// A structure representing a vector of LWE ciphertexts with 32 bits of precision on the GPU.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct CudaLweCiphertextVector32(pub(crate) CudaLweList<u32>);
 
 impl AbstractEntity for CudaLweCiphertextVector32 {
@@ -27,7 +27,7 @@ impl LweCiphertextVectorEntity for CudaLweCiphertextVector32 {
 }
 
 /// A structure representing a vector of LWE ciphertexts with 64 bits of precision on the GPU.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct CudaLweCiphertextVector64(pub(crate) CudaLweList<u64>);
 
 impl AbstractEntity for CudaLweCiphertextVector64 {

--- a/concrete-core/src/backends/cuda/implementation/entities/lwe_keyswitch_key.rs
+++ b/concrete-core/src/backends/cuda/implementation/entities/lwe_keyswitch_key.rs
@@ -5,7 +5,7 @@ use crate::specification::entities::markers::{BinaryKeyDistribution, LweKeyswitc
 use crate::specification::entities::{AbstractEntity, LweKeyswitchKeyEntity};
 
 /// A structure representing a keyswitch key for 32 bits precision ciphertexts on the GPU.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct CudaLweKeyswitchKey32(pub(crate) CudaLweKeyswitchKey<u32>);
 
 impl AbstractEntity for CudaLweKeyswitchKey32 {
@@ -34,7 +34,7 @@ impl LweKeyswitchKeyEntity for CudaLweKeyswitchKey32 {
 }
 
 /// A structure representing a  keyswitch key for 64 bits precision ciphertexts on the GPU.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct CudaLweKeyswitchKey64(pub(crate) CudaLweKeyswitchKey<u64>);
 
 impl AbstractEntity for CudaLweKeyswitchKey64 {

--- a/concrete-core/src/backends/cuda/private/crypto/bootstrap/mod.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/bootstrap/mod.rs
@@ -1,16 +1,15 @@
 //! Bootstrap key with Cuda.
-use crate::backends::cuda::private::device::GpuIndex;
-use crate::backends::cuda::private::pointers::CudaBootstrapKeyPointer;
+use crate::backends::cuda::private::vec::CudaVec;
 use concrete_commons::numeric::UnsignedInteger;
 use concrete_commons::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
 };
 use std::marker::PhantomData;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct CudaBootstrapKey<T: UnsignedInteger> {
-    // Pointers to GPU data: one pointer per GPU
-    pub(crate) d_ptr_vec: Vec<CudaBootstrapKeyPointer>,
+#[derive(Debug)]
+pub(crate) struct CudaBootstrapKey<T> {
+    // Pointers to GPU data: one cuda vec per GPU
+    pub(crate) d_vecs: Vec<CudaVec<f64>>,
     // Input LWE dimension
     pub(crate) input_lwe_dimension: LweDimension,
     // Size of polynomials in the key
@@ -49,10 +48,5 @@ impl<T: UnsignedInteger> CudaBootstrapKey<T> {
     #[allow(dead_code)]
     pub(crate) fn decomposition_base_log(&self) -> DecompositionBaseLog {
         self.decomp_base_log
-    }
-
-    #[allow(dead_code)]
-    pub(crate) unsafe fn get_ptr(&self, gpu_index: GpuIndex) -> CudaBootstrapKeyPointer {
-        self.d_ptr_vec[gpu_index.0 as usize]
     }
 }

--- a/concrete-core/src/backends/cuda/private/crypto/glwe/ciphertext.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/glwe/ciphertext.rs
@@ -1,25 +1,20 @@
-use std::marker::PhantomData;
-
+use crate::backends::cuda::private::vec::CudaVec;
 use concrete_commons::numeric::UnsignedInteger;
 use concrete_commons::parameters::{GlweDimension, PolynomialSize};
-
-use crate::backends::cuda::private::pointers::CudaGlweCiphertextPointer;
 
 /// One GLWE ciphertext on GPU 0.
 ///
 /// There is no multi GPU support at this stage since the user cannot
 /// specify on which GPU to convert the data.
 // Fields with `d_` are data in the GPU
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) struct CudaGlweCiphertext<T: UnsignedInteger> {
-    // Pointer to GPU data: one pointer on GPU 0
-    pub(crate) d_ptr: CudaGlweCiphertextPointer,
+    // Pointer to GPU data: one cuda vec on GPU 0
+    pub(crate) d_vec: CudaVec<T>,
     // Glwe dimension
     pub(crate) glwe_dimension: GlweDimension,
     // Polynomial size
     pub(crate) polynomial_size: PolynomialSize,
-    // Field to hold type T
-    pub(crate) _phantom: PhantomData<T>,
 }
 
 impl<T: UnsignedInteger> CudaGlweCiphertext<T> {
@@ -29,11 +24,5 @@ impl<T: UnsignedInteger> CudaGlweCiphertext<T> {
 
     pub(crate) fn polynomial_size(&self) -> PolynomialSize {
         self.polynomial_size
-    }
-
-    /// Returns a pointer to the data on a chosen GPU
-    #[allow(dead_code)]
-    pub(crate) unsafe fn get_ptr(&self) -> CudaGlweCiphertextPointer {
-        self.d_ptr
     }
 }

--- a/concrete-core/src/backends/cuda/private/crypto/glwe/list.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/glwe/list.rs
@@ -1,10 +1,6 @@
-use std::marker::PhantomData;
-
+use crate::backends::cuda::private::vec::CudaVec;
 use concrete_commons::numeric::UnsignedInteger;
 use concrete_commons::parameters::{GlweCiphertextCount, GlweDimension, PolynomialSize};
-
-use crate::backends::cuda::private::device::GpuIndex;
-use crate::backends::cuda::private::pointers::CudaGlweCiphertextVectorPointer;
 
 /// An array of GLWE ciphertexts in the GPU.
 ///
@@ -15,18 +11,16 @@ use crate::backends::cuda::private::pointers::CudaGlweCiphertextVectorPointer;
 /// for end users to actually handle GPUs, streams and partitioning on their
 /// own.
 // Fields with `d_` are data in the GPU
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) struct CudaGlweList<T: UnsignedInteger> {
-    // Pointers to GPU data: one pointer per GPU
-    pub(crate) d_ptr_vec: Vec<CudaGlweCiphertextVectorPointer>,
+    // Pointers to GPU data: one cuda vec per GPU
+    pub(crate) d_vecs: Vec<CudaVec<T>>,
     // Number of ciphertexts in the array
     pub(crate) glwe_ciphertext_count: GlweCiphertextCount,
     // Glwe dimension
     pub(crate) glwe_dimension: GlweDimension,
     // Polynomial size
     pub(crate) polynomial_size: PolynomialSize,
-    // Field to hold type T
-    pub(crate) _phantom: PhantomData<T>,
 }
 
 impl<T: UnsignedInteger> CudaGlweList<T> {
@@ -40,11 +34,5 @@ impl<T: UnsignedInteger> CudaGlweList<T> {
 
     pub(crate) fn polynomial_size(&self) -> PolynomialSize {
         self.polynomial_size
-    }
-
-    /// Returns a pointer to the data on a chosen GPU
-    #[allow(dead_code)]
-    pub(crate) unsafe fn get_ptr(&self, gpu_index: GpuIndex) -> CudaGlweCiphertextVectorPointer {
-        self.d_ptr_vec[gpu_index.0 as usize]
     }
 }

--- a/concrete-core/src/backends/cuda/private/crypto/keyswitch/mod.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/keyswitch/mod.rs
@@ -1,14 +1,12 @@
 //! Keyswitch key with Cuda.
-use crate::backends::cuda::private::device::GpuIndex;
-use crate::backends::cuda::private::pointers::CudaLweKeyswitchKeyPointer;
+use crate::backends::cuda::private::vec::CudaVec;
 use concrete_commons::numeric::UnsignedInteger;
 use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount, LweDimension};
-use std::marker::PhantomData;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) struct CudaLweKeyswitchKey<T: UnsignedInteger> {
-    // Pointers to GPU data: one pointer per GPU
-    pub(crate) d_ptr_vec: Vec<CudaLweKeyswitchKeyPointer>,
+    // Pointers to GPU data: one cuda vec per GPU
+    pub(crate) d_vecs: Vec<CudaVec<T>>,
     // Input LWE dimension
     pub(crate) input_lwe_dimension: LweDimension,
     // Output LWE dimension
@@ -17,8 +15,6 @@ pub(crate) struct CudaLweKeyswitchKey<T: UnsignedInteger> {
     pub(crate) decomp_level: DecompositionLevelCount,
     // Value of the base log for the decomposition
     pub(crate) decomp_base_log: DecompositionBaseLog,
-    // Field to hold type T
-    pub(crate) _phantom: PhantomData<T>,
 }
 
 impl<T: UnsignedInteger> CudaLweKeyswitchKey<T> {
@@ -40,10 +36,5 @@ impl<T: UnsignedInteger> CudaLweKeyswitchKey<T> {
     #[allow(dead_code)]
     pub(crate) fn decomposition_base_log(&self) -> DecompositionBaseLog {
         self.decomp_base_log
-    }
-
-    #[allow(dead_code)]
-    pub(crate) unsafe fn get_ptr(&self, gpu_index: GpuIndex) -> CudaLweKeyswitchKeyPointer {
-        self.d_ptr_vec[gpu_index.0 as usize]
     }
 }

--- a/concrete-core/src/backends/cuda/private/crypto/lwe/ciphertext.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/lwe/ciphertext.rs
@@ -1,9 +1,6 @@
-use std::marker::PhantomData;
-
+use crate::backends::cuda::private::vec::CudaVec;
 use concrete_commons::numeric::UnsignedInteger;
 use concrete_commons::parameters::LweDimension;
-
-use crate::backends::cuda::private::pointers::CudaLweCiphertextPointer;
 
 /// An LWE ciphertext on the GPU 0.
 ///
@@ -11,24 +8,16 @@ use crate::backends::cuda::private::pointers::CudaLweCiphertextPointer;
 /// specify on which GPU to convert the data.
 
 // Fields with `d_` are data in the GPU
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) struct CudaLweCiphertext<T: UnsignedInteger> {
-    // Pointers to GPU data: one pointer per GPU
-    pub(crate) d_ptr: CudaLweCiphertextPointer,
+    // Pointers to GPU data: one cuda vec on GPU 0
+    pub(crate) d_vec: CudaVec<T>,
     // Lwe dimension
     pub(crate) lwe_dimension: LweDimension,
-    // Field to hold type T
-    pub(crate) _phantom: PhantomData<T>,
 }
 
 impl<T: UnsignedInteger> CudaLweCiphertext<T> {
     pub(crate) fn lwe_dimension(&self) -> LweDimension {
         self.lwe_dimension
-    }
-
-    /// Returns a mut pointer to the GPU data on GPU 0
-    #[allow(dead_code)]
-    pub(crate) unsafe fn get_ptr(&self) -> CudaLweCiphertextPointer {
-        self.d_ptr
     }
 }

--- a/concrete-core/src/backends/cuda/private/crypto/lwe/list.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/lwe/list.rs
@@ -1,10 +1,6 @@
-use std::marker::PhantomData;
-
-use crate::backends::cuda::private::device::GpuIndex;
+use crate::backends::cuda::private::vec::CudaVec;
 use concrete_commons::numeric::UnsignedInteger;
 use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
-
-use crate::backends::cuda::private::pointers::CudaLweCiphertextVectorPointer;
 
 /// An array of LWE ciphertexts in the GPU.
 ///
@@ -22,17 +18,14 @@ use crate::backends::cuda::private::pointers::CudaLweCiphertextVectorPointer;
 ///   last GPU the same amount of ciphertexts as the others + the ciphertexts
 ///   that don't fit in case the remainder is not zero.
 
-// Fields with `d_` are data in the GPU
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) struct CudaLweList<T: UnsignedInteger> {
-    // Pointers to GPU data: one pointer per GPU
-    pub(crate) d_ptr_vec: Vec<CudaLweCiphertextVectorPointer>,
+    // Pointers to GPU data: one cuda vec per GPU
+    pub(crate) d_vecs: Vec<CudaVec<T>>,
     // Number of ciphertexts in the array
     pub(crate) lwe_ciphertext_count: LweCiphertextCount,
     // Lwe dimension
     pub(crate) lwe_dimension: LweDimension,
-    // Field to hold type T
-    pub(crate) _phantom: PhantomData<T>,
 }
 
 impl<T: UnsignedInteger> CudaLweList<T> {
@@ -42,11 +35,5 @@ impl<T: UnsignedInteger> CudaLweList<T> {
 
     pub(crate) fn lwe_dimension(&self) -> LweDimension {
         self.lwe_dimension
-    }
-
-    /// Returns a mut pointer to the GPU data on a chosen GPU
-    #[allow(dead_code)]
-    pub(crate) unsafe fn get_ptr(&self, gpu_index: GpuIndex) -> CudaLweCiphertextVectorPointer {
-        self.d_ptr_vec[gpu_index.0 as usize]
     }
 }

--- a/concrete-core/src/backends/cuda/private/mod.rs
+++ b/concrete-core/src/backends/cuda/private/mod.rs
@@ -1,3 +1,4 @@
 pub mod crypto;
 pub mod device;
 pub mod pointers;
+pub mod vec;

--- a/concrete-core/src/backends/cuda/private/pointers.rs
+++ b/concrete-core/src/backends/cuda/private/pointers.rs
@@ -3,31 +3,3 @@ use std::ffi::c_void;
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct StreamPointer(pub *mut c_void);
-
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct CudaLweCiphertextVectorPointer(pub *mut c_void);
-
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct CudaGlweCiphertextVectorPointer(pub *mut c_void);
-
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct CudaLweCiphertextPointer(pub *mut c_void);
-
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct CudaGlweCiphertextPointer(pub *mut c_void);
-
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct CudaBootstrapKeyPointer(pub *mut c_void);
-
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct CpuBootstrapKeyPointer(pub *mut c_void);
-
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct CudaLweKeyswitchKeyPointer(pub *mut c_void);

--- a/concrete-core/src/backends/cuda/private/vec.rs
+++ b/concrete-core/src/backends/cuda/private/vec.rs
@@ -1,0 +1,52 @@
+use concrete_commons::numeric::Numeric;
+use concrete_cuda::cuda_bind::cuda_drop;
+use std::ffi::c_void;
+use std::marker::PhantomData;
+
+/// A contiguous array type stored in the gpu memory.
+///
+/// Note:
+/// -----
+///
+/// Such a structure:
+/// + can be created via the `CudaStream::malloc` function
+/// + can not be copied or cloned but can be (mutably) borrowed
+/// + frees the gpu memory on drop.
+///
+/// Put differently, it owns a region of the gpu memory at a given time. For this reason, regarding
+/// memory, it is pretty close to a `Vec`. That being said, it only present a very very limited api.
+#[derive(Debug)]
+pub struct CudaVec<T: Numeric> {
+    pub(super) ptr: *mut c_void,
+    pub(super) idx: u32,
+    pub(super) len: usize,
+    pub(super) _phantom: PhantomData<T>,
+}
+
+impl<T: Numeric> CudaVec<T> {
+    /// Returns a raw pointer to the vector’s buffer.
+    pub fn as_c_ptr(&self) -> *const c_void {
+        self.ptr as *const c_void
+    }
+
+    /// Returns an unsafe mutable pointer to the vector’s buffer.
+    pub fn as_mut_c_ptr(&mut self) -> *mut c_void {
+        self.ptr
+    }
+
+    /// Returns the number of elements in the vector, also referred to as its ‘length’.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if the CudaVec contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+impl<T: Numeric> Drop for CudaVec<T> {
+    fn drop(&mut self) {
+        unsafe { cuda_drop(self.ptr, self.idx) };
+    }
+}

--- a/concrete-core/src/specification/entities/mod.rs
+++ b/concrete-core/src/specification/entities/mod.rs
@@ -15,7 +15,7 @@ use std::fmt::Debug;
 /// An `AbstractEntity` type is nothing more than a type with an associated
 /// [`Kind`](`AbstractEntity::Kind`) marker type (implementing the [`EntityKindMarker`] trait),
 /// which encodes in the type system, the abstract nature of the object.
-pub trait AbstractEntity: Debug + PartialEq {
+pub trait AbstractEntity: Debug {
     // # Why associated types and not generic parameters ?
     //
     // With generic parameters you can have one type implement a variety of abstract entity. With

--- a/concrete-cuda/cuda/src/device.cu
+++ b/concrete-cuda/cuda/src/device.cu
@@ -55,8 +55,14 @@ int cuda_check_valid_malloc(uint64_t size, uint32_t gpu_index) {
 /// 0: success
 /// -1: error, invalid device pointer
 /// -2: error, gpu index doesn't exist
+/// -3: error, zero copy size
 int cuda_memcpy_async_to_gpu(void *dest, void *src, uint64_t size,
                              void *v_stream, uint32_t gpu_index) {
+  if (size == 0) {
+    // error code: zero copy size
+    return -3;
+  }
+  
   if (gpu_index >= cuda_get_number_of_gpus()) {
     // error code: invalid gpu_index
     return -2;
@@ -91,8 +97,14 @@ int cuda_synchronize_device(uint32_t gpu_index) {
 /// 0: success
 /// -1: error, invalid device pointer
 /// -2: error, gpu index doesn't exist
+/// -3: error, zero copy size
 int cuda_memcpy_async_to_cpu(void *dest, const void *src, uint64_t size,
                              void *v_stream, uint32_t gpu_index) {
+  if (size == 0) {
+    // error code: zero copy size
+    return -3;
+  }
+
   if (gpu_index >= cuda_get_number_of_gpus()) {
     // error code: invalid gpu_index
     return -2;


### PR DESCRIPTION
### Resolves:

closes zama-ai/concrete-core-internal#331

### Description

In order to remove the DestructionEngine, we have to automatically cleanup the memory when dropping one structure contained in the entities of the cuda backend.

We chose to factor out this logic in a CudaVec structure, which owns a memory region on one gpu.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
