### PR TITLE
refactor(csprng): remove the bound index which is a near duplicate of last

### DIFF
--- a/concrete-csprng/Cargo.toml
+++ b/concrete-csprng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concrete-csprng"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["D. Ligier", "J.B. Orfila", "A. Péré", "S. Tap", "Zama team"]
 license = "BSD-3-Clause-Clear"


### PR DESCRIPTION
### Resolves:

### Description

last is the one used in tight loops, get_bound is used rarely, removed
bound which makes the struct 128 + 64 = 192 bits smaller or 24 bytes less

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
