### PR TITLE
fix(cuda): update allocate_and_copy test

### DIFF
--- a/concrete-core/src/backends/cuda/private/device.rs
+++ b/concrete-core/src/backends/cuda/private/device.rs
@@ -430,17 +430,14 @@ mod tests {
         let gpu_index = GpuIndex(0);
         let stream = CudaStream::new(gpu_index).unwrap();
         stream.check_device_memory(vec.len() as u64).unwrap();
-        let ptr = stream.malloc::<u64>(vec.len() as u32);
+        let mut d_vec: CudaVec<u64> = stream.malloc::<u64>(vec.len() as u32);
         unsafe {
-            stream.copy_to_gpu(ptr, &vec);
+            stream.copy_to_gpu(&mut d_vec, &vec);
         }
         let mut empty = vec![0_u64; vec.len()];
         unsafe {
-            stream.copy_to_cpu(&mut empty, ptr);
+            stream.copy_to_cpu(&mut empty, &d_vec);
         }
         assert_eq!(vec, empty);
-        unsafe {
-            stream.drop(ptr).unwrap();
-        }
     }
 }

--- a/concrete-tasks/src/test.rs
+++ b/concrete-tasks/src/test.rs
@@ -45,6 +45,10 @@ pub fn cuda_doc_test() -> Result<(), Error> {
     cmd!(<ENV_TARGET_NATIVE> "cargo test --doc -p concrete-core --features=backend_cuda -- backends::cuda ")
 }
 
+pub fn cuda_core_test() -> Result<(), Error> {
+    cmd!(<ENV_TARGET_NATIVE> "cargo test -p concrete-core --features=backend_cuda -- backends::cuda ")
+}
+
 pub fn crates() -> Result<(), Error> {
     commons()?;
     core()?;
@@ -56,7 +60,8 @@ pub fn crates() -> Result<(), Error> {
 
 pub fn cuda() -> Result<(), Error> {
     cuda_test()?;
-    cuda_doc_test()
+    cuda_doc_test()?;
+    cuda_core_test()
 }
 
 pub fn cov_crates() -> Result<(), Error> {


### PR DESCRIPTION
### Resolves: [375](https://github.com/zama-ai/concrete-core-internal/issues/375)

### Description
Updates the allocate_and_copy private test to use CudaVec instead of pointers.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
