### PR TITLE
Feature/circuit bootstrapping

### DIFF
--- a/concrete-commons/src/parameters.rs
+++ b/concrete-commons/src/parameters.rs
@@ -193,3 +193,8 @@ pub struct DeltaLog(pub usize);
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct ExtractedBitsCount(pub usize);
+
+/// The number of functional packing keyswitch key in a functional packing keyswitch key list.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+pub struct FunctionalPackingKeyswitchKeyCount(pub usize);

--- a/concrete-core-fixture/src/generation/prototyping/private_functional_packing_keyswitch_key.rs
+++ b/concrete-core-fixture/src/generation/prototyping/private_functional_packing_keyswitch_key.rs
@@ -30,6 +30,7 @@ pub trait PrototypesPrivateFunctionalPackingKeyswitchKey<
         InputKeyDistribution = InputKeyDistribution,
         OutputKeyDistribution = OutputKeyDistribution,
     >;
+    #[allow(clippy::too_many_arguments)]
     fn new_private_functional_packing_keyswitch_key(
         &mut self,
         input_key: &<Self as PrototypesLweSecretKey<
@@ -43,7 +44,8 @@ pub trait PrototypesPrivateFunctionalPackingKeyswitchKey<
         decomposition_level: DecompositionLevelCount,
         decomposition_base_log: DecompositionBaseLog,
         noise: StandardDev,
-        polynomial_scalar: &<Self as PrototypesCleartextVector<Precision>>::CleartextVectorProto,
+        f: &dyn Fn(Precision::Raw) -> Precision::Raw,
+        polynomial: &<Self as PrototypesCleartextVector<Precision>>::CleartextVectorProto,
     ) -> Self::PrivateFunctionalPackingKeyswitchKeyProto;
 }
 
@@ -64,6 +66,7 @@ impl
         decomposition_level: DecompositionLevelCount,
         decomposition_base_log: DecompositionBaseLog,
         noise: StandardDev,
+        f: &dyn Fn(u32) -> u32,
         polynomial_scalar: &Self::CleartextVectorProto,
     ) -> Self::PrivateFunctionalPackingKeyswitchKeyProto {
         ProtoBinaryBinaryPrivateFunctionalPackingKeyswitchKey32(
@@ -74,6 +77,7 @@ impl
                     decomposition_level,
                     decomposition_base_log,
                     noise,
+                    f,
                     &polynomial_scalar.0,
                 )
                 .unwrap(),
@@ -98,6 +102,7 @@ impl
         decomposition_level: DecompositionLevelCount,
         decomposition_base_log: DecompositionBaseLog,
         noise: StandardDev,
+        f: &dyn Fn(u64) -> u64,
         polynomial_scalar: &Self::CleartextVectorProto,
     ) -> Self::PrivateFunctionalPackingKeyswitchKeyProto {
         ProtoBinaryBinaryPrivateFunctionalPackingKeyswitchKey64(
@@ -108,6 +113,7 @@ impl
                     decomposition_level,
                     decomposition_base_log,
                     noise,
+                    f,
                     &polynomial_scalar.0,
                 )
                 .unwrap(),

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_vector_glwe_ciphertext_discarding_private_functional_packing_keyswitch.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_vector_glwe_ciphertext_discarding_private_functional_packing_keyswitch.rs
@@ -55,6 +55,7 @@ impl
     ///         decomposition_level_count,
     ///         decomposition_base_log,
     ///         StandardDev(noise.get_standard_dev()),
+    ///         &|x| x,
     ///         &polynomial,
     ///     )?;
     /// let plaintext_vector = engine.create_plaintext_vector(&input_vector)?;
@@ -156,6 +157,7 @@ impl
     ///         decomposition_level_count,
     ///         decomposition_base_log,
     ///         StandardDev(noise.get_standard_dev()),
+    ///         &|x| x,
     ///         &polynomial,
     ///     )?;
     /// let plaintext_vector = engine.create_plaintext_vector(&input_vector)?;

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_private_functional_packing_keyswitch_key_creation.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_private_functional_packing_keyswitch_key_creation.rs
@@ -29,6 +29,7 @@ impl
         GlweSecretKey32,
         PrivateFunctionalPackingKeyswitchKey32,
         CleartextVector32,
+        u32,
     > for DefaultEngine
 {
     /// # Example:
@@ -66,6 +67,7 @@ impl
     ///     decomposition_level_count,
     ///     decomposition_base_log,
     ///     StandardDev(noise.get_standard_dev()),
+    ///     &|x|x,
     ///     &polynomial,
     /// )?;
     /// #
@@ -93,7 +95,8 @@ impl
         decomposition_level_count: DecompositionLevelCount,
         decomposition_base_log: DecompositionBaseLog,
         noise: StandardDev,
-        polynomial_scalar: &CleartextVector32,
+        f: &dyn Fn(u32) -> u32,
+        polynomial: &CleartextVector32,
     ) -> Result<
         PrivateFunctionalPackingKeyswitchKey32,
         PrivateFunctionalPackingKeyswitchKeyCreationError<Self::EngineError>,
@@ -103,7 +106,7 @@ impl
             decomposition_base_log,
             32,
             output_key.polynomial_size(),
-            PolynomialSize(polynomial_scalar.0.as_tensor().len()),
+            PolynomialSize(polynomial.0.as_tensor().len()),
         )?;
         Ok(unsafe {
             self.create_private_functional_packing_keyswitch_key_unchecked(
@@ -112,7 +115,8 @@ impl
                 decomposition_level_count,
                 decomposition_base_log,
                 noise,
-                polynomial_scalar,
+                f,
+                polynomial,
             )
         })
     }
@@ -124,7 +128,8 @@ impl
         decomposition_level_count: DecompositionLevelCount,
         decomposition_base_log: DecompositionBaseLog,
         noise: StandardDev,
-        polynomial_scalar: &CleartextVector32,
+        f: &dyn Fn(u32) -> u32,
+        polynomial: &CleartextVector32,
     ) -> PrivateFunctionalPackingKeyswitchKey32 {
         let mut pfpksk = ImplPrivateFunctionalPackingKeyswitchKey::allocate(
             0,
@@ -134,13 +139,14 @@ impl
             output_key.glwe_dimension(),
             output_key.polynomial_size(),
         );
-        let poly = Polynomial::from_container(polynomial_scalar.0.as_tensor().as_slice().to_vec());
+        let poly = Polynomial::from_container(polynomial.0.as_tensor().as_slice().to_vec());
 
         pfpksk.fill_with_private_functional_packing_keyswitch_key(
             &input_key.0,
             &output_key.0,
             noise,
             &mut self.encryption_generator,
+            f,
             &poly,
         );
         PrivateFunctionalPackingKeyswitchKey32(pfpksk)
@@ -159,13 +165,14 @@ impl
         GlweSecretKey64,
         PrivateFunctionalPackingKeyswitchKey64,
         CleartextVector64,
+        u64,
     > for DefaultEngine
 {
     /// # Example:
     /// ```
     /// use concrete_commons::dispersion::Variance;
     /// use concrete_commons::parameters::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, LweDimension,
+    ///     DecompositionBaseLog, DecompositionLevelCount, LweDimension, GlweDimension
     /// };
     /// use concrete_core::prelude::*;
     /// # use std::error::Error;
@@ -196,7 +203,8 @@ impl
     ///     decomposition_level_count,
     ///     decomposition_base_log,
     ///     StandardDev(noise.get_standard_dev()),
-    ///     &polynomial
+    ///     &|x|x,
+    ///     &polynomial,
     /// )?;
     /// #
     /// assert_eq!(
@@ -223,7 +231,8 @@ impl
         decomposition_level_count: DecompositionLevelCount,
         decomposition_base_log: DecompositionBaseLog,
         noise: StandardDev,
-        polynomial_scalar: &CleartextVector64,
+        f: &dyn Fn(u64) -> u64,
+        polynomial: &CleartextVector64,
     ) -> Result<
         PrivateFunctionalPackingKeyswitchKey64,
         PrivateFunctionalPackingKeyswitchKeyCreationError<Self::EngineError>,
@@ -233,7 +242,7 @@ impl
             decomposition_base_log,
             64,
             output_key.polynomial_size(),
-            PolynomialSize(polynomial_scalar.0.as_tensor().len()),
+            PolynomialSize(polynomial.0.as_tensor().len()),
         )?;
         Ok(unsafe {
             self.create_private_functional_packing_keyswitch_key_unchecked(
@@ -242,7 +251,8 @@ impl
                 decomposition_level_count,
                 decomposition_base_log,
                 noise,
-                polynomial_scalar,
+                f,
+                polynomial,
             )
         })
     }
@@ -254,7 +264,8 @@ impl
         decomposition_level_count: DecompositionLevelCount,
         decomposition_base_log: DecompositionBaseLog,
         noise: StandardDev,
-        polynomial_scalar: &CleartextVector64,
+        f: &dyn Fn(u64) -> u64,
+        polynomial: &CleartextVector64,
     ) -> PrivateFunctionalPackingKeyswitchKey64 {
         let mut pfpksk = ImplPrivateFunctionalPackingKeyswitchKey::allocate(
             0,
@@ -264,13 +275,14 @@ impl
             output_key.glwe_dimension(),
             output_key.polynomial_size(),
         );
-        let poly = Polynomial::from_container(polynomial_scalar.0.as_tensor().as_slice().to_vec());
+        let poly = Polynomial::from_container(polynomial.0.as_tensor().as_slice().to_vec());
 
         pfpksk.fill_with_private_functional_packing_keyswitch_key(
             &input_key.0,
             &output_key.0,
             noise,
             &mut self.encryption_generator,
+            f,
             &poly,
         );
         PrivateFunctionalPackingKeyswitchKey64(pfpksk)

--- a/concrete-core/src/backends/fftw/private/crypto/wop_pbs/mod.rs
+++ b/concrete-core/src/backends/fftw/private/crypto/wop_pbs/mod.rs
@@ -1,13 +1,16 @@
 //! Primitives for the so-called Wop-PBS (Without Padding Programmable Bootstrapping)
 
 use crate::backends::fftw::private::crypto::bootstrap::{FourierBootstrapKey, FourierBuffers};
-use crate::backends::fftw::private::math::fft::{AlignedVec, Complex64};
+use crate::backends::fftw::private::math::fft::Complex64;
 use crate::commons::crypto::encoding::Cleartext;
-use crate::commons::crypto::glwe::GlweCiphertext;
+use crate::commons::crypto::ggsw::StandardGgswCiphertext;
+use crate::commons::crypto::glwe::{GlweCiphertext, PrivateFunctionalPackingKeyswitchKeyList};
 use crate::commons::crypto::lwe::{LweCiphertext, LweKeyswitchKey, LweList};
-use crate::commons::math::tensor::{AsMutTensor, AsRefTensor};
+use crate::commons::math::tensor::{AsMutTensor, AsRefSlice, AsRefTensor};
 use crate::commons::math::torus::UnsignedTorus;
-use concrete_commons::parameters::{CiphertextCount, DeltaLog, ExtractedBitsCount, LweDimension};
+use concrete_commons::parameters::{
+    DecompositionBaseLog, DecompositionLevelCount, DeltaLog, ExtractedBitsCount, LweDimension,
+};
 
 #[cfg(test)]
 mod test;
@@ -18,16 +21,17 @@ mod test;
 /// Ouput bits are ordered from the MSB to the LSB. Each one of them is output in a distinct LWE
 /// ciphertext, containing the encryption of the bit scaled by q/2 (i.e., the most significant bit
 /// in the plaintext representation).
-pub fn extract_bits<Scalar>(
+pub fn extract_bits<Scalar, C1>(
     delta_log: DeltaLog,
+    lwe_list_out: &mut LweList<Vec<Scalar>>,
     lwe_in: &LweCiphertext<Vec<Scalar>>,
     ksk: &LweKeyswitchKey<Vec<Scalar>>,
-    fourier_bsk: &FourierBootstrapKey<AlignedVec<Complex64>, Scalar>,
+    fourier_bsk: &FourierBootstrapKey<C1, Scalar>,
     buffers: &mut FourierBuffers<Scalar>,
     number_of_bits_to_extract: ExtractedBitsCount,
-) -> LweList<Vec<Scalar>>
-where
+) where
     Scalar: UnsignedTorus,
+    FourierBootstrapKey<C1, Scalar>: AsRefTensor<Element = Complex64>,
 {
     let ciphertext_n_bits = Scalar::BITS;
     let number_of_bits_to_extract = number_of_bits_to_extract.0;
@@ -40,6 +44,18 @@ where
         ciphertext_n_bits,
         delta_log.0,
         ciphertext_n_bits - delta_log.0,
+    );
+    debug_assert!(
+        lwe_list_out.lwe_size() == ksk.lwe_size(),
+        "lwe_list_out needs to have an lwe_size of {}, got {}",
+        ksk.lwe_size().0,
+        lwe_list_out.lwe_size().0,
+    );
+    debug_assert!(
+        lwe_list_out.count().0 == number_of_bits_to_extract,
+        "lwe_list_out needs to have a ciphertext count of {}, got {}",
+        number_of_bits_to_extract,
+        lwe_list_out.count().0,
     );
 
     let polynomial_size = fourier_bsk.polynomial_size();
@@ -57,15 +73,8 @@ where
         LweDimension(glwe_dimension.0 * polynomial_size.0).to_lwe_size(),
     );
 
-    // Output List
-    let mut output_lwe_list = LweList::allocate(
-        Scalar::ZERO,
-        ksk.lwe_size(),
-        CiphertextCount(number_of_bits_to_extract),
-    );
-
     // We iterate on the list in reverse as we want to store the extracted MSB at index 0
-    for (bit_idx, mut output_ct) in output_lwe_list.ciphertext_iter_mut().rev().enumerate() {
+    for (bit_idx, mut output_ct) in lwe_list_out.ciphertext_iter_mut().rev().enumerate() {
         // Shift on padding bit
         lwe_bit_left_shift_buffer.fill_with_scalar_mul(
             &lwe_in_buffer,
@@ -121,6 +130,169 @@ where
         // Remove the extracted bit from the initial LWE to get a 0 at the extracted bit location.
         lwe_in_buffer.update_with_sub(&lwe_out_pbs_buffer);
     }
+}
 
-    output_lwe_list
+/// Circuit bootstrapping for binary messages, i.e. containing only one bit of message
+///
+/// The output GGSW ciphertext `ggsw_out` decomposition base log and level count are used as the
+/// circuit_bootstrap_binary decomposition base log and level count.
+pub fn circuit_bootstrap_binary<Scalar, C1, C2, C3, C4>(
+    fourier_bsk: &FourierBootstrapKey<C1, Scalar>,
+    lwe_in: &LweCiphertext<C2>,
+    ggsw_out: &mut StandardGgswCiphertext<C3>,
+    buffers: &mut FourierBuffers<Scalar>,
+    delta_log: DeltaLog,
+    fpksk_list: &PrivateFunctionalPackingKeyswitchKeyList<C4>,
+) where
+    Scalar: UnsignedTorus,
+    FourierBootstrapKey<C1, Scalar>: AsRefTensor<Element = Complex64>,
+    C2: AsRefSlice<Element = Scalar>,
+    StandardGgswCiphertext<C3>: AsMutTensor<Element = Scalar>,
+    PrivateFunctionalPackingKeyswitchKeyList<C4>: AsRefTensor<Element = Scalar>,
+{
+    let level_cbs = ggsw_out.decomposition_level_count();
+    let base_log_cbs = ggsw_out.decomposition_base_log();
+
+    debug_assert!(
+        level_cbs.0 >= 1,
+        "level_cbs needs to be >= 1, got {}",
+        level_cbs.0
+    );
+    debug_assert!(
+        base_log_cbs.0 >= 1,
+        "base_log_cbs needs to be >= 1, got {}",
+        base_log_cbs.0
+    );
+
+    let bsk_glwe_dimension = fourier_bsk.glwe_size().to_glwe_dimension();
+    let bsk_polynomial_size = fourier_bsk.polynomial_size();
+
+    let fpksk_input_lwe_key_dimension = fpksk_list.input_lwe_key_dimension();
+
+    debug_assert!(
+        fpksk_input_lwe_key_dimension.0 == bsk_polynomial_size.0 * bsk_glwe_dimension.0,
+        "The fourier_bsk polynomial_size, got {}, must be equal to the fpksk \
+        input_lwe_key_dimension, got {}",
+        bsk_polynomial_size.0 * bsk_glwe_dimension.0,
+        fpksk_input_lwe_key_dimension.0
+    );
+
+    let fpksk_output_polynomial_size = fpksk_list.output_polynomial_size();
+    let fpksk_output_glwe_key_dimension = fpksk_list.output_glwe_key_dimension();
+
+    debug_assert!(
+        ggsw_out.polynomial_size() == fpksk_output_polynomial_size,
+        "The output GGSW ciphertext needs to have the same polynomial size as the fpksks, \
+        got {}, expeceted {}",
+        ggsw_out.polynomial_size().0,
+        fpksk_output_polynomial_size.0
+    );
+
+    debug_assert!(
+        ggsw_out.glwe_size().to_glwe_dimension() == fpksk_output_glwe_key_dimension,
+        "The output GGSW ciphertext needs to have the same GLWE dimension as the fpksks, \
+        got {}, expeceted {}",
+        ggsw_out.glwe_size().to_glwe_dimension().0,
+        fpksk_output_glwe_key_dimension.0
+    );
+
+    debug_assert!(
+        ggsw_out.glwe_size().0 * ggsw_out.decomposition_level_count().0
+            == fpksk_list.fpksk_count().0,
+        "The input vector of fpksk needs to have {} (ggsw.glwe_size * \
+        ggsw.decomposition_level_count) elements got {}",
+        ggsw_out.glwe_size().0 * ggsw_out.decomposition_level_count().0,
+        fpksk_list.fpksk_count().0,
+    );
+
+    // Output for every bootstrapping
+    let mut lwe_out_bs_buffer: LweCiphertext<Vec<Scalar>> = LweCiphertext::allocate(
+        Scalar::ZERO,
+        LweDimension(bsk_glwe_dimension.0 * bsk_polynomial_size.0).to_lwe_size(),
+    );
+    // Output for every pfksk that that come from the output GGSW
+    let mut glwe_out_pfksk_buffer = ggsw_out.as_mut_glwe_list();
+
+    let mut out_pfksk_buffer_iter = glwe_out_pfksk_buffer.ciphertext_iter_mut();
+
+    for level_idx in 0..level_cbs.0 {
+        homomorphic_shift_binary(
+            fourier_bsk,
+            &mut lwe_out_bs_buffer,
+            lwe_in,
+            buffers,
+            DecompositionLevelCount(level_idx + 1),
+            base_log_cbs,
+            delta_log,
+        );
+
+        for pfksk in fpksk_list.fpksk_iter() {
+            let mut glwe_out = out_pfksk_buffer_iter.next().unwrap();
+            pfksk.private_functional_keyswitch_ciphertext(&mut glwe_out, &lwe_out_bs_buffer);
+        }
+    }
+}
+
+/// Homomorphic shift for LWE without padding bit
+///
+/// Starts by shifting the message bit at bit #delta_log to the padding bit and then shifts it to
+/// the right by base_log * level.
+pub fn homomorphic_shift_binary<Scalar, C1, C2, C3>(
+    fourier_bsk: &FourierBootstrapKey<C1, Scalar>,
+    lwe_out: &mut LweCiphertext<C2>,
+    lwe_in: &LweCiphertext<C3>,
+    buffers: &mut FourierBuffers<Scalar>,
+    level_count_cbs: DecompositionLevelCount,
+    base_log_cbs: DecompositionBaseLog,
+    delta_log: DeltaLog,
+) where
+    Scalar: UnsignedTorus,
+    FourierBootstrapKey<C1, Scalar>: AsRefTensor<Element = Complex64>,
+    LweCiphertext<C2>: AsMutTensor<Element = Scalar>,
+    LweCiphertext<C3>: AsRefTensor<Element = Scalar>,
+{
+    let ciphertext_n_bits = Scalar::BITS;
+    let lwe_in_size = lwe_in.lwe_size();
+    let polynomial_size = fourier_bsk.polynomial_size();
+
+    let mut lwe_left_shift_buffer = LweCiphertext::allocate(Scalar::ZERO, lwe_in_size);
+    // Shift message LSB on padding bit, at this point we expect to have messages with only 1 bit
+    // of information
+    lwe_left_shift_buffer.fill_with_scalar_mul(
+        lwe_in,
+        &Cleartext(Scalar::ONE << (ciphertext_n_bits - delta_log.0 - 1)),
+    );
+
+    // Add q/4 to center the error while computing a negacyclic LUT
+    let mut shift_buffer_body = lwe_left_shift_buffer.get_mut_body();
+    shift_buffer_body.0 = shift_buffer_body
+        .0
+        .wrapping_add(Scalar::ONE << (ciphertext_n_bits - 2));
+
+    let mut pbs_accumulator =
+        GlweCiphertext::allocate(Scalar::ZERO, polynomial_size, fourier_bsk.glwe_size());
+
+    // Fill lut (equivalent to trivial encryption as mask is 0s)
+    // The LUT is filled with -alpha in each coefficient where
+    // alpha = 2^{log(q) - 1 - base_log * level}
+    for poly_coeff in pbs_accumulator
+        .get_mut_body()
+        .as_mut_polynomial()
+        .coefficient_iter_mut()
+    {
+        *poly_coeff = Scalar::ZERO.wrapping_sub(
+            Scalar::ONE << (ciphertext_n_bits - 1 - base_log_cbs.0 * level_count_cbs.0),
+        );
+    }
+
+    // Applying a negacyclic LUT on a ciphertext with one bit of message in the MSB and no bit
+    // of padding
+    fourier_bsk.bootstrap(lwe_out, &lwe_left_shift_buffer, &pbs_accumulator, buffers);
+
+    // Add alpha where alpha = 2^{log(q) - 1 - base_log * level}
+    // To end up with an encryption of 0 if the message bit was 0 and 1 in the other case
+    let out_body = lwe_out.get_mut_body();
+    out_body.0 = out_body
+        .0
+        .wrapping_add(Scalar::ONE << (ciphertext_n_bits - 1 - base_log_cbs.0 * level_count_cbs.0));
 }

--- a/concrete-core/src/backends/fftw/private/crypto/wop_pbs/test.rs
+++ b/concrete-core/src/backends/fftw/private/crypto/wop_pbs/test.rs
@@ -1,20 +1,23 @@
 use crate::backends::fftw::private::crypto::bootstrap::{FourierBootstrapKey, FourierBuffers};
-use crate::backends::fftw::private::crypto::wop_pbs::extract_bits;
+use crate::backends::fftw::private::crypto::wop_pbs::{circuit_bootstrap_binary, extract_bits};
 use crate::backends::fftw::private::math::fft::Complex64;
 use crate::commons::crypto::bootstrap::StandardBootstrapKey;
-use crate::commons::crypto::encoding::Plaintext;
-use crate::commons::crypto::lwe::{LweCiphertext, LweKeyswitchKey};
+use crate::commons::crypto::encoding::{Plaintext, PlaintextList};
+use crate::commons::crypto::ggsw::StandardGgswCiphertext;
+use crate::commons::crypto::glwe::PrivateFunctionalPackingKeyswitchKeyList;
+use crate::commons::crypto::lwe::{LweCiphertext, LweKeyswitchKey, LweList};
 use crate::commons::crypto::secret::generators::{
     EncryptionRandomGenerator, SecretRandomGenerator,
 };
 use crate::commons::crypto::secret::{GlweSecretKey, LweSecretKey};
 use crate::commons::math::decomposition::SignedDecomposer;
-use crate::commons::math::tensor::{AsRefSlice, AsRefTensor};
+use crate::commons::math::tensor::{AsMutTensor, AsRefSlice, AsRefTensor};
 use crate::commons::test_tools;
 use concrete_commons::dispersion::LogStandardDev;
 use concrete_commons::parameters::{
-    DecompositionBaseLog, DecompositionLevelCount, DeltaLog, ExtractedBitsCount, GlweDimension,
-    LweDimension, LweSize, PolynomialSize,
+    CiphertextCount, DecompositionBaseLog, DecompositionLevelCount, DeltaLog, ExtractedBitsCount,
+    FunctionalPackingKeyswitchKeyCount, GlweDimension, LweDimension, LweSize, PlaintextCount,
+    PolynomialSize,
 };
 use concrete_csprng::generators::SoftwareRandomGenerator;
 use concrete_csprng::seeders::{Seeder, UnixSeeder};
@@ -111,8 +114,16 @@ pub fn test_extract_bits() {
         // Bit extraction
         // Extract all the bits
         let number_values_to_extract = ExtractedBitsCount(64 - delta_log.0);
-        let result_lwe = extract_bits(
+
+        let mut lwe_out_list = LweList::allocate(
+            0u64,
+            ksk_lwe_big_to_small.lwe_size(),
+            CiphertextCount(number_values_to_extract.0),
+        );
+
+        extract_bits(
             delta_log,
+            &mut lwe_out_list,
             &lwe_in,
             &ksk_lwe_big_to_small,
             &fourier_bsk,
@@ -121,7 +132,7 @@ pub fn test_extract_bits() {
         );
 
         // Decryption of extracted bit
-        for (i, result_ct) in result_lwe.ciphertext_iter().rev().enumerate() {
+        for (i, result_ct) in lwe_out_list.ciphertext_iter().rev().enumerate() {
             let mut decrypted_message = Plaintext(0_u64);
             lwe_small_sk.decrypt_lwe(&mut decrypted_message, &result_ct);
             // Round after decryption using decomposer
@@ -138,5 +149,194 @@ pub fn test_extract_bits() {
                 message.0
             )
         }
+    }
+}
+
+// Test the circuit bootstrapping with private functional ks
+// Verify the decryption has the expected content
+#[test]
+pub fn test_circuit_bootstrapping_binary() {
+    // Define settings for an insecure toy example
+    let polynomial_size = PolynomialSize(512);
+    let glwe_dimension = GlweDimension(2);
+    let lwe_dimension = LweDimension(10);
+
+    let level_bsk = DecompositionLevelCount(2);
+    let base_log_bsk = DecompositionBaseLog(15);
+
+    let level_pksk = DecompositionLevelCount(2);
+    let base_log_pksk = DecompositionBaseLog(15);
+
+    let level_count_cbs = DecompositionLevelCount(1);
+    let base_log_cbs = DecompositionBaseLog(10);
+
+    let std = LogStandardDev::from_log_standard_dev(-60.);
+
+    const UNSAFE_SECRET: u128 = 0;
+    let mut seeder = UnixSeeder::new(UNSAFE_SECRET);
+
+    let mut secret_generator = SecretRandomGenerator::<SoftwareRandomGenerator>::new(seeder.seed());
+    let mut encryption_generator =
+        EncryptionRandomGenerator::<SoftwareRandomGenerator>::new(seeder.seed(), &mut seeder);
+
+    // Create GLWE and LWE secret key
+    let glwe_sk: GlweSecretKey<_, Vec<u64>> =
+        GlweSecretKey::generate_binary(glwe_dimension, polynomial_size, &mut secret_generator);
+    let lwe_sk: LweSecretKey<_, Vec<u64>> =
+        LweSecretKey::generate_binary(lwe_dimension, &mut secret_generator);
+
+    // Allocation and generation of the bootstrap key in standard domain:
+    let mut std_bsk = StandardBootstrapKey::allocate(
+        0u64,
+        glwe_dimension.to_glwe_size(),
+        polynomial_size,
+        level_bsk,
+        base_log_bsk,
+        lwe_dimension,
+    );
+    std_bsk.fill_with_new_key(&lwe_sk, &glwe_sk, std, &mut encryption_generator);
+
+    // Allocation of the fourier bootstrapping key
+    let mut fourier_bsk: FourierBootstrapKey<_, u64> = FourierBootstrapKey::allocate(
+        Complex64::new(0., 0.),
+        glwe_dimension.to_glwe_size(),
+        polynomial_size,
+        level_bsk,
+        base_log_bsk,
+        lwe_dimension,
+    );
+
+    let mut buffers = FourierBuffers::new(fourier_bsk.polynomial_size(), fourier_bsk.glwe_size());
+    fourier_bsk.fill_with_forward_fourier(&std_bsk, &mut buffers);
+
+    let lwe_sk_bs_output = LweSecretKey::binary_from_container(glwe_sk.as_tensor().as_slice());
+
+    // Creation of all the pfksk for the circuit bootstrapping
+    let mut vec_pfksk = PrivateFunctionalPackingKeyswitchKeyList::allocate(
+        0u64,
+        level_pksk,
+        base_log_pksk,
+        lwe_sk_bs_output.key_size(),
+        glwe_sk.key_size(),
+        glwe_sk.polynomial_size(),
+        FunctionalPackingKeyswitchKeyCount(glwe_dimension.to_glwe_size().0),
+    );
+
+    vec_pfksk.fill_with_fpksk_for_circuit_bootstrap(
+        &lwe_sk_bs_output,
+        &glwe_sk,
+        &glwe_sk,
+        std,
+        &mut encryption_generator,
+    );
+
+    let delta_log = DeltaLog(60);
+
+    // value is 0 or 1 as CBS works on messages expected to contain 1 bit of information
+    let value: u64 = test_tools::random_uint_between(0..2u64);
+    // Encryption of an LWE with the value 'message'
+    let message = Plaintext((value) << delta_log.0);
+    let mut lwe_in = LweCiphertext::allocate(0u64, lwe_dimension.to_lwe_size());
+    lwe_sk.encrypt_lwe(&mut lwe_in, &message, std, &mut encryption_generator);
+
+    let mut cbs_res = StandardGgswCiphertext::allocate(
+        0u64,
+        polynomial_size,
+        glwe_dimension.to_glwe_size(),
+        level_count_cbs,
+        base_log_cbs,
+    );
+
+    // Execute the CBS
+    circuit_bootstrap_binary(
+        &fourier_bsk,
+        &lwe_in,
+        &mut cbs_res,
+        &mut buffers,
+        delta_log,
+        &vec_pfksk,
+    );
+
+    let glwe_size = glwe_dimension.to_glwe_size();
+
+    //print the key to check if the RLWE in the GGSW seem to be well created
+    println!("RLWE secret key:\n{:?}", glwe_sk);
+    let mut decrypted = PlaintextList::allocate(
+        0_u64,
+        PlaintextCount(polynomial_size.0 * level_count_cbs.0 * glwe_size.0),
+    );
+    glwe_sk.decrypt_glwe_list(&mut decrypted, &cbs_res.as_glwe_list());
+
+    let level_size = polynomial_size.0 * glwe_size.0;
+
+    println!("\nGGSW decryption:");
+    for (level_idx, level_decrypted_glwe) in decrypted
+        .sublist_iter(PlaintextCount(level_size))
+        .enumerate()
+    {
+        for (decrypted_glwe, original_polynomial_from_glwe_sk) in level_decrypted_glwe
+            .sublist_iter(PlaintextCount(polynomial_size.0))
+            .take(glwe_dimension.0)
+            .zip(glwe_sk.as_polynomial_list().polynomial_iter())
+        {
+            let current_level = level_idx + 1;
+            let mut expected_decryption = PlaintextList::allocate(
+                0u64,
+                PlaintextCount(original_polynomial_from_glwe_sk.polynomial_size().0),
+            );
+            expected_decryption
+                .as_mut_tensor()
+                .fill_with_copy(original_polynomial_from_glwe_sk.as_tensor());
+
+            let multiplying_factor = 0u64.wrapping_sub(value);
+
+            expected_decryption
+                .as_mut_tensor()
+                .update_with_scalar_mul(&multiplying_factor);
+
+            let decomposer =
+                SignedDecomposer::new(base_log_cbs, DecompositionLevelCount(current_level));
+
+            expected_decryption
+                .as_mut_tensor()
+                .update_with(|coeff| *coeff >>= 64 - base_log_cbs.0 * current_level);
+
+            let mut decoded_glwe =
+                PlaintextList::from_container(decrypted_glwe.as_tensor().as_container().to_vec());
+
+            decoded_glwe.as_mut_tensor().update_with(|coeff| {
+                *coeff = decomposer.closest_representable(*coeff)
+                    >> (64 - base_log_cbs.0 * current_level)
+            });
+
+            assert_eq!(
+                expected_decryption.as_tensor().as_slice(),
+                decoded_glwe.as_tensor().as_slice()
+            );
+        }
+        let last_decrypted_glwe = level_decrypted_glwe
+            .sublist_iter(PlaintextCount(polynomial_size.0))
+            .rev()
+            .next()
+            .unwrap();
+
+        let mut last_decoded_glwe =
+            PlaintextList::from_container(last_decrypted_glwe.as_tensor().as_container().to_vec());
+
+        let decomposer = SignedDecomposer::new(base_log_cbs, level_count_cbs);
+
+        last_decoded_glwe.as_mut_tensor().update_with(|coeff| {
+            *coeff = decomposer.closest_representable(*coeff)
+                >> (64 - base_log_cbs.0 * level_count_cbs.0)
+        });
+
+        let mut expected_decryption = PlaintextList::allocate(0u64, last_decoded_glwe.count());
+
+        *expected_decryption.as_mut_tensor().first_mut() = value;
+
+        assert_eq!(
+            expected_decryption.as_tensor().as_slice(),
+            last_decoded_glwe.as_tensor().as_slice()
+        );
     }
 }

--- a/concrete-core/src/commons/crypto/encoding/plaintext.rs
+++ b/concrete-core/src/commons/crypto/encoding/plaintext.rs
@@ -146,7 +146,7 @@ impl<Cont> PlaintextList<Cont> {
     pub fn sublist_iter(
         &self,
         count: PlaintextCount,
-    ) -> impl Iterator<Item = PlaintextList<&[<Self as AsRefTensor>::Element]>>
+    ) -> impl DoubleEndedIterator<Item = PlaintextList<&[<Self as AsRefTensor>::Element]>>
     where
         Self: AsRefTensor,
     {

--- a/concrete-core/src/specification/engines/lwe_private_functional_packing_keyswitch_key_creation.rs
+++ b/concrete-core/src/specification/engines/lwe_private_functional_packing_keyswitch_key_creation.rs
@@ -86,6 +86,7 @@ pub trait PrivateFunctionalPackingKeyswitchKeyCreationEngine<
     OutputSecretKey,
     PrivateFunctionalPackingKeyswitchKey,
     CleartextVector,
+    FunctionScalarType,
 >: AbstractEngine where
     InputSecretKey: LweSecretKeyEntity,
     OutputSecretKey: GlweSecretKeyEntity,
@@ -93,6 +94,7 @@ pub trait PrivateFunctionalPackingKeyswitchKeyCreationEngine<
     PrivateFunctionalPackingKeyswitchKey: PrivateFunctionalPackingKeyswitchKeyEntity,
 {
     /// Creates a private functional packing keyswitch key.
+    #[allow(clippy::too_many_arguments)]
     fn create_private_functional_packing_keyswitch_key(
         &mut self,
         input_key: &InputSecretKey,
@@ -100,7 +102,8 @@ pub trait PrivateFunctionalPackingKeyswitchKeyCreationEngine<
         decomposition_level_count: DecompositionLevelCount,
         decomposition_base_log: DecompositionBaseLog,
         noise: StandardDev,
-        polynomial_scalar: &CleartextVector,
+        f: &dyn Fn(FunctionScalarType) -> FunctionScalarType,
+        polynomial: &CleartextVector,
     ) -> Result<
         PrivateFunctionalPackingKeyswitchKey,
         PrivateFunctionalPackingKeyswitchKeyCreationError<Self::EngineError>,
@@ -112,6 +115,7 @@ pub trait PrivateFunctionalPackingKeyswitchKeyCreationEngine<
     /// For the _general_ safety concerns regarding this operation, refer to the different variants
     /// of [`PrivateFunctionalPackingKeyswitchKeyCreationError`]. For safety concerns _specific_
     /// to an engine, refer to the implementer safety section.
+    #[allow(clippy::too_many_arguments)]
     unsafe fn create_private_functional_packing_keyswitch_key_unchecked(
         &mut self,
         input_key: &InputSecretKey,
@@ -119,6 +123,7 @@ pub trait PrivateFunctionalPackingKeyswitchKeyCreationEngine<
         decomposition_level_count: DecompositionLevelCount,
         decomposition_base_log: DecompositionBaseLog,
         noise: StandardDev,
-        polynomial_scalar: &CleartextVector,
+        f: &dyn Fn(FunctionScalarType) -> FunctionScalarType,
+        polynomial: &CleartextVector,
     ) -> PrivateFunctionalPackingKeyswitchKey;
 }


### PR DESCRIPTION
### Resolves:

closes https://github.com/zama-ai/concrete-core-internal/issues/352

### Description

Add private implementation for circuit bootstrap, slight rework of the FPKSK to take a reference to a function/closure to avoid the issue of the closure size while still being able to pass a function (less tedious than writing polynomials by hand).

Slight rework of the extract bits to be able to pass an output container directly

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
