### PR TITLE
ci: Add remote configuration for slab ci bot

### DIFF
--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -1,0 +1,22 @@
+[profile.cpu]
+region = "eu-west-3"
+image_id = "ami-000311d202e281658"
+instance_type = "m5.2xlarge"
+subnet_id = "subnet-0e042c7621461f754"
+
+[profile.gpu]
+region = "us-east-1"
+image_id = "ami-0df0337664ad627fe"
+instance_type = "p3.2xlarge"
+subnet_id = "subnet-8123c9e7"
+security_group = "sg-0466d33ced960ba35"
+
+[command.cpu_test]
+workflow = "aws_tests_slab_beta.yml"
+profile = "cpu"
+check_run_name = "AWS tests (Slab)"
+
+[command.gpu_test]
+workflow = "aws_tests_gpu_slab_beta.yml"
+profile = "gpu"
+check_run_name = "AWS tests GPU (Slab)"


### PR DESCRIPTION
### Description

In the next Slab CI bot release, the inner workings of the server change a bit. In order to have more flexibility on command declaration and EC2 profile definitions for each repositories, the configuration belongs now to each repo.

Each time a command is run from a PR, the file `ci/slab.toml` will be fetched and read from the branch the PR refers to. A great aspect of this behavior is the ability to add a new command/profile in your PR to test your code in other conditions. Another one is to avoid having hardcoded profiles structs and commands in Slab, and thus remove the need to make a release or reboot Slab in case of global configuration changes.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
* [ ] ~~Docs have been added / updated (for bug fixes / features)~~
* [ ] ~~The PR description links to the related issue (to link an issue, use '#XXX'.)~~
* [ ] ~~The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)~~
* [ ] ~~The draft release description has been updated~~
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
