### PR TITLE
fix(test): update zero encryption vector fixture to use realistic params

### DIFF
--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_decryption.rs
@@ -56,7 +56,7 @@ where
             vec![
                 GlweCiphertextDecryptionParameters {
                     noise: Variance(0.00000001),
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                 },
                 GlweCiphertextDecryptionParameters {

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_decryption.rs
@@ -57,7 +57,7 @@ where
             vec![
                 GlweCiphertextDiscardingDecryptionParameters {
                     noise: Variance(0.00000001),
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                 },
                 GlweCiphertextDiscardingDecryptionParameters {

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_encryption.rs
@@ -57,7 +57,7 @@ where
             vec![
                 GlweCiphertextDiscardingEncryptionParameters {
                     noise: Variance(0.00000001),
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                 },
                 GlweCiphertextDiscardingEncryptionParameters {

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_trivial_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_trivial_encryption.rs
@@ -49,7 +49,7 @@ where
         Box::new(
             vec![
                 GlweCiphertextDiscardingTrivialEncryptionParameters {
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                 },
                 GlweCiphertextDiscardingTrivialEncryptionParameters {

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_encryption.rs
@@ -54,7 +54,7 @@ where
             vec![
                 GlweCiphertextEncryptionParameters {
                     noise: Variance(0.00000001),
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                 },
                 GlweCiphertextEncryptionParameters {

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_trivial_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_trivial_decryption.rs
@@ -45,7 +45,7 @@ where
         Box::new(
             vec![
                 GlweCiphertextTrivialDecryptionParameters {
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                 },
                 GlweCiphertextTrivialDecryptionParameters {

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_trivial_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_trivial_encryption.rs
@@ -43,7 +43,7 @@ where
         Box::new(
             vec![
                 GlweCiphertextTrivialEncryptionParameters {
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                 },
                 GlweCiphertextTrivialEncryptionParameters {

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_decryption.rs
@@ -57,7 +57,7 @@ where
         Box::new(
             vec![
                 GlweCiphertextVectorDecryptionParameters {
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                     count: GlweCiphertextCount(10),
                     noise: Variance(0.00000001),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_discarding_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_discarding_decryption.rs
@@ -63,7 +63,7 @@ where
             vec![
                 GlweCiphertextVectorDiscardingDecryptionParameters {
                     noise: Variance(0.00000001),
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                     count: GlweCiphertextCount(10),
                 },

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_discarding_encryption.rs
@@ -63,7 +63,7 @@ where
             vec![
                 GlweCiphertextVectorDiscardingEncryptionParameters {
                     noise: Variance(0.00000001),
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                     count: GlweCiphertextCount(10),
                 },

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_encryption.rs
@@ -54,7 +54,7 @@ where
         Box::new(
             vec![
                 GlweCiphertextVectorEncryptionParameters {
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                     count: GlweCiphertextCount(10),
                     noise: Variance(0.00000001),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_trivial_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_trivial_decryption.rs
@@ -52,7 +52,7 @@ where
         Box::new(
             vec![
                 GlweCiphertextVectorTrivialDecryptionParameters {
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                     count: GlweCiphertextCount(100),
                 },

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_trivial_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_trivial_encryption.rs
@@ -46,7 +46,7 @@ where
         Box::new(
             vec![
                 GlweCiphertextVectorTrivialEncryptionParameters {
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                     count: GlweCiphertextCount(100),
                 },

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_zero_encryption.rs
@@ -51,7 +51,7 @@ where
             vec![
                 GlweCiphertextVectorZeroEncryptionParameters {
                     noise: Variance(0.00000001),
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                     count: GlweCiphertextCount(100),
                 },

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_zero_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_zero_encryption.rs
@@ -47,7 +47,7 @@ where
             vec![
                 GlweCiphertextZeroEncryptionParameters {
                     noise: Variance(0.00000001),
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                 },
                 GlweCiphertextZeroEncryptionParameters {

--- a/concrete-core-fixture/src/fixture/glwe_seeded_ciphertext_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_seeded_ciphertext_encryption.rs
@@ -55,7 +55,7 @@ where
             vec![
                 GlweSeededCiphertextEncryptionParameters {
                     noise: Variance(0.00000001),
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                 },
                 GlweSeededCiphertextEncryptionParameters {

--- a/concrete-core-fixture/src/fixture/glwe_seeded_ciphertext_to_glwe_ciphertext_transformation.rs
+++ b/concrete-core-fixture/src/fixture/glwe_seeded_ciphertext_to_glwe_ciphertext_transformation.rs
@@ -74,7 +74,7 @@ where
             vec![
                 GlweSeededCiphertextToGlweCiphertextTransformationParameters {
                     noise: Variance(0.00000001),
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                 },
                 GlweSeededCiphertextToGlweCiphertextTransformationParameters {

--- a/concrete-core-fixture/src/fixture/glwe_seeded_ciphertext_vector_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_seeded_ciphertext_vector_encryption.rs
@@ -60,7 +60,7 @@ where
         Box::new(
             vec![
                 GlweSeededCiphertextVectorEncryptionParameters {
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                     count: GlweCiphertextCount(10),
                     noise: Variance(0.00000001),

--- a/concrete-core-fixture/src/fixture/glwe_seeded_ciphertext_vector_to_glwe_ciphertext_vector_transformation.rs
+++ b/concrete-core-fixture/src/fixture/glwe_seeded_ciphertext_vector_to_glwe_ciphertext_vector_transformation.rs
@@ -84,7 +84,7 @@ where
         Box::new(
             vec![
                 GlweSeededCiphertextVectorToGlweCiphertextVectorTransformationParameters {
-                    glwe_dimension: GlweDimension(200),
+                    glwe_dimension: GlweDimension(2),
                     polynomial_size: PolynomialSize(256),
                     count: GlweCiphertextCount(10),
                     noise: Variance(0.00000001),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_extraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_extraction.rs
@@ -55,7 +55,7 @@ where
         Box::new(
             vec![LweCiphertextDiscardingExtractionParameters {
                 noise: Variance(0.00000001),
-                glwe_dimension: GlweDimension(200),
+                glwe_dimension: GlweDimension(2),
                 poly_size: PolynomialSize(256),
                 nth: MonomialIndex(0),
             }]


### PR DESCRIPTION
### Resolves:

### Description

we rarely use GlweDimension > 2 (if ever) and the zero encryption test seems to be
the one that slows our whole test suite down, this should allow for much
faster PRs

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
