### PR TITLE
feat(cuda): add some missing cuda discarding lwe conversion

### DIFF
--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_discarding_conversion.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_discarding_conversion.rs
@@ -1,12 +1,218 @@
 use crate::backends::cuda::implementation::engines::{CudaEngine, CudaError};
-use crate::backends::cuda::implementation::entities::CudaLweCiphertext64;
-use crate::commons::math::tensor::AsMutSlice;
-use crate::prelude::LweCiphertextMutView64;
+use crate::backends::cuda::implementation::entities::{CudaLweCiphertext32, CudaLweCiphertext64};
+use crate::commons::math::tensor::{AsMutSlice, AsRefSlice};
+use crate::prelude::{LweCiphertext32, LweCiphertextMutView32, LweCiphertextMutView64};
 use crate::specification::engines::{
     LweCiphertextDiscardingConversionEngine, LweCiphertextDiscardingConversionError,
 };
 
 /// # Description
+///
+/// Convert an LWE ciphertext with 32 bits of precision from GPU 0 to a view on the CPU.
+impl LweCiphertextDiscardingConversionEngine<CudaLweCiphertext32, LweCiphertextMutView32<'_>>
+    for CudaEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// use std::borrow::BorrowMut;
+    /// let lwe_dimension = LweDimension(6);
+    /// // Here a hard-set encoding is applied (shift by 25 bits)
+    /// let input = 3_u32 << 25;
+    /// let noise = Variance(2_f64.powf(-50.));
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let h_key: LweSecretKey32 = default_engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let h_plaintext: Plaintext32 = default_engine.create_plaintext(&input)?;
+    /// let mut h_ciphertext: LweCiphertext32 =
+    ///     default_engine.encrypt_lwe_ciphertext(&h_key, &h_plaintext, noise)?;
+    ///
+    /// let mut cuda_engine = CudaEngine::new(())?;
+    /// let d_ciphertext: CudaLweCiphertext32 = cuda_engine.convert_lwe_ciphertext(&h_ciphertext)?;
+    ///
+    /// // Prepares the output container
+    /// let mut h_raw_output_ciphertext = vec![0_u32; lwe_dimension.0 + 1];
+    /// let mut h_output_view_ciphertext: LweCiphertextMutView32 =
+    ///     default_engine.create_lwe_ciphertext(h_raw_output_ciphertext.as_mut_slice())?;
+    ///
+    /// cuda_engine.discard_convert_lwe_ciphertext(&mut h_output_view_ciphertext, &d_ciphertext)?;
+    ///
+    /// assert_eq!(h_output_view_ciphertext.lwe_dimension(), lwe_dimension);
+    /// // Extracts the internal container
+    /// let h_raw_input_ciphertext: Vec<u32> =
+    ///     default_engine.consume_retrieve_lwe_ciphertext(h_ciphertext)?;
+    /// let h_raw_output_ciphertext: &[u32] =
+    ///     default_engine.consume_retrieve_lwe_ciphertext(h_output_view_ciphertext)?;
+    /// assert_eq!(h_raw_input_ciphertext.as_slice(), h_raw_output_ciphertext);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_convert_lwe_ciphertext(
+        &mut self,
+        output: &mut LweCiphertextMutView32,
+        input: &CudaLweCiphertext32,
+    ) -> Result<(), LweCiphertextDiscardingConversionError<CudaError>> {
+        unsafe { self.discard_convert_lwe_ciphertext_unchecked(output, input) };
+        Ok(())
+    }
+
+    unsafe fn discard_convert_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut LweCiphertextMutView32,
+        input: &CudaLweCiphertext32,
+    ) {
+        let stream = &self.streams[0];
+        stream.copy_to_cpu::<u32>(output.0.tensor.as_mut_slice(), &input.0.d_vec);
+    }
+}
+
+/// # Description
+///
+/// Convert an LWE ciphertext with 32 bits of precision from GPU 0 to a ciphertext on the CPU.
+impl LweCiphertextDiscardingConversionEngine<CudaLweCiphertext32, LweCiphertext32> for CudaEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// use std::borrow::BorrowMut;
+    /// let lwe_dimension = LweDimension(6);
+    /// // Here a hard-set encoding is applied (shift by 25 bits)
+    /// let input = 3_u32 << 25;
+    /// let noise = Variance(2_f64.powf(-50.));
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let h_key: LweSecretKey32 = default_engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let h_plaintext: Plaintext32 = default_engine.create_plaintext(&input)?;
+    /// let mut h_ciphertext: LweCiphertext32 =
+    ///     default_engine.encrypt_lwe_ciphertext(&h_key, &h_plaintext, noise)?;
+    ///
+    /// let mut cuda_engine = CudaEngine::new(())?;
+    /// let d_ciphertext: CudaLweCiphertext32 = cuda_engine.convert_lwe_ciphertext(&h_ciphertext)?;
+    ///
+    /// // Prepares the output container
+    /// let h_raw_output_ciphertext = vec![0_u32; lwe_dimension.0 + 1];
+    /// let mut h_output_ciphertext: LweCiphertext32 =
+    ///     default_engine.create_lwe_ciphertext(h_raw_output_ciphertext)?;
+    ///
+    /// cuda_engine.discard_convert_lwe_ciphertext(&mut h_output_ciphertext, &d_ciphertext)?;
+    ///
+    /// assert_eq!(h_output_ciphertext.lwe_dimension(), lwe_dimension);
+    /// // Extracts the internal container
+    /// let h_raw_input_ciphertext: Vec<u32> =
+    ///     default_engine.consume_retrieve_lwe_ciphertext(h_ciphertext)?;
+    /// let h_raw_output_ciphertext: Vec<u32> =
+    ///     default_engine.consume_retrieve_lwe_ciphertext(h_output_ciphertext)?;
+    /// assert_eq!(h_raw_input_ciphertext, h_raw_output_ciphertext);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_convert_lwe_ciphertext(
+        &mut self,
+        output: &mut LweCiphertext32,
+        input: &CudaLweCiphertext32,
+    ) -> Result<(), LweCiphertextDiscardingConversionError<CudaError>> {
+        unsafe { self.discard_convert_lwe_ciphertext_unchecked(output, input) };
+        Ok(())
+    }
+
+    unsafe fn discard_convert_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut LweCiphertext32,
+        input: &CudaLweCiphertext32,
+    ) {
+        let stream = &self.streams[0];
+        stream.copy_to_cpu::<u32>(output.0.tensor.as_mut_slice(), &input.0.d_vec);
+    }
+}
+
+/// # Description
+///
+/// Convert an LWE ciphertext with 32 bits of precision from CPU to a ciphertext on the GPU 0.
+impl LweCiphertextDiscardingConversionEngine<LweCiphertext32, CudaLweCiphertext32> for CudaEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// use std::borrow::BorrowMut;
+    /// let lwe_dimension = LweDimension(6);
+    /// // Here a hard-set encoding is applied (shift by 25 bits)
+    /// let input = 3_u32 << 25;
+    /// let noise = Variance(2_f64.powf(-50.));
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let h_key: LweSecretKey32 = default_engine.create_lwe_secret_key(lwe_dimension)?;
+    /// let h_plaintext: Plaintext32 = default_engine.create_plaintext(&input)?;
+    /// let mut h_ciphertext: LweCiphertext32 =
+    ///     default_engine.encrypt_lwe_ciphertext(&h_key, &h_plaintext, noise)?;
+    ///
+    /// let mut cuda_engine = CudaEngine::new(())?;
+    /// let mut d_ciphertext: CudaLweCiphertext32 =
+    ///     cuda_engine.convert_lwe_ciphertext(&h_ciphertext)?;
+    ///
+    /// let h_ciphertext_out: LweCiphertext32 = cuda_engine.convert_lwe_ciphertext(&d_ciphertext)?;
+    ///
+    /// assert_eq!(h_ciphertext, h_ciphertext_out);
+    ///
+    /// // Prepare input for discarding convert
+    /// let input_2 = 5_u32 << 25;
+    /// let h_plaintext_2: Plaintext32 = default_engine.create_plaintext(&input_2)?;
+    /// let mut h_ciphertext_2: LweCiphertext32 = default_engine
+    ///     .trivially_encrypt_lwe_ciphertext(lwe_dimension.to_lwe_size(), &h_plaintext_2)?;
+    ///
+    /// cuda_engine.discard_convert_lwe_ciphertext(&mut d_ciphertext, &h_ciphertext_2)?;
+    ///
+    /// let h_ciphertext_out_2: LweCiphertext32 = cuda_engine.convert_lwe_ciphertext(&d_ciphertext)?;
+    ///
+    /// assert_eq!(h_ciphertext_2, h_ciphertext_out_2);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_convert_lwe_ciphertext(
+        &mut self,
+        output: &mut CudaLweCiphertext32,
+        input: &LweCiphertext32,
+    ) -> Result<(), LweCiphertextDiscardingConversionError<CudaError>> {
+        unsafe { self.discard_convert_lwe_ciphertext_unchecked(output, input) };
+        Ok(())
+    }
+
+    unsafe fn discard_convert_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut CudaLweCiphertext32,
+        input: &LweCiphertext32,
+    ) {
+        let stream = &self.streams[0];
+        stream.copy_to_gpu::<u32>(&mut output.0.d_vec, input.0.tensor.as_slice());
+    }
+}
+
+/// # Description
+///
 /// Convert an LWE ciphertext with 64 bits of precision from GPU 0 to a view on the CPU.
 impl LweCiphertextDiscardingConversionEngine<CudaLweCiphertext64, LweCiphertextMutView64<'_>>
     for CudaEngine
@@ -22,7 +228,7 @@ impl LweCiphertextDiscardingConversionEngine<CudaLweCiphertext64, LweCiphertextM
     /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
     /// use std::borrow::BorrowMut;
     /// let lwe_dimension = LweDimension(6);
-    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// // Here a hard-set encoding is applied (shift by 25 bits)
     /// let input = 3_u64 << 50;
     /// let noise = Variance(2_f64.powf(-50.));
     ///
@@ -35,7 +241,7 @@ impl LweCiphertextDiscardingConversionEngine<CudaLweCiphertext64, LweCiphertextM
     ///
     /// let mut cuda_engine = CudaEngine::new(())?;
     /// let d_ciphertext: CudaLweCiphertext64 = cuda_engine.convert_lwe_ciphertext(&h_ciphertext)?;
-    /// ///
+    ///
     /// // Prepares the output container
     /// let mut h_raw_output_ciphertext = vec![0_u64; lwe_dimension.0 + 1];
     /// let mut h_view_output_ciphertext: LweCiphertextMutView64 =


### PR DESCRIPTION
### Resolves:https://github.com/zama-ai/concrete-core-internal/issues/373

### Description

This adds some discarding conversion between GPU and CPU that are needed for concrete-boolean

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
