### PR TITLE
Increase the amount of samples in the gaussian distribution test

### DIFF
--- a/concrete-core/src/commons/math/random/tests.rs
+++ b/concrete-core/src/commons/math/random/tests.rs
@@ -62,7 +62,7 @@ fn test_distribution<T: UnsignedTorus>() {
     // settings
     let std_dev: f64 = f64::powi(2., -5);
     let mean: f64 = 0.;
-    let k = 1_000_000;
+    let k = 10_000_000;
     let mut generator = new_random_generator();
 
     // generates normal random


### PR DESCRIPTION
### Resolves: zama-ai/concrete-core-internal#334

### Description

The test for Gaussian distribution in concrete-core is still flaky, because we don't draw enough inputs.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
