### PR TITLE
chore(cuda): remove redundant getters in the cuda backend

### DIFF
--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_amortized_engine/lwe_ciphertext_vector_discarding_bootstrap.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_amortized_engine/lwe_ciphertext_vector_discarding_bootstrap.rs
@@ -118,7 +118,7 @@ impl
         LweCiphertextVectorDiscardingBootstrapError::perform_generic_checks(
             output, input, acc, bsk,
         )?;
-        let poly_size = bsk.0.polynomial_size().0;
+        let poly_size = bsk.polynomial_size().0;
         check_poly_size!(poly_size);
         unsafe { self.discard_bootstrap_lwe_ciphertext_vector_unchecked(output, input, acc, bsk) };
         Ok(())
@@ -131,7 +131,7 @@ impl
         acc: &CudaGlweCiphertextVector32,
         bsk: &CudaFourierLweBootstrapKey32,
     ) {
-        let samples_per_gpu = input.0.lwe_ciphertext_count().0 / self.get_number_of_gpus();
+        let samples_per_gpu = input.lwe_ciphertext_count().0 / self.get_number_of_gpus();
 
         for gpu_index in 0..self.get_number_of_gpus() {
             let mut samples = samples_per_gpu;
@@ -273,7 +273,7 @@ impl
         LweCiphertextVectorDiscardingBootstrapError::perform_generic_checks(
             output, input, acc, bsk,
         )?;
-        let poly_size = bsk.0.polynomial_size().0;
+        let poly_size = bsk.polynomial_size().0;
         check_poly_size!(poly_size);
         unsafe { self.discard_bootstrap_lwe_ciphertext_vector_unchecked(output, input, acc, bsk) };
         Ok(())
@@ -286,7 +286,7 @@ impl
         acc: &CudaGlweCiphertextVector64,
         bsk: &CudaFourierLweBootstrapKey64,
     ) {
-        let samples_per_gpu = input.0.lwe_ciphertext_count().0 / self.get_number_of_gpus();
+        let samples_per_gpu = input.lwe_ciphertext_count().0 / self.get_number_of_gpus();
 
         for gpu_index in 0..self.get_number_of_gpus() {
             let mut samples = samples_per_gpu;
@@ -309,7 +309,7 @@ impl
                 &d_test_vector_indexes,
                 input.0.d_vecs.get(gpu_index).unwrap(),
                 bsk.0.d_vecs.get(gpu_index).unwrap(),
-                input.0.lwe_dimension,
+                input.lwe_dimension(),
                 bsk.polynomial_size(),
                 bsk.decomposition_base_log(),
                 bsk.decomposition_level_count(),

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_discarding_bootstrap.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_discarding_bootstrap.rs
@@ -113,7 +113,7 @@ impl
         bsk: &CudaFourierLweBootstrapKey32,
     ) -> Result<(), LweCiphertextDiscardingBootstrapError<CudaError>> {
         LweCiphertextDiscardingBootstrapError::perform_generic_checks(output, input, acc, bsk)?;
-        let poly_size = bsk.0.polynomial_size().0;
+        let poly_size = bsk.polynomial_size().0;
         check_poly_size!(poly_size);
         unsafe { self.discard_bootstrap_lwe_ciphertext_unchecked(output, input, acc, bsk) };
         Ok(())
@@ -243,7 +243,7 @@ impl
         bsk: &CudaFourierLweBootstrapKey64,
     ) -> Result<(), LweCiphertextDiscardingBootstrapError<CudaError>> {
         LweCiphertextDiscardingBootstrapError::perform_generic_checks(output, input, acc, bsk)?;
-        let poly_size = bsk.0.polynomial_size().0;
+        let poly_size = bsk.polynomial_size().0;
         check_poly_size!(poly_size);
         unsafe { self.discard_bootstrap_lwe_ciphertext_unchecked(output, input, acc, bsk) };
         Ok(())

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_discarding_keyswitch.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_discarding_keyswitch.rs
@@ -7,6 +7,7 @@ use crate::backends::cuda::private::device::NumberOfSamples;
 use crate::specification::engines::{
     LweCiphertextDiscardingKeyswitchEngine, LweCiphertextDiscardingKeyswitchError,
 };
+use crate::specification::entities::LweKeyswitchKeyEntity;
 
 impl From<CudaError> for LweCiphertextDiscardingKeyswitchError<CudaError> {
     fn from(err: CudaError) -> Self {
@@ -113,8 +114,8 @@ impl
             input.0.lwe_dimension,
             output.0.lwe_dimension,
             ksk.0.d_vecs.first().unwrap(),
-            ksk.0.decomposition_base_log(),
-            ksk.0.decomposition_level_count(),
+            ksk.decomposition_base_log(),
+            ksk.decomposition_level_count(),
             NumberOfSamples(1),
         );
     }
@@ -219,8 +220,8 @@ impl
             input.0.lwe_dimension,
             output.0.lwe_dimension,
             ksk.0.d_vecs.first().unwrap(),
-            ksk.0.decomposition_base_log(),
-            ksk.0.decomposition_level_count(),
+            ksk.decomposition_base_log(),
+            ksk.decomposition_level_count(),
             NumberOfSamples(1),
         );
     }

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_vector_discarding_bootstrap.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_vector_discarding_bootstrap.rs
@@ -117,7 +117,7 @@ impl
         LweCiphertextVectorDiscardingBootstrapError::perform_generic_checks(
             output, input, acc, bsk,
         )?;
-        let poly_size = bsk.0.polynomial_size().0;
+        let poly_size = bsk.polynomial_size().0;
         check_poly_size!(poly_size);
         unsafe { self.discard_bootstrap_lwe_ciphertext_vector_unchecked(output, input, acc, bsk) };
         Ok(())
@@ -130,7 +130,7 @@ impl
         acc: &CudaGlweCiphertextVector32,
         bsk: &CudaFourierLweBootstrapKey32,
     ) {
-        let samples_per_gpu = input.0.lwe_ciphertext_count().0 / self.get_number_of_gpus();
+        let samples_per_gpu = input.lwe_ciphertext_count().0 / self.get_number_of_gpus();
 
         for gpu_index in 0..self.get_number_of_gpus() {
             let mut samples = samples_per_gpu;
@@ -154,7 +154,7 @@ impl
                 input.0.d_vecs.get(gpu_index).unwrap(),
                 bsk.0.d_vecs.get(gpu_index).unwrap(),
                 input.0.lwe_dimension,
-                bsk.0.polynomial_size,
+                bsk.polynomial_size(),
                 bsk.decomposition_base_log(),
                 bsk.decomposition_level_count(),
                 NumberOfSamples(samples),
@@ -271,7 +271,7 @@ impl
         LweCiphertextVectorDiscardingBootstrapError::perform_generic_checks(
             output, input, acc, bsk,
         )?;
-        let poly_size = bsk.0.polynomial_size().0;
+        let poly_size = bsk.polynomial_size().0;
         check_poly_size!(poly_size);
         unsafe { self.discard_bootstrap_lwe_ciphertext_vector_unchecked(output, input, acc, bsk) };
         Ok(())
@@ -284,7 +284,7 @@ impl
         acc: &CudaGlweCiphertextVector64,
         bsk: &CudaFourierLweBootstrapKey64,
     ) {
-        let samples_per_gpu = input.0.lwe_ciphertext_count().0 / self.get_number_of_gpus();
+        let samples_per_gpu = input.lwe_ciphertext_count().0 / self.get_number_of_gpus();
 
         for gpu_index in 0..self.get_number_of_gpus() {
             let mut samples = samples_per_gpu;
@@ -308,7 +308,7 @@ impl
                 input.0.d_vecs.get(gpu_index).unwrap(),
                 bsk.0.d_vecs.get(gpu_index).unwrap(),
                 input.0.lwe_dimension,
-                bsk.0.polynomial_size,
+                bsk.polynomial_size(),
                 bsk.decomposition_base_log(),
                 bsk.decomposition_level_count(),
                 NumberOfSamples(samples),

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_vector_discarding_keyswitch.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_vector_discarding_keyswitch.rs
@@ -8,6 +8,7 @@ use crate::backends::cuda::private::device::NumberOfSamples;
 use crate::specification::engines::{
     LweCiphertextVectorDiscardingKeyswitchEngine, LweCiphertextVectorDiscardingKeyswitchError,
 };
+use crate::specification::entities::{LweCiphertextVectorEntity, LweKeyswitchKeyEntity};
 
 impl From<CudaError> for LweCiphertextVectorDiscardingKeyswitchError<CudaError> {
     fn from(err: CudaError) -> Self {
@@ -116,7 +117,7 @@ impl
         ksk: &CudaLweKeyswitchKey32,
     ) {
         let samples_per_gpu =
-            NumberOfSamples(input.0.lwe_ciphertext_count().0 / self.get_number_of_gpus());
+            NumberOfSamples(input.lwe_ciphertext_count().0 / self.get_number_of_gpus());
 
         for gpu_index in 0..self.get_number_of_gpus() {
             let stream = self.streams.get(gpu_index).unwrap();
@@ -127,8 +128,8 @@ impl
                 input.0.lwe_dimension,
                 output.0.lwe_dimension,
                 ksk.0.d_vecs.get(gpu_index).unwrap(),
-                ksk.0.decomposition_base_log(),
-                ksk.0.decomposition_level_count(),
+                ksk.decomposition_base_log(),
+                ksk.decomposition_level_count(),
                 samples_per_gpu,
             );
         }
@@ -236,7 +237,7 @@ impl
         ksk: &CudaLweKeyswitchKey64,
     ) {
         let samples_per_gpu =
-            NumberOfSamples(input.0.lwe_ciphertext_count().0 / self.get_number_of_gpus());
+            NumberOfSamples(input.lwe_ciphertext_count().0 / self.get_number_of_gpus());
 
         for gpu_index in 0..self.get_number_of_gpus() {
             let stream = self.streams.get(gpu_index).unwrap();
@@ -247,8 +248,8 @@ impl
                 input.0.lwe_dimension,
                 output.0.lwe_dimension,
                 ksk.0.d_vecs.get(gpu_index).unwrap(),
-                ksk.0.decomposition_base_log(),
-                ksk.0.decomposition_level_count(),
+                ksk.decomposition_base_log(),
+                ksk.decomposition_level_count(),
                 samples_per_gpu,
             );
         }

--- a/concrete-core/src/backends/cuda/implementation/entities/glwe_ciphertext.rs
+++ b/concrete-core/src/backends/cuda/implementation/entities/glwe_ciphertext.rs
@@ -19,11 +19,11 @@ impl GlweCiphertextEntity for CudaGlweCiphertext32 {
     type KeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
-        self.0.glwe_dimension()
+        self.0.glwe_dimension
     }
 
     fn polynomial_size(&self) -> PolynomialSize {
-        self.0.polynomial_size()
+        self.0.polynomial_size
     }
 }
 
@@ -40,10 +40,10 @@ impl GlweCiphertextEntity for CudaGlweCiphertext64 {
     type KeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
-        self.0.glwe_dimension()
+        self.0.glwe_dimension
     }
 
     fn polynomial_size(&self) -> PolynomialSize {
-        self.0.polynomial_size()
+        self.0.polynomial_size
     }
 }

--- a/concrete-core/src/backends/cuda/implementation/entities/glwe_ciphertext_vector.rs
+++ b/concrete-core/src/backends/cuda/implementation/entities/glwe_ciphertext_vector.rs
@@ -19,15 +19,15 @@ impl GlweCiphertextVectorEntity for CudaGlweCiphertextVector32 {
     type KeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
-        self.0.glwe_dimension()
+        self.0.glwe_dimension
     }
 
     fn polynomial_size(&self) -> PolynomialSize {
-        self.0.polynomial_size()
+        self.0.polynomial_size
     }
 
     fn glwe_ciphertext_count(&self) -> GlweCiphertextCount {
-        self.0.glwe_ciphertext_count()
+        self.0.glwe_ciphertext_count
     }
 }
 
@@ -44,14 +44,14 @@ impl GlweCiphertextVectorEntity for CudaGlweCiphertextVector64 {
     type KeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
-        self.0.glwe_dimension()
+        self.0.glwe_dimension
     }
 
     fn polynomial_size(&self) -> PolynomialSize {
-        self.0.polynomial_size()
+        self.0.polynomial_size
     }
 
     fn glwe_ciphertext_count(&self) -> GlweCiphertextCount {
-        self.0.glwe_ciphertext_count()
+        self.0.glwe_ciphertext_count
     }
 }

--- a/concrete-core/src/backends/cuda/implementation/entities/lwe_bootstrap_key.rs
+++ b/concrete-core/src/backends/cuda/implementation/entities/lwe_bootstrap_key.rs
@@ -19,23 +19,23 @@ impl LweBootstrapKeyEntity for CudaFourierLweBootstrapKey32 {
     type OutputKeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
-        self.0.glwe_dimension()
+        self.0.glwe_dimension
     }
 
     fn polynomial_size(&self) -> PolynomialSize {
-        self.0.polynomial_size()
+        self.0.polynomial_size
     }
 
     fn input_lwe_dimension(&self) -> LweDimension {
-        self.0.input_lwe_dimension()
+        self.0.input_lwe_dimension
     }
 
     fn decomposition_base_log(&self) -> DecompositionBaseLog {
-        self.0.decomposition_base_log()
+        self.0.decomp_base_log
     }
 
     fn decomposition_level_count(&self) -> DecompositionLevelCount {
-        self.0.decomposition_level_count()
+        self.0.decomp_level
     }
 }
 
@@ -52,22 +52,22 @@ impl LweBootstrapKeyEntity for CudaFourierLweBootstrapKey64 {
     type OutputKeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
-        self.0.glwe_dimension()
+        self.0.glwe_dimension
     }
 
     fn polynomial_size(&self) -> PolynomialSize {
-        self.0.polynomial_size()
+        self.0.polynomial_size
     }
 
     fn input_lwe_dimension(&self) -> LweDimension {
-        self.0.input_lwe_dimension()
+        self.0.input_lwe_dimension
     }
 
     fn decomposition_base_log(&self) -> DecompositionBaseLog {
-        self.0.decomposition_base_log()
+        self.0.decomp_base_log
     }
 
     fn decomposition_level_count(&self) -> DecompositionLevelCount {
-        self.0.decomposition_level_count()
+        self.0.decomp_level
     }
 }

--- a/concrete-core/src/backends/cuda/implementation/entities/lwe_ciphertext.rs
+++ b/concrete-core/src/backends/cuda/implementation/entities/lwe_ciphertext.rs
@@ -18,7 +18,7 @@ impl LweCiphertextEntity for CudaLweCiphertext32 {
     type KeyDistribution = BinaryKeyDistribution;
 
     fn lwe_dimension(&self) -> LweDimension {
-        self.0.lwe_dimension()
+        self.0.lwe_dimension
     }
 }
 
@@ -34,6 +34,6 @@ impl LweCiphertextEntity for CudaLweCiphertext64 {
     type KeyDistribution = BinaryKeyDistribution;
 
     fn lwe_dimension(&self) -> LweDimension {
-        self.0.lwe_dimension()
+        self.0.lwe_dimension
     }
 }

--- a/concrete-core/src/backends/cuda/implementation/entities/lwe_ciphertext_vector.rs
+++ b/concrete-core/src/backends/cuda/implementation/entities/lwe_ciphertext_vector.rs
@@ -18,11 +18,11 @@ impl LweCiphertextVectorEntity for CudaLweCiphertextVector32 {
     type KeyDistribution = BinaryKeyDistribution;
 
     fn lwe_dimension(&self) -> LweDimension {
-        self.0.lwe_dimension()
+        self.0.lwe_dimension
     }
 
     fn lwe_ciphertext_count(&self) -> LweCiphertextCount {
-        self.0.lwe_ciphertext_count()
+        self.0.lwe_ciphertext_count
     }
 }
 
@@ -38,10 +38,10 @@ impl LweCiphertextVectorEntity for CudaLweCiphertextVector64 {
     type KeyDistribution = BinaryKeyDistribution;
 
     fn lwe_dimension(&self) -> LweDimension {
-        self.0.lwe_dimension()
+        self.0.lwe_dimension
     }
 
     fn lwe_ciphertext_count(&self) -> LweCiphertextCount {
-        self.0.lwe_ciphertext_count()
+        self.0.lwe_ciphertext_count
     }
 }

--- a/concrete-core/src/backends/cuda/implementation/entities/lwe_keyswitch_key.rs
+++ b/concrete-core/src/backends/cuda/implementation/entities/lwe_keyswitch_key.rs
@@ -17,19 +17,19 @@ impl LweKeyswitchKeyEntity for CudaLweKeyswitchKey32 {
     type OutputKeyDistribution = BinaryKeyDistribution;
 
     fn input_lwe_dimension(&self) -> LweDimension {
-        self.0.input_lwe_dimension()
+        self.0.input_lwe_dimension
     }
 
     fn output_lwe_dimension(&self) -> LweDimension {
-        self.0.output_lwe_dimension()
+        self.0.output_lwe_dimension
     }
 
     fn decomposition_level_count(&self) -> DecompositionLevelCount {
-        self.0.decomposition_level_count()
+        self.0.decomp_level
     }
 
     fn decomposition_base_log(&self) -> DecompositionBaseLog {
-        self.0.decomposition_base_log()
+        self.0.decomp_base_log
     }
 }
 
@@ -46,18 +46,18 @@ impl LweKeyswitchKeyEntity for CudaLweKeyswitchKey64 {
     type OutputKeyDistribution = BinaryKeyDistribution;
 
     fn input_lwe_dimension(&self) -> LweDimension {
-        self.0.input_lwe_dimension()
+        self.0.input_lwe_dimension
     }
 
     fn output_lwe_dimension(&self) -> LweDimension {
-        self.0.output_lwe_dimension()
+        self.0.output_lwe_dimension
     }
 
     fn decomposition_level_count(&self) -> DecompositionLevelCount {
-        self.0.decomposition_level_count()
+        self.0.decomp_level
     }
 
     fn decomposition_base_log(&self) -> DecompositionBaseLog {
-        self.0.decomposition_base_log()
+        self.0.decomp_base_log
     }
 }

--- a/concrete-core/src/backends/cuda/private/crypto/bootstrap/mod.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/bootstrap/mod.rs
@@ -1,6 +1,5 @@
 //! Bootstrap key with Cuda.
 use crate::backends::cuda::private::vec::CudaVec;
-use concrete_commons::numeric::UnsignedInteger;
 use concrete_commons::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
 };
@@ -22,31 +21,4 @@ pub(crate) struct CudaBootstrapKey<T> {
     pub(crate) decomp_base_log: DecompositionBaseLog,
     // Field to hold type T
     pub(crate) _phantom: PhantomData<T>,
-}
-
-impl<T: UnsignedInteger> CudaBootstrapKey<T> {
-    #[allow(dead_code)]
-    pub(crate) fn polynomial_size(&self) -> PolynomialSize {
-        self.polynomial_size
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn input_lwe_dimension(&self) -> LweDimension {
-        self.input_lwe_dimension
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn glwe_dimension(&self) -> GlweDimension {
-        self.glwe_dimension
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn decomposition_level_count(&self) -> DecompositionLevelCount {
-        self.decomp_level
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn decomposition_base_log(&self) -> DecompositionBaseLog {
-        self.decomp_base_log
-    }
 }

--- a/concrete-core/src/backends/cuda/private/crypto/glwe/ciphertext.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/glwe/ciphertext.rs
@@ -16,13 +16,3 @@ pub(crate) struct CudaGlweCiphertext<T: UnsignedInteger> {
     // Polynomial size
     pub(crate) polynomial_size: PolynomialSize,
 }
-
-impl<T: UnsignedInteger> CudaGlweCiphertext<T> {
-    pub(crate) fn glwe_dimension(&self) -> GlweDimension {
-        self.glwe_dimension
-    }
-
-    pub(crate) fn polynomial_size(&self) -> PolynomialSize {
-        self.polynomial_size
-    }
-}

--- a/concrete-core/src/backends/cuda/private/crypto/glwe/list.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/glwe/list.rs
@@ -22,17 +22,3 @@ pub(crate) struct CudaGlweList<T: UnsignedInteger> {
     // Polynomial size
     pub(crate) polynomial_size: PolynomialSize,
 }
-
-impl<T: UnsignedInteger> CudaGlweList<T> {
-    pub(crate) fn glwe_ciphertext_count(&self) -> GlweCiphertextCount {
-        self.glwe_ciphertext_count
-    }
-
-    pub(crate) fn glwe_dimension(&self) -> GlweDimension {
-        self.glwe_dimension
-    }
-
-    pub(crate) fn polynomial_size(&self) -> PolynomialSize {
-        self.polynomial_size
-    }
-}

--- a/concrete-core/src/backends/cuda/private/crypto/keyswitch/mod.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/keyswitch/mod.rs
@@ -16,25 +16,3 @@ pub(crate) struct CudaLweKeyswitchKey<T: UnsignedInteger> {
     // Value of the base log for the decomposition
     pub(crate) decomp_base_log: DecompositionBaseLog,
 }
-
-impl<T: UnsignedInteger> CudaLweKeyswitchKey<T> {
-    #[allow(dead_code)]
-    pub(crate) fn input_lwe_dimension(&self) -> LweDimension {
-        self.input_lwe_dimension
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn output_lwe_dimension(&self) -> LweDimension {
-        self.output_lwe_dimension
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn decomposition_level_count(&self) -> DecompositionLevelCount {
-        self.decomp_level
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn decomposition_base_log(&self) -> DecompositionBaseLog {
-        self.decomp_base_log
-    }
-}

--- a/concrete-core/src/backends/cuda/private/crypto/lwe/ciphertext.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/lwe/ciphertext.rs
@@ -15,9 +15,3 @@ pub(crate) struct CudaLweCiphertext<T: UnsignedInteger> {
     // Lwe dimension
     pub(crate) lwe_dimension: LweDimension,
 }
-
-impl<T: UnsignedInteger> CudaLweCiphertext<T> {
-    pub(crate) fn lwe_dimension(&self) -> LweDimension {
-        self.lwe_dimension
-    }
-}

--- a/concrete-core/src/backends/cuda/private/crypto/lwe/list.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/lwe/list.rs
@@ -27,13 +27,3 @@ pub(crate) struct CudaLweList<T: UnsignedInteger> {
     // Lwe dimension
     pub(crate) lwe_dimension: LweDimension,
 }
-
-impl<T: UnsignedInteger> CudaLweList<T> {
-    pub(crate) fn lwe_ciphertext_count(&self) -> LweCiphertextCount {
-        self.lwe_ciphertext_count
-    }
-
-    pub(crate) fn lwe_dimension(&self) -> LweDimension {
-        self.lwe_dimension
-    }
-}


### PR DESCRIPTION
### Resolves: zama-ai/concrete-core-internal#359

### Description
Some getters in the private API of the Cuda backend are redundant so we prefer to remove them.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
