### PR TITLE
chore(ffi): do not limit creations of UnixSeeder from a single secret

### DIFF
--- a/concrete-core-ffi/src/seeders/unix_seeder.rs
+++ b/concrete-core-ffi/src/seeders/unix_seeder.rs
@@ -7,29 +7,16 @@ use std::os::raw::c_int;
 
 struct UnixSeederFactory {
     secret: u128,
-    allowed_to_create_seeder: bool,
 }
 
 impl UnixSeederFactory {
     pub fn new(secret: u128) -> Self {
-        Self {
-            secret,
-            allowed_to_create_seeder: true,
-        }
+        Self { secret }
     }
 }
 
 impl SeederFactory for UnixSeederFactory {
     fn create_seeder(&mut self) -> Result<Box<dyn Seeder>, String> {
-        if !self.allowed_to_create_seeder {
-            return Err(
-                "The current UnixSeederFactory already created a seeder with the stored secret \
-                and will not create anymore for security reasons. If you need a new UnixSeeder \
-                create another UnixSeederFactory with a different secret."
-                    .to_owned(),
-            );
-        }
-        self.allowed_to_create_seeder = false;
         Ok(Box::new(UnixSeeder::new(self.secret)))
     }
 }
@@ -60,15 +47,12 @@ fn u128_from_two_u64(high_64: u64, low_64: u64) -> u128 {
     (high_bytes << 64) ^ low_bytes
 }
 
-/// ⚠ It is VERY dangerous to re-use a secret to seed a UnixSeeder. The returned [`SeederBuilder`]
-/// instance is only callable once and will panic if called more than once.
-///
 /// This function requires a 128 bits seed that will be used as a secret to create a `UnixSeeder`
 /// instance. Two 64 bits unsigned integers (`secret_high_64` and `secret_low_64`) are required to
 /// create the 128 bits secret.
 ///
-/// Return a [`SeederBuilder`] which will create only one `UnixSeeder`, that can be passed to engine
-/// creation functions that require it. Using the [`SeederBuilder`] more than once will panic.
+/// Return a [`SeederBuilder`] which yields `UnixSeeder`s that can be passed to engine creation
+/// functions that require it.
 ///
 /// This function is [checked](crate#safety-checked-and-unchecked-functions).
 #[no_mangle]
@@ -86,9 +70,6 @@ pub unsafe extern "C" fn get_unix_seeder_builder(
     })
 }
 
-/// ⚠ It is VERY dangerous to re-use a secret to seed a UnixSeeder. The returned [`SeederBuilder`]
-/// instance is only callable once and will panic if called more than once.
-///
 /// [Unchecked](crate#safety-checked-and-unchecked-functions) version of
 /// [`get_unix_seeder_builder`].
 #[no_mangle]


### PR DESCRIPTION
### Resolves:

### Description

we were being overly cautious, a secret here is like a secret key

FYI @BourgerieQuentin and @mayeul-zama 

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
