### PR TITLE
Refactor/boxed block cipher for fork

### DIFF
--- a/concrete-csprng/src/generators/aes_ctr/parallel.rs
+++ b/concrete-csprng/src/generators/aes_ctr/parallel.rs
@@ -7,9 +7,9 @@ use crate::generators::{BytesPerChild, ChildrenCount, ForkError};
 pub type ParallelChildrenIterator<BlockCipher> = rayon::iter::Map<
     rayon::iter::Zip<
         rayon::range::Iter<usize>,
-        rayon::iter::RepeatN<(BlockCipher, TableIndex, BytesPerChild)>,
+        rayon::iter::RepeatN<(Box<BlockCipher>, TableIndex, BytesPerChild)>,
     >,
-    fn((usize, (BlockCipher, TableIndex, BytesPerChild))) -> AesCtrGenerator<BlockCipher>,
+    fn((usize, (Box<BlockCipher>, TableIndex, BytesPerChild))) -> AesCtrGenerator<BlockCipher>,
 >;
 
 impl<BlockCipher: AesBlockCipher> AesCtrGenerator<BlockCipher> {


### PR DESCRIPTION
### Resolves:

### Description

saw improvements on dev machine for csprng tests runtime (623s down to 475s)

Should help fix the stack overflow problem that is plagging the debug builds and the M1 mac builds (to be tested)

M1 builds seem to be passing during manual tests, this is looking good

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
