### PR TITLE
feat(concrete_npe): remove torus type generics

### DIFF
--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_ggsw_ciphertext_discarding_external_product.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_ggsw_ciphertext_discarding_external_product.rs
@@ -262,31 +262,34 @@ where
 {
     let k_type_id = TypeId::of::<K>();
     if k_type_id == TypeId::of::<BinaryKeyDistribution>() {
-        concrete_npe::estimate_external_product_noise_with_binary_ggsw::<T, D1, D2, BinaryKeyKind>(
+        concrete_npe::estimate_external_product_noise_with_binary_ggsw::<D1, D2, BinaryKeyKind>(
             poly_size,
             rlwe_mask_size,
             var_glwe,
             var_ggsw,
             base_log,
             level,
+            T::BITS as u32,
         )
     } else if k_type_id == TypeId::of::<TernaryKeyDistribution>() {
-        concrete_npe::estimate_external_product_noise_with_binary_ggsw::<T, D1, D2, TernaryKeyKind>(
+        concrete_npe::estimate_external_product_noise_with_binary_ggsw::<D1, D2, TernaryKeyKind>(
             poly_size,
             rlwe_mask_size,
             var_glwe,
             var_ggsw,
             base_log,
             level,
+            T::BITS as u32,
         )
     } else if k_type_id == TypeId::of::<GaussianKeyDistribution>() {
-        concrete_npe::estimate_external_product_noise_with_binary_ggsw::<T, D1, D2, GaussianKeyKind>(
+        concrete_npe::estimate_external_product_noise_with_binary_ggsw::<D1, D2, GaussianKeyKind>(
             poly_size,
             rlwe_mask_size,
             var_glwe,
             var_ggsw,
             base_log,
             level,
+            T::BITS as u32,
         )
     } else {
         panic!("Unknown key distribution encountered.")

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_ggsw_ciphertext_external_product.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_ggsw_ciphertext_external_product.rs
@@ -247,31 +247,34 @@ where
 {
     let k_type_id = TypeId::of::<K>();
     if k_type_id == TypeId::of::<BinaryKeyDistribution>() {
-        concrete_npe::estimate_external_product_noise_with_binary_ggsw::<T, D1, D2, BinaryKeyKind>(
+        concrete_npe::estimate_external_product_noise_with_binary_ggsw::<D1, D2, BinaryKeyKind>(
             poly_size,
             rlwe_mask_size,
             var_glwe,
             var_ggsw,
             base_log,
             level,
+            T::BITS as u32,
         )
     } else if k_type_id == TypeId::of::<TernaryKeyDistribution>() {
-        concrete_npe::estimate_external_product_noise_with_binary_ggsw::<T, D1, D2, TernaryKeyKind>(
+        concrete_npe::estimate_external_product_noise_with_binary_ggsw::<D1, D2, TernaryKeyKind>(
             poly_size,
             rlwe_mask_size,
             var_glwe,
             var_ggsw,
             base_log,
             level,
+            T::BITS as u32,
         )
     } else if k_type_id == TypeId::of::<GaussianKeyDistribution>() {
-        concrete_npe::estimate_external_product_noise_with_binary_ggsw::<T, D1, D2, GaussianKeyKind>(
+        concrete_npe::estimate_external_product_noise_with_binary_ggsw::<D1, D2, GaussianKeyKind>(
             poly_size,
             rlwe_mask_size,
             var_glwe,
             var_ggsw,
             base_log,
             level,
+            T::BITS as u32,
         )
     } else {
         panic!("Unknown key distribution encountered.")

--- a/concrete-core-fixture/src/fixture/glwe_ciphertexts_ggsw_ciphertext_fusing_cmux.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertexts_ggsw_ciphertext_fusing_cmux.rs
@@ -275,7 +275,7 @@ where
 {
     let k_type_id = TypeId::of::<K>();
     if k_type_id == TypeId::of::<BinaryKeyDistribution>() {
-        concrete_npe::estimate_cmux_noise_with_binary_ggsw::<T, D1, D2, D3, BinaryKeyKind>(
+        concrete_npe::estimate_cmux_noise_with_binary_ggsw::<D1, D2, D3, BinaryKeyKind>(
             glwe_mask_size,
             poly_size,
             base_log,
@@ -283,9 +283,10 @@ where
             var_output_glwe,
             var_glwe,
             var_ggsw,
+            T::BITS as u32,
         )
     } else if k_type_id == TypeId::of::<TernaryKeyDistribution>() {
-        concrete_npe::estimate_cmux_noise_with_binary_ggsw::<T, D1, D2, D3, TernaryKeyKind>(
+        concrete_npe::estimate_cmux_noise_with_binary_ggsw::<D1, D2, D3, TernaryKeyKind>(
             glwe_mask_size,
             poly_size,
             base_log,
@@ -293,9 +294,10 @@ where
             var_output_glwe,
             var_glwe,
             var_ggsw,
+            T::BITS as u32,
         )
     } else if k_type_id == TypeId::of::<GaussianKeyDistribution>() {
-        concrete_npe::estimate_cmux_noise_with_binary_ggsw::<T, D1, D2, D3, GaussianKeyKind>(
+        concrete_npe::estimate_cmux_noise_with_binary_ggsw::<D1, D2, D3, GaussianKeyKind>(
             glwe_mask_size,
             poly_size,
             base_log,
@@ -303,6 +305,7 @@ where
             var_output_glwe,
             var_glwe,
             var_ggsw,
+            T::BITS as u32,
         )
     } else {
         panic!("Unknown key distribution encountered.")

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_addition.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_addition.rs
@@ -7,7 +7,7 @@ use crate::generation::{IntegerPrecision, KeyDistributionMarker, Maker};
 use crate::raw::generation::RawUnsignedIntegers;
 use crate::raw::statistical_test::assert_noise_distribution;
 use concrete_commons::dispersion::{DispersionParameter, LogStandardDev, Variance};
-use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::numeric::{Numeric, UnsignedInteger};
 use concrete_commons::parameters::LweDimension;
 use concrete_core::prelude::{LweCiphertextDiscardingAdditionEngine, LweCiphertextEntity};
 
@@ -160,11 +160,11 @@ where
         _maker: &mut Maker,
         _repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::Criteria {
-        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<
-            Precision::Raw,
-            _,
-            _,
-        >(parameters.noise, parameters.noise);
+        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<_, _>(
+            parameters.noise,
+            parameters.noise,
+            Precision::Raw::BITS as u32,
+        );
         (predicted_variance,)
     }
 

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_1.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_1.rs
@@ -312,31 +312,34 @@ where
 {
     let k_type_id = TypeId::of::<K>();
     if k_type_id == TypeId::of::<BinaryKeyDistribution>() {
-        concrete_npe::estimate_pbs_noise::<T, D, BinaryKeyKind>(
+        concrete_npe::estimate_pbs_noise::<D, BinaryKeyKind>(
             lwe_mask_size,
             poly_size,
             rlwe_mask_size,
             base_log,
             level,
             dispersion_bsk,
+            T::BITS as u32,
         )
     } else if k_type_id == TypeId::of::<TernaryKeyDistribution>() {
-        concrete_npe::estimate_pbs_noise::<T, D, TernaryKeyKind>(
+        concrete_npe::estimate_pbs_noise::<D, TernaryKeyKind>(
             lwe_mask_size,
             poly_size,
             rlwe_mask_size,
             base_log,
             level,
             dispersion_bsk,
+            T::BITS as u32,
         )
     } else if k_type_id == TypeId::of::<GaussianKeyDistribution>() {
-        concrete_npe::estimate_pbs_noise::<T, D, GaussianKeyKind>(
+        concrete_npe::estimate_pbs_noise::<D, GaussianKeyKind>(
             lwe_mask_size,
             poly_size,
             rlwe_mask_size,
             base_log,
             level,
             dispersion_bsk,
+            T::BITS as u32,
         )
     } else {
         panic!("Unknown key distribution encountered.")

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_keyswitch.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_keyswitch.rs
@@ -264,7 +264,6 @@ where
     let k_type_id = TypeId::of::<K>();
     if k_type_id == TypeId::of::<BinaryKeyDistribution>() {
         concrete_npe::estimate_keyswitch_noise_lwe_to_glwe_with_constant_terms::<
-            T,
             D1,
             D2,
             BinaryKeyKind,
@@ -274,10 +273,10 @@ where
             dispersion_ksk,
             base_log,
             level,
+            T::BITS as u32,
         )
     } else if k_type_id == TypeId::of::<TernaryKeyDistribution>() {
         concrete_npe::estimate_keyswitch_noise_lwe_to_glwe_with_constant_terms::<
-            T,
             D1,
             D2,
             TernaryKeyKind,
@@ -287,10 +286,10 @@ where
             dispersion_ksk,
             base_log,
             level,
+            T::BITS as u32,
         )
     } else if k_type_id == TypeId::of::<GaussianKeyDistribution>() {
         concrete_npe::estimate_keyswitch_noise_lwe_to_glwe_with_constant_terms::<
-            T,
             D1,
             D2,
             GaussianKeyKind,
@@ -300,6 +299,7 @@ where
             dispersion_ksk,
             base_log,
             level,
+            T::BITS as u32,
         )
     } else {
         panic!("Unknown key distribution encountered.")

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_subtraction.rs
@@ -1,5 +1,5 @@
 use concrete_commons::dispersion::{DispersionParameter, LogStandardDev, Variance};
-use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::numeric::{Numeric, UnsignedInteger};
 use concrete_commons::parameters::LweDimension;
 use concrete_core::prelude::{LweCiphertextDiscardingSubtractionEngine, LweCiphertextEntity};
 
@@ -161,11 +161,11 @@ where
         _maker: &mut Maker,
         _repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::Criteria {
-        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<
-            Precision::Raw,
-            _,
-            _,
-        >(parameters.noise, parameters.noise);
+        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<_, _>(
+            parameters.noise,
+            parameters.noise,
+            Precision::Raw::BITS as u32,
+        );
         (predicted_variance,)
     }
 

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_addition.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_addition.rs
@@ -7,7 +7,7 @@ use crate::generation::{IntegerPrecision, KeyDistributionMarker, Maker};
 use crate::raw::generation::RawUnsignedIntegers;
 use crate::raw::statistical_test::assert_noise_distribution;
 use concrete_commons::dispersion::{DispersionParameter, LogStandardDev, Variance};
-use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::numeric::{Numeric, UnsignedInteger};
 use concrete_commons::parameters::LweDimension;
 use concrete_core::prelude::{LweCiphertextEntity, LweCiphertextFusingAdditionEngine};
 
@@ -145,11 +145,11 @@ where
         _maker: &mut Maker,
         _repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::Criteria {
-        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<
-            Precision::Raw,
-            _,
-            _,
-        >(parameters.noise, parameters.noise);
+        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<_, _>(
+            parameters.noise,
+            parameters.noise,
+            Precision::Raw::BITS as u32,
+        );
         (predicted_variance,)
     }
 

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_subtraction.rs
@@ -7,7 +7,7 @@ use crate::generation::{IntegerPrecision, KeyDistributionMarker, Maker};
 use crate::raw::generation::RawUnsignedIntegers;
 use crate::raw::statistical_test::assert_noise_distribution;
 use concrete_commons::dispersion::{DispersionParameter, LogStandardDev, Variance};
-use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::numeric::{Numeric, UnsignedInteger};
 use concrete_commons::parameters::LweDimension;
 use concrete_core::prelude::{LweCiphertextEntity, LweCiphertextFusingSubtractionEngine};
 
@@ -145,11 +145,11 @@ where
         _maker: &mut Maker,
         _repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::Criteria {
-        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<
-            Precision::Raw,
-            _,
-            _,
-        >(parameters.noise, parameters.noise);
+        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<_, _>(
+            parameters.noise,
+            parameters.noise,
+            Precision::Raw::BITS as u32,
+        );
         (predicted_variance,)
     }
 

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_addition.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_addition.rs
@@ -1,5 +1,5 @@
 use concrete_commons::dispersion::{DispersionParameter, LogStandardDev, Variance};
-use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::numeric::{Numeric, UnsignedInteger};
 use concrete_commons::parameters::LweDimension;
 use concrete_core::prelude::{
     LweCiphertextCount, LweCiphertextVectorDiscardingAdditionEngine, LweCiphertextVectorEntity,
@@ -221,11 +221,11 @@ where
         _maker: &mut Maker,
         _repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::Criteria {
-        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<
-            Precision::Raw,
-            _,
-            _,
-        >(parameters.noise, parameters.noise);
+        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<_, _>(
+            parameters.noise,
+            parameters.noise,
+            Precision::Raw::BITS as u32,
+        );
         (predicted_variance,)
     }
 

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_subtraction.rs
@@ -1,5 +1,5 @@
 use concrete_commons::dispersion::{DispersionParameter, LogStandardDev, Variance};
-use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::numeric::{Numeric, UnsignedInteger};
 use concrete_commons::parameters::LweDimension;
 use concrete_core::prelude::{
     LweCiphertextCount, LweCiphertextVectorDiscardingSubtractionEngine, LweCiphertextVectorEntity,
@@ -223,11 +223,11 @@ where
         _maker: &mut Maker,
         _repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::Criteria {
-        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<
-            Precision::Raw,
-            _,
-            _,
-        >(parameters.noise, parameters.noise);
+        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<_, _>(
+            parameters.noise,
+            parameters.noise,
+            Precision::Raw::BITS as u32,
+        );
         (predicted_variance,)
     }
 

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_fusing_addition.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_fusing_addition.rs
@@ -1,5 +1,5 @@
 use concrete_commons::dispersion::{DispersionParameter, LogStandardDev, Variance};
-use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::numeric::{Numeric, UnsignedInteger};
 use concrete_commons::parameters::LweDimension;
 use concrete_core::prelude::{
     LweCiphertextCount, LweCiphertextVectorEntity, LweCiphertextVectorFusingAdditionEngine,
@@ -185,11 +185,11 @@ where
         _maker: &mut Maker,
         _repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::Criteria {
-        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<
-            Precision::Raw,
-            _,
-            _,
-        >(parameters.noise, parameters.noise);
+        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<_, _>(
+            parameters.noise,
+            parameters.noise,
+            Precision::Raw::BITS as u32,
+        );
         (predicted_variance,)
     }
 

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_fusing_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_fusing_subtraction.rs
@@ -1,5 +1,5 @@
 use concrete_commons::dispersion::{DispersionParameter, LogStandardDev, Variance};
-use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::numeric::{Numeric, UnsignedInteger};
 use concrete_commons::parameters::LweDimension;
 use concrete_core::prelude::{
     LweCiphertextCount, LweCiphertextVectorEntity, LweCiphertextVectorFusingSubtractionEngine,
@@ -186,11 +186,11 @@ where
         _maker: &mut Maker,
         _repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::Criteria {
-        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<
-            Precision::Raw,
-            _,
-            _,
-        >(parameters.noise, parameters.noise);
+        let predicted_variance: Variance = concrete_npe::estimate_addition_noise::<_, _>(
+            parameters.noise,
+            parameters.noise,
+            Precision::Raw::BITS as u32,
+        );
         (predicted_variance,)
     }
 

--- a/concrete-core/src/commons/crypto/gsw/tests.rs
+++ b/concrete-core/src/commons/crypto/gsw/tests.rs
@@ -78,13 +78,14 @@ fn test_external_product_gsw<T: UnsignedTorus>() {
 
     // call the NPE to find the theoretical amount of noise after the bootstrap
     let output_variance =
-        npe::estimate_external_product_noise_with_binary_ggsw::<T, _, _, BinaryKeyKind>(
+        npe::estimate_external_product_noise_with_binary_ggsw::<_, _, BinaryKeyKind>(
             PolynomialSize(1),
             GlweDimension(dimension.0),
             Variance(f64::powi(std_dev.get_standard_dev(), 2)),
             Variance(f64::powi(std_dev.get_standard_dev(), 2)),
             base_log,
             level,
+            T::BITS as u32,
         );
     // we check that the obtain distribution is the same
     // as the theoretical one
@@ -144,7 +145,7 @@ fn test_cmux_0_gsw<T: UnsignedTorus>() {
     }
 
     // call the NPE to find the theoretical amount of noise after the cmux
-    let output_variance = npe::estimate_cmux_noise_with_binary_ggsw::<T, _, _, _, BinaryKeyKind>(
+    let output_variance = npe::estimate_cmux_noise_with_binary_ggsw::<_, _, _, BinaryKeyKind>(
         GlweDimension(dimension.0),
         PolynomialSize(1),
         base_log,
@@ -152,6 +153,7 @@ fn test_cmux_0_gsw<T: UnsignedTorus>() {
         Variance(f64::powi(std_dev.get_standard_dev(), 2)),
         Variance(f64::powi(std_dev.get_standard_dev(), 2)),
         Variance(f64::powi(std_dev.get_standard_dev(), 2)),
+        T::BITS as u32,
     );
     // we check that the obtain distribution is the same
     // as the theoretical one
@@ -211,7 +213,7 @@ fn test_cmux_1_gsw<T: UnsignedTorus>() {
     }
 
     // call the NPE to find the theoretical amount of noise after the bootstrap
-    let output_variance = npe::estimate_cmux_noise_with_binary_ggsw::<T, _, _, _, BinaryKeyKind>(
+    let output_variance = npe::estimate_cmux_noise_with_binary_ggsw::<_, _, _, BinaryKeyKind>(
         GlweDimension(dimension.0),
         PolynomialSize(1),
         base_log,
@@ -219,6 +221,7 @@ fn test_cmux_1_gsw<T: UnsignedTorus>() {
         Variance(f64::powi(std_dev.get_standard_dev(), 2)),
         Variance(f64::powi(std_dev.get_standard_dev(), 2)),
         Variance(f64::powi(std_dev.get_standard_dev(), 2)),
+        T::BITS as u32,
     );
     // we check that the obtain distribution is the same
     // as the theoretical one

--- a/concrete-npe/src/key_dispersion.rs
+++ b/concrete-npe/src/key_dispersion.rs
@@ -6,7 +6,6 @@ use concrete_commons::parameters::PolynomialSize;
 
 use super::*;
 use concrete_commons::key_kinds::*;
-use concrete_commons::numeric::UnsignedInteger;
 
 // The Gaussian secret keys have modular standard deviation set to 3.2 by default.
 const GAUSSIAN_MODULAR_STDEV: f64 = 3.2;
@@ -21,15 +20,13 @@ pub trait KeyDispersion: KeyKind {
     /// use concrete_commons::key_kinds::*;
     /// use concrete_npe::*;
     ///
-    /// type ui = u64;
-    ///
     /// let var_out_1 =
-    ///     Variance::get_modular_variance::<ui>(&GaussianKeyKind::variance_key_coefficient::<ui>());
+    ///     Variance::get_modular_variance(&GaussianKeyKind::variance_key_coefficient(64), 64);
     /// let expected_var_out_1 = 10.24;
     /// println!("{}", var_out_1);
     /// assert!((expected_var_out_1 - var_out_1).abs() < 0.0001);
     /// ```
-    fn variance_key_coefficient<T: UnsignedInteger>() -> Variance;
+    fn variance_key_coefficient(log2_modulus: u32) -> Variance;
 
     /// Returns the expectation of key coefficients.
     /// # Example
@@ -54,16 +51,13 @@ pub trait KeyDispersion: KeyKind {
     /// use concrete_commons::key_kinds::*;
     /// use concrete_npe::*;
     ///
-    /// type ui = u64;
-    ///
-    /// let var_out_2 = Variance::get_modular_variance::<ui>(
-    ///     &TernaryKeyKind::variance_key_coefficient_squared::<ui>(),
-    /// );
+    /// let var_out_2 =
+    ///     Variance::get_modular_variance(&TernaryKeyKind::variance_key_coefficient_squared(64), 64);
     /// let expected_var_out_2 = 0.2222;
     /// println!("{}", var_out_2);
     /// assert!((expected_var_out_2 - var_out_2).abs() < 0.0001);
     /// ```
-    fn variance_key_coefficient_squared<T: UnsignedInteger>() -> Variance;
+    fn variance_key_coefficient_squared(log2_modulus: u32) -> Variance;
 
     /// Returns the expectation of the squared key coefficients.
     /// # Example
@@ -72,14 +66,12 @@ pub trait KeyDispersion: KeyKind {
     /// use concrete_commons::key_kinds::*;
     /// use concrete_npe::*;
     ///
-    /// type ui = u64;
-    ///
-    /// let expect_out_2 = GaussianKeyKind::expectation_key_coefficient_squared::<ui>();
+    /// let expect_out_2 = GaussianKeyKind::expectation_key_coefficient_squared(64);
     /// let expected_expect_out_2 = 10.24;
     /// println!("{}", expect_out_2);
     /// assert!((expected_expect_out_2 - expect_out_2).abs() < 0.0001);
     /// ```
-    fn expectation_key_coefficient_squared<T: UnsignedInteger>() -> f64;
+    fn expectation_key_coefficient_squared(log2_modulus: u32) -> f64;
 
     /// Returns the variance of the odd coefficients of a polynomial key to the square.
     /// # Example
@@ -89,18 +81,19 @@ pub trait KeyDispersion: KeyKind {
     /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_npe::*;
     ///
-    /// type ui = u64;
     /// let polynomial_size = PolynomialSize(1024);
     ///
-    /// let var_odd_out_3 = Variance::get_modular_variance::<ui>(
-    ///     &TernaryKeyKind::variance_odd_coefficient_in_polynomial_key_squared::<ui>(polynomial_size),
+    /// let var_odd_out_3 = Variance::get_modular_variance(
+    ///     &TernaryKeyKind::variance_odd_coefficient_in_polynomial_key_squared(polynomial_size, 64),
+    ///     64,
     /// );
     /// let expected_var_odd_out_3 = 910.2222;
     /// println!("{}", var_odd_out_3);
     /// assert!((expected_var_odd_out_3 - var_odd_out_3).abs() < 0.0001);
     /// ```
-    fn variance_odd_coefficient_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn variance_odd_coefficient_in_polynomial_key_squared(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> Variance;
 
     /// Returns the variance of the even coefficients of a polynomial key to the square
@@ -111,18 +104,19 @@ pub trait KeyDispersion: KeyKind {
     /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_npe::*;
     ///
-    /// type ui = u64;
     /// let polynomial_size = PolynomialSize(1024);
     ///
-    /// let var_even_out_3 = Variance::get_modular_variance::<ui>(
-    ///     &BinaryKeyKind::variance_even_coefficient_in_polynomial_key_squared::<ui>(polynomial_size),
+    /// let var_even_out_3 = Variance::get_modular_variance(
+    ///     &BinaryKeyKind::variance_even_coefficient_in_polynomial_key_squared(polynomial_size, 64),
+    ///     64,
     /// );
     /// let expected_var_even_out_3 = 383.75;
     /// println!("{}", var_even_out_3);
     /// assert!((expected_var_even_out_3 - var_even_out_3).abs() < 0.0001);
     /// ```
-    fn variance_even_coefficient_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn variance_even_coefficient_in_polynomial_key_squared(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> Variance;
 
     /// Returns the mean expectation of the coefficients of a polynomial key to the square.
@@ -133,17 +127,17 @@ pub trait KeyDispersion: KeyKind {
     /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_npe::*;
     ///
-    /// type ui = u64;
     /// let polynomial_size = PolynomialSize(1024);
     ///
     /// let expect_out_3 =
-    ///     GaussianKeyKind::squared_expectation_mean_in_polynomial_key_squared::<ui>(polynomial_size);
+    ///     GaussianKeyKind::squared_expectation_mean_in_polynomial_key_squared(polynomial_size, 64);
     /// let expected_expect_out_3 = 0.0;
     /// println!("{}", expect_out_3);
     /// assert!((expected_expect_out_3 - expect_out_3).abs() < 0.0001);
     /// ```
-    fn squared_expectation_mean_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn squared_expectation_mean_in_polynomial_key_squared(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> f64;
 
     /// Returns the variance of the
@@ -156,18 +150,19 @@ pub trait KeyDispersion: KeyKind {
     /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_npe::*;
     ///
-    /// type ui = u64;
     /// let polynomial_size = PolynomialSize(1024);
     ///
-    /// let var_out_4 = Variance::get_modular_variance::<ui>(
-    ///     &ZeroKeyKind::variance_coefficient_in_polynomial_key_times_key::<ui>(polynomial_size),
+    /// let var_out_4 = Variance::get_modular_variance(
+    ///     &ZeroKeyKind::variance_coefficient_in_polynomial_key_times_key(polynomial_size, 64),
+    ///     64,
     /// );
     /// let expected_var_out_4 = 0.0;
     /// println!("{}", var_out_4);
     /// assert!((expected_var_out_4 - var_out_4).abs() < 0.0001);
     /// ```
-    fn variance_coefficient_in_polynomial_key_times_key<T: UnsignedInteger>(
+    fn variance_coefficient_in_polynomial_key_times_key(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> Variance;
 
     /// Returns the mean expectation of
@@ -195,53 +190,61 @@ pub trait KeyDispersion: KeyKind {
 /// Implementations are provided for binary, ternary and Gaussian key kinds.
 /// The ZeroKeyKind is only for debug purposes.
 impl KeyDispersion for BinaryKeyKind {
-    fn variance_key_coefficient<T: UnsignedInteger>() -> Variance {
-        Variance::from_modular_variance::<T>(1. / 4.)
+    fn variance_key_coefficient(log2_modulus: u32) -> Variance {
+        Variance::from_modular_variance(1. / 4., log2_modulus)
     }
     fn expectation_key_coefficient() -> f64 {
         1. / 2.
     }
-    fn variance_key_coefficient_squared<T: UnsignedInteger>() -> Variance {
-        Variance::from_modular_variance::<T>(1. / 4.)
+    fn variance_key_coefficient_squared(log2_modulus: u32) -> Variance {
+        Variance::from_modular_variance(1. / 4., log2_modulus)
     }
-    fn expectation_key_coefficient_squared<T: UnsignedInteger>() -> f64 {
+    fn expectation_key_coefficient_squared(_log2_modulus: u32) -> f64 {
         1. / 2.
     }
-    fn variance_odd_coefficient_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn variance_odd_coefficient_in_polynomial_key_squared(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> Variance {
         if poly_size.0 == 1 {
-            Variance::from_modular_variance::<T>(0.)
+            Variance::from_modular_variance(0., log2_modulus)
         } else {
-            Variance::from_modular_variance::<T>(3. * (poly_size.0 as f64) / 8.)
+            Variance::from_modular_variance(3. * (poly_size.0 as f64) / 8., log2_modulus)
         }
     }
-    fn variance_even_coefficient_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn variance_even_coefficient_in_polynomial_key_squared(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> Variance {
         if poly_size.0 == 1 {
-            Variance::from_modular_variance::<T>(
-                2. * Variance::get_modular_variance::<T>(
-                    &BinaryKeyKind::variance_key_coefficient_squared::<T>(),
+            Variance::from_modular_variance(
+                2. * Variance::get_modular_variance(
+                    &BinaryKeyKind::variance_key_coefficient_squared(log2_modulus),
+                    log2_modulus,
                 ),
+                log2_modulus,
             )
         } else {
-            Variance::from_modular_variance::<T>(((3 * poly_size.0 - 2) as f64) / 8.)
+            Variance::from_modular_variance(((3 * poly_size.0 - 2) as f64) / 8., log2_modulus)
         }
     }
-    fn squared_expectation_mean_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn squared_expectation_mean_in_polynomial_key_squared(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> f64 {
         if poly_size.0 == 1 {
-            square(BinaryKeyKind::expectation_key_coefficient_squared::<T>())
+            square(BinaryKeyKind::expectation_key_coefficient_squared(
+                log2_modulus,
+            ))
         } else {
             (square(poly_size.0 as f64) + 2.) / 48.
         }
     }
-    fn variance_coefficient_in_polynomial_key_times_key<T: UnsignedInteger>(
+    fn variance_coefficient_in_polynomial_key_times_key(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> Variance {
-        Variance::from_modular_variance::<T>(3. * (poly_size.0 as f64) / 16.)
+        Variance::from_modular_variance(3. * (poly_size.0 as f64) / 16., log2_modulus)
     }
     fn square_expectation_mean_in_polynomial_key_times_key(poly_size: PolynomialSize) -> f64 {
         (square(poly_size.0 as f64) + 2.) / 48.
@@ -249,53 +252,61 @@ impl KeyDispersion for BinaryKeyKind {
 }
 
 impl KeyDispersion for TernaryKeyKind {
-    fn variance_key_coefficient<T: UnsignedInteger>() -> Variance {
-        Variance::from_modular_variance::<T>(2. / 3.)
+    fn variance_key_coefficient(log2_modulus: u32) -> Variance {
+        Variance::from_modular_variance(2. / 3., log2_modulus)
     }
     fn expectation_key_coefficient() -> f64 {
         0.
     }
-    fn variance_key_coefficient_squared<T: UnsignedInteger>() -> Variance {
-        Variance::from_modular_variance::<T>(2. / 9.)
+    fn variance_key_coefficient_squared(log2_modulus: u32) -> Variance {
+        Variance::from_modular_variance(2. / 9., log2_modulus)
     }
-    fn expectation_key_coefficient_squared<T: UnsignedInteger>() -> f64 {
+    fn expectation_key_coefficient_squared(_log2_modulus: u32) -> f64 {
         2. / 3.
     }
-    fn variance_odd_coefficient_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn variance_odd_coefficient_in_polynomial_key_squared(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> Variance {
         if poly_size.0 == 1 {
-            Variance::from_modular_variance::<T>(0.)
+            Variance::from_modular_variance(0., log2_modulus)
         } else {
-            Variance::from_modular_variance::<T>(8. * (poly_size.0 as f64) / 9.)
+            Variance::from_modular_variance(8. * (poly_size.0 as f64) / 9., log2_modulus)
         }
     }
-    fn variance_even_coefficient_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn variance_even_coefficient_in_polynomial_key_squared(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> Variance {
         if poly_size.0 == 1 {
-            Variance::from_modular_variance::<T>(
-                2. * Variance::get_modular_variance::<T>(
-                    &TernaryKeyKind::variance_key_coefficient_squared::<T>(),
+            Variance::from_modular_variance(
+                2. * Variance::get_modular_variance(
+                    &TernaryKeyKind::variance_key_coefficient_squared(log2_modulus),
+                    log2_modulus,
                 ),
+                log2_modulus,
             )
         } else {
-            Variance::from_modular_variance::<T>(4. * ((2 * poly_size.0 - 3) as f64) / 9.)
+            Variance::from_modular_variance(4. * ((2 * poly_size.0 - 3) as f64) / 9., log2_modulus)
         }
     }
-    fn squared_expectation_mean_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn squared_expectation_mean_in_polynomial_key_squared(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> f64 {
         if poly_size.0 == 1 {
-            square(TernaryKeyKind::expectation_key_coefficient_squared::<T>())
+            square(TernaryKeyKind::expectation_key_coefficient_squared(
+                log2_modulus,
+            ))
         } else {
             0.
         }
     }
-    fn variance_coefficient_in_polynomial_key_times_key<T: UnsignedInteger>(
+    fn variance_coefficient_in_polynomial_key_times_key(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> Variance {
-        Variance::from_modular_variance::<T>(4. * (poly_size.0 as f64) / 9.)
+        Variance::from_modular_variance(4. * (poly_size.0 as f64) / 9., log2_modulus)
     }
     fn square_expectation_mean_in_polynomial_key_times_key(_poly_size: PolynomialSize) -> f64 {
         0.
@@ -303,70 +314,89 @@ impl KeyDispersion for TernaryKeyKind {
 }
 
 impl KeyDispersion for GaussianKeyKind {
-    fn variance_key_coefficient<T: UnsignedInteger>() -> Variance {
-        Variance::from_modular_variance::<T>(square(GAUSSIAN_MODULAR_STDEV))
+    fn variance_key_coefficient(log2_modulus: u32) -> Variance {
+        Variance::from_modular_variance(square(GAUSSIAN_MODULAR_STDEV), log2_modulus)
     }
     fn expectation_key_coefficient() -> f64 {
         0.
     }
-    fn variance_key_coefficient_squared<T: UnsignedInteger>() -> Variance {
-        Variance::from_modular_variance::<T>(
-            2. * square(Variance::get_modular_variance::<T>(
-                &GaussianKeyKind::variance_key_coefficient::<T>(),
+    fn variance_key_coefficient_squared(log2_modulus: u32) -> Variance {
+        Variance::from_modular_variance(
+            2. * square(Variance::get_modular_variance(
+                &GaussianKeyKind::variance_key_coefficient(log2_modulus),
+                log2_modulus,
             )),
+            log2_modulus,
         )
     }
-    fn expectation_key_coefficient_squared<T: UnsignedInteger>() -> f64 {
-        Variance::get_modular_variance::<T>(&GaussianKeyKind::variance_key_coefficient::<T>())
+    fn expectation_key_coefficient_squared(log2_modulus: u32) -> f64 {
+        Variance::get_modular_variance(
+            &GaussianKeyKind::variance_key_coefficient(log2_modulus),
+            log2_modulus,
+        )
     }
-    fn variance_odd_coefficient_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn variance_odd_coefficient_in_polynomial_key_squared(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> Variance {
         if poly_size.0 == 1 {
-            Variance::from_modular_variance::<T>(0.)
+            Variance::from_modular_variance(0., log2_modulus)
         } else {
-            Variance::from_modular_variance::<T>(
+            Variance::from_modular_variance(
                 2. * (poly_size.0 as f64)
-                    * square(Variance::get_modular_variance::<T>(
-                        &GaussianKeyKind::variance_key_coefficient::<T>(),
+                    * square(Variance::get_modular_variance(
+                        &GaussianKeyKind::variance_key_coefficient(log2_modulus),
+                        log2_modulus,
                     )),
+                log2_modulus,
             )
         }
     }
-    fn variance_even_coefficient_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn variance_even_coefficient_in_polynomial_key_squared(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> Variance {
         if poly_size.0 == 1 {
-            Variance::from_modular_variance::<T>(
-                2. * Variance::get_modular_variance::<T>(
-                    &GaussianKeyKind::variance_key_coefficient_squared::<T>(),
+            Variance::from_modular_variance(
+                2. * Variance::get_modular_variance(
+                    &GaussianKeyKind::variance_key_coefficient_squared(log2_modulus),
+                    log2_modulus,
                 ),
+                log2_modulus,
             )
         } else {
-            Variance::from_modular_variance::<T>(
+            Variance::from_modular_variance(
                 2. * (poly_size.0 as f64)
-                    * square(Variance::get_modular_variance::<T>(
-                        &GaussianKeyKind::variance_key_coefficient::<T>(),
+                    * square(Variance::get_modular_variance(
+                        &GaussianKeyKind::variance_key_coefficient(log2_modulus),
+                        log2_modulus,
                     )),
+                log2_modulus,
             )
         }
     }
-    fn squared_expectation_mean_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn squared_expectation_mean_in_polynomial_key_squared(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> f64 {
         if poly_size.0 == 1 {
-            square(GaussianKeyKind::expectation_key_coefficient_squared::<T>())
+            square(GaussianKeyKind::expectation_key_coefficient_squared(
+                log2_modulus,
+            ))
         } else {
             0.
         }
     }
-    fn variance_coefficient_in_polynomial_key_times_key<T: UnsignedInteger>(
+    fn variance_coefficient_in_polynomial_key_times_key(
         poly_size: PolynomialSize,
+        log2_modulus: u32,
     ) -> Variance {
-        Variance::from_modular_variance::<T>(
-            square(Variance::get_modular_variance::<T>(
-                &GaussianKeyKind::variance_key_coefficient::<T>(),
+        Variance::from_modular_variance(
+            square(Variance::get_modular_variance(
+                &GaussianKeyKind::variance_key_coefficient(log2_modulus),
+                log2_modulus,
             )) * (poly_size.0 as f64),
+            log2_modulus,
         )
     }
     fn square_expectation_mean_in_polynomial_key_times_key(_poly_size: PolynomialSize) -> f64 {
@@ -375,37 +405,41 @@ impl KeyDispersion for GaussianKeyKind {
 }
 
 impl KeyDispersion for ZeroKeyKind {
-    fn variance_key_coefficient<T: UnsignedInteger>() -> Variance {
-        Variance::from_modular_variance::<T>(0.)
+    fn variance_key_coefficient(log2_modulus: u32) -> Variance {
+        Variance::from_modular_variance(0., log2_modulus)
     }
     fn expectation_key_coefficient() -> f64 {
         0.
     }
-    fn variance_key_coefficient_squared<T: UnsignedInteger>() -> Variance {
-        Variance::from_modular_variance::<T>(0.)
+    fn variance_key_coefficient_squared(log2_modulus: u32) -> Variance {
+        Variance::from_modular_variance(0., log2_modulus)
     }
-    fn expectation_key_coefficient_squared<T: UnsignedInteger>() -> f64 {
+    fn expectation_key_coefficient_squared(_log2_modulus: u32) -> f64 {
         0.
     }
-    fn variance_odd_coefficient_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn variance_odd_coefficient_in_polynomial_key_squared(
         _poly_size: PolynomialSize,
+        _log2_modulus: u32,
     ) -> Variance {
-        Variance::from_modular_variance::<T>(0.)
+        Variance(0.)
     }
-    fn variance_even_coefficient_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn variance_even_coefficient_in_polynomial_key_squared(
         _poly_size: PolynomialSize,
+        _log2_modulus: u32,
     ) -> Variance {
-        Variance::from_modular_variance::<T>(0.)
+        Variance(0.)
     }
-    fn squared_expectation_mean_in_polynomial_key_squared<T: UnsignedInteger>(
+    fn squared_expectation_mean_in_polynomial_key_squared(
         _poly_size: PolynomialSize,
+        _log2_modulus: u32,
     ) -> f64 {
         0.
     }
-    fn variance_coefficient_in_polynomial_key_times_key<T: UnsignedInteger>(
+    fn variance_coefficient_in_polynomial_key_times_key(
         _poly_size: PolynomialSize,
+        _log2_modulus: u32,
     ) -> Variance {
-        Variance::from_modular_variance::<T>(0.)
+        Variance(0.)
     }
     fn square_expectation_mean_in_polynomial_key_times_key(_poly_size: PolynomialSize) -> f64 {
         0.

--- a/concrete-npe/src/lib.rs
+++ b/concrete-npe/src/lib.rs
@@ -28,7 +28,7 @@
 //! //We call the npe to estimate characteristics of the noise after an addition
 //! //between these two variances.
 //! //Here, we assume that ciphertexts are encoded over 64 bits.
-//! let var_out = estimate_addition_noise::<u64, _, _>(var1, var2);
+//! let var_out = estimate_addition_noise::<_, _>(var1, var2, 64);
 //! println!("Expect Variance (2^24) =  {}", 2_f64.powi(-24));
 //! println!("Output Variance {}", var_out.get_variance());
 //! assert!((2_f64.powi(-24) - var_out.get_variance()).abs() < 0.0001);

--- a/concrete-npe/src/operators.rs
+++ b/concrete-npe/src/operators.rs
@@ -16,21 +16,24 @@ use super::*;
 /// use concrete_npe::estimate_addition_noise;
 /// let var1 = Variance(2_f64.powf(-25.));
 /// let var2 = Variance(2_f64.powf(-25.));
-/// let var_out = estimate_addition_noise::<u64, _, _>(var1, var2);
+/// let var_out = estimate_addition_noise::<_, _>(var1, var2, 64);
 /// println!("Expect Variance (2^24) =  {}", 2_f64.powi(-24));
 /// println!("Output Variance {}", var_out.get_variance());
 /// assert!((2_f64.powi(-24) - var_out.get_variance()).abs() < 0.0001);
 /// ```
-pub fn estimate_addition_noise<T, D1, D2>(dispersion_ct1: D1, dispersion_ct2: D2) -> Variance
+pub fn estimate_addition_noise<D1, D2>(
+    dispersion_ct1: D1,
+    dispersion_ct2: D2,
+    log2_modulus: u32,
+) -> Variance
 where
-    T: UnsignedInteger,
     D1: DispersionParameter,
     D2: DispersionParameter,
 {
     // The result variance is equal to the sum of the input variances
-    let var_res: f64 =
-        dispersion_ct1.get_modular_variance::<T>() + dispersion_ct2.get_modular_variance::<T>();
-    Variance::from_modular_variance::<T>(var_res)
+    let var_res: f64 = dispersion_ct1.get_modular_variance(log2_modulus)
+        + dispersion_ct2.get_modular_variance(log2_modulus);
+    Variance::from_modular_variance(var_res, log2_modulus)
 }
 
 /// Computes the dispersion of an addition of
@@ -43,22 +46,21 @@ where
 /// let var2 = Variance(2_f64.powf(-25.));
 /// let var3 = Variance(2_f64.powf(-24.));
 /// let var_in = [var1, var2, var3];
-/// let var_out = estimate_several_additions_noise::<u64, _>(&var_in);
+/// let var_out = estimate_several_additions_noise::<_>(&var_in, 64);
 /// println!("Expect Variance (2^24) =  {}", 2_f64.powi(-23));
 /// println!("Output Variance {}", var_out.get_variance());
 /// assert!((2_f64.powi(-23) - var_out.get_variance()).abs() < 0.0001);
 /// ```
-pub fn estimate_several_additions_noise<T, D>(dispersion_cts: &[D]) -> Variance
+pub fn estimate_several_additions_noise<D>(dispersion_cts: &[D], log2_modulus: u32) -> Variance
 where
-    T: UnsignedInteger,
     D: DispersionParameter,
 {
     let mut var_res: f64 = 0.;
     // The result variance is equal to the sum of the input variances
     for dispersion in dispersion_cts.iter() {
-        var_res += dispersion.get_modular_variance::<T>();
+        var_res += dispersion.get_modular_variance(log2_modulus);
     }
-    Variance::from_modular_variance::<T>(var_res)
+    Variance::from_modular_variance(var_res, log2_modulus)
 }
 
 /// Computes the dispersion of a multiplication
@@ -147,13 +149,13 @@ where
 /// use concrete_npe::estimate_tensor_product_noise;
 /// let dimension = GlweDimension(3);
 /// let polynomial_size = PolynomialSize(1024);
-/// let dispersion_rlwe_0 = Variance::from_modular_variance::<u64>(2_f64.powi(24));
-/// let dispersion_rlwe_1 = Variance::from_modular_variance::<u64>(2_f64.powi(24));
+/// let dispersion_rlwe_0 = Variance::from_modular_variance(2_f64.powi(24), 64);
+/// let dispersion_rlwe_1 = Variance::from_modular_variance(2_f64.powi(24), 64);
 /// let delta_1 = 2_f64.powi(40);
 /// let delta_2 = 2_f64.powi(42);
 /// let max_msg_1 = 15.;
 /// let max_msg_2 = 7.;
-/// let var_out = estimate_tensor_product_noise::<u64, _, _, BinaryKeyKind>(
+/// let var_out = estimate_tensor_product_noise::<_, _, BinaryKeyKind>(
 ///     polynomial_size,
 ///     dimension,
 ///     dispersion_rlwe_0,
@@ -162,10 +164,11 @@ where
 ///     delta_2,
 ///     max_msg_1,
 ///     max_msg_2,
+///     64,
 /// );
 /// ```
 #[allow(clippy::too_many_arguments)]
-pub fn estimate_tensor_product_noise<T, D1, D2, K>(
+pub fn estimate_tensor_product_noise<D1, D2, K>(
     poly_size: PolynomialSize,
     rlwe_dimension: GlweDimension,
     dispersion_glwe1: D1,
@@ -174,9 +177,9 @@ pub fn estimate_tensor_product_noise<T, D1, D2, K>(
     delta_2: f64,
     max_msg_1: f64,
     max_msg_2: f64,
+    log2_modulus: u32,
 ) -> Variance
 where
-    T: UnsignedInteger,
     D1: DispersionParameter,
     D2: DispersionParameter,
     K: KeyDispersion,
@@ -186,26 +189,33 @@ where
     let k = rlwe_dimension.0 as f64;
     let delta = f64::min(delta_1, delta_2);
     let delta_square = square(delta);
-    let q_square = 2_f64.powi((2 * T::BITS) as i32);
+    let q_square = 2_f64.powi((2 * log2_modulus) as i32);
     // #1
     let res_1 = big_n / delta_square
-        * (dispersion_glwe1.get_modular_variance::<T>() * square(delta_2) * square(max_msg_2)
-            + dispersion_glwe2.get_modular_variance::<T>() * square(delta_1) * square(max_msg_1)
-            + dispersion_glwe1.get_modular_variance::<T>()
-                * dispersion_glwe2.get_modular_variance::<T>());
+        * (dispersion_glwe1.get_modular_variance(log2_modulus)
+            * square(delta_2)
+            * square(max_msg_2)
+            + dispersion_glwe2.get_modular_variance(log2_modulus)
+                * square(delta_1)
+                * square(max_msg_1)
+            + dispersion_glwe1.get_modular_variance(log2_modulus)
+                * dispersion_glwe2.get_modular_variance(log2_modulus));
 
     // #2
     let res_2 = (
         // 1ere parenthese
         (q_square - 1.) / 12.
             * (1.
-                + k * big_n * K::variance_key_coefficient::<T>().get_modular_variance::<T>()
+                + k * big_n
+                    * K::variance_key_coefficient(log2_modulus).get_modular_variance(log2_modulus)
                 + k * big_n * square(K::expectation_key_coefficient()))
-            + k * big_n / 4. * K::variance_key_coefficient::<T>().get_modular_variance::<T>()
+            + k * big_n / 4.
+                * K::variance_key_coefficient(log2_modulus).get_modular_variance(log2_modulus)
             + 1. / 4. * square(1. + k * big_n * K::expectation_key_coefficient())
     ) * (
         // 2e parenthese
-        dispersion_glwe1.get_modular_variance::<T>() + dispersion_glwe2.get_modular_variance::<T>()
+        dispersion_glwe1.get_modular_variance(log2_modulus)
+            + dispersion_glwe2.get_modular_variance(log2_modulus)
     ) * big_n
         / delta_square;
 
@@ -213,29 +223,45 @@ where
     let res_3 = 1. / 12.
         + k * big_n / (12. * delta_square)
             * ((delta_square - 1.)
-                * (K::variance_key_coefficient::<T>().get_modular_variance::<T>()
+                * (K::variance_key_coefficient(log2_modulus).get_modular_variance(log2_modulus)
                     + square(K::expectation_key_coefficient()))
-                + 3. * K::variance_key_coefficient::<T>().get_modular_variance::<T>())
+                + 3. * K::variance_key_coefficient(log2_modulus)
+                    .get_modular_variance(log2_modulus))
         + k * (k - 1.) * big_n / (24. * delta_square)
             * ((delta_square - 1.)
-                * (K::variance_coefficient_in_polynomial_key_times_key::<T>(poly_size)
-                    .get_modular_variance::<T>()
+                * (K::variance_coefficient_in_polynomial_key_times_key(poly_size, log2_modulus)
+                    .get_modular_variance(log2_modulus)
                     + K::square_expectation_mean_in_polynomial_key_times_key(poly_size))
-                + 3. * K::variance_coefficient_in_polynomial_key_times_key::<T>(poly_size)
-                    .get_modular_variance::<T>())
+                + 3. * K::variance_coefficient_in_polynomial_key_times_key(
+                    poly_size,
+                    log2_modulus,
+                )
+                .get_modular_variance(log2_modulus))
         + k * big_n / (24. * delta_square)
             * ((delta_square - 1.)
-                * (K::variance_odd_coefficient_in_polynomial_key_squared::<T>(poly_size)
-                    .get_modular_variance::<T>()
-                    + K::variance_even_coefficient_in_polynomial_key_squared::<T>(poly_size)
-                        .get_modular_variance::<T>()
-                    + 2. * K::squared_expectation_mean_in_polynomial_key_squared::<T>(poly_size))
-                + 3. * (K::variance_odd_coefficient_in_polynomial_key_squared::<T>(poly_size)
-                    .get_modular_variance::<T>()
-                    + K::variance_even_coefficient_in_polynomial_key_squared::<T>(poly_size)
-                        .get_modular_variance::<T>()));
+                * (K::variance_odd_coefficient_in_polynomial_key_squared(poly_size, log2_modulus)
+                    .get_modular_variance(log2_modulus)
+                    + K::variance_even_coefficient_in_polynomial_key_squared(
+                        poly_size,
+                        log2_modulus,
+                    )
+                    .get_modular_variance(log2_modulus)
+                    + 2. * K::squared_expectation_mean_in_polynomial_key_squared(
+                        poly_size,
+                        log2_modulus,
+                    ))
+                + 3. * (K::variance_odd_coefficient_in_polynomial_key_squared(
+                    poly_size,
+                    log2_modulus,
+                )
+                .get_modular_variance(log2_modulus)
+                    + K::variance_even_coefficient_in_polynomial_key_squared(
+                        poly_size,
+                        log2_modulus,
+                    )
+                    .get_modular_variance(log2_modulus)));
 
-    Variance::from_modular_variance::<T>(res_2 + res_1 + res_3)
+    Variance::from_modular_variance(res_2 + res_1 + res_3, log2_modulus)
 }
 
 /// Computes the dispersion of a GLWE after relinearization.
@@ -252,23 +278,24 @@ where
 /// let base_log = DecompositionBaseLog(7);
 /// let polynomial_size = PolynomialSize(1024);
 /// let dispersion_rlk = Variance(2_f64.powi(-38));
-/// let var_cmux = estimate_relinearization_noise::<u64, _, BinaryKeyKind>(
+/// let var_cmux = estimate_relinearization_noise::<_, BinaryKeyKind>(
 ///     polynomial_size,
 ///     dimension,
 ///     dispersion_rlk,
 ///     base_log,
 ///     l_gadget,
+///     64,
 /// );
 /// ```
-pub fn estimate_relinearization_noise<T, D, K>(
+pub fn estimate_relinearization_noise<D, K>(
     poly_size: PolynomialSize,
     glwe_dimension: GlweDimension,
     dispersion_rlk: D,
     base_log: DecompositionBaseLog,
     level: DecompositionLevelCount,
+    log2_modulus: u32,
 ) -> Variance
 where
-    T: UnsignedInteger,
     D: DispersionParameter,
     K: KeyDispersion,
 {
@@ -277,11 +304,12 @@ where
     let k = glwe_dimension.0 as f64;
     let base = 2_f64.powi(base_log.0 as i32);
     let b2l = 2_f64.powi((2 * level.0) as i32);
-    let q_square = 2_f64.powi((2 * T::BITS) as i32);
+    let q_square = 2_f64.powi((2 * log2_modulus) as i32);
 
     // first term
     let res_1 =
-        k * (level.0 as f64) * big_n * dispersion_rlk.get_modular_variance::<T>() * (k + 1.) / 2.
+        k * (level.0 as f64) * big_n * dispersion_rlk.get_modular_variance(log2_modulus) * (k + 1.)
+            / 2.
             * (square(base) + 2.)
             / 12.;
 
@@ -289,26 +317,26 @@ where
     let res_2 = k * big_n / 2.
         * (q_square / (12. * b2l) - 1. / 12.)
         * ((k - 1.)
-            * (K::variance_coefficient_in_polynomial_key_times_key::<T>(poly_size)
-                .get_modular_variance::<T>()
+            * (K::variance_coefficient_in_polynomial_key_times_key(poly_size, log2_modulus)
+                .get_modular_variance(log2_modulus)
                 + K::square_expectation_mean_in_polynomial_key_times_key(poly_size))
-            + K::variance_odd_coefficient_in_polynomial_key_squared::<T>(poly_size)
-                .get_modular_variance::<T>()
-            + K::variance_even_coefficient_in_polynomial_key_squared::<T>(poly_size)
-                .get_modular_variance::<T>()
+            + K::variance_odd_coefficient_in_polynomial_key_squared(poly_size, log2_modulus)
+                .get_modular_variance(log2_modulus)
+            + K::variance_even_coefficient_in_polynomial_key_squared(poly_size, log2_modulus)
+                .get_modular_variance(log2_modulus)
             + 2. * K::square_expectation_mean_in_polynomial_key_times_key(poly_size));
 
     // third term
     let res_3 = k * big_n / 8.
         * ((k - 1.)
-            * K::variance_coefficient_in_polynomial_key_times_key::<T>(poly_size)
-                .get_modular_variance::<T>()
-            + K::variance_odd_coefficient_in_polynomial_key_squared::<T>(poly_size)
-                .get_modular_variance::<T>()
-            + K::variance_even_coefficient_in_polynomial_key_squared::<T>(poly_size)
-                .get_modular_variance::<T>());
+            * K::variance_coefficient_in_polynomial_key_times_key(poly_size, log2_modulus)
+                .get_modular_variance(log2_modulus)
+            + K::variance_odd_coefficient_in_polynomial_key_squared(poly_size, log2_modulus)
+                .get_modular_variance(log2_modulus)
+            + K::variance_even_coefficient_in_polynomial_key_squared(poly_size, log2_modulus)
+                .get_modular_variance(log2_modulus));
 
-    Variance::from_modular_variance::<T>(res_1 + res_2 + res_3)
+    Variance::from_modular_variance(res_1 + res_2 + res_3, log2_modulus)
 }
 
 /// Computes the dispersion of a GLWE multiplication between two GLWEs (i.e., a
@@ -323,8 +351,8 @@ where
 /// use concrete_npe::estimate_multiplication_noise;
 /// let dimension = GlweDimension(3);
 /// let polynomial_size = PolynomialSize(1024);
-/// let dispersion_rlwe_0 = Variance::from_modular_variance::<u64>(2_f64.powi(24));
-/// let dispersion_rlwe_1 = Variance::from_modular_variance::<u64>(2_f64.powi(24));
+/// let dispersion_rlwe_0 = Variance::from_modular_variance(2_f64.powi(24), 64);
+/// let dispersion_rlwe_1 = Variance::from_modular_variance(2_f64.powi(24), 64);
 /// let delta_1 = 2_f64.powi(40);
 /// let delta_2 = 2_f64.powi(42);
 /// let max_msg_1 = 15.;
@@ -332,7 +360,7 @@ where
 /// let l_gadget = DecompositionLevelCount(4);
 /// let base_log = DecompositionBaseLog(7);
 /// let dispersion_rlk = Variance(2_f64.powi(-38));
-/// let var_out = estimate_multiplication_noise::<u64, _, _, _, BinaryKeyKind>(
+/// let var_out = estimate_multiplication_noise::<_, _, _, BinaryKeyKind>(
 ///     polynomial_size,
 ///     dimension,
 ///     dispersion_rlwe_0,
@@ -344,10 +372,11 @@ where
 ///     dispersion_rlk,
 ///     base_log,
 ///     l_gadget,
+///     64,
 /// );
 /// ```
 #[allow(clippy::too_many_arguments)]
-pub fn estimate_multiplication_noise<T, D1, D2, D3, K>(
+pub fn estimate_multiplication_noise<D1, D2, D3, K>(
     poly_size: PolynomialSize,
     mask_size: GlweDimension,
     dispersion_glwe1: D1,
@@ -359,16 +388,16 @@ pub fn estimate_multiplication_noise<T, D1, D2, D3, K>(
     dispersion_rlk: D3,
     base_log: DecompositionBaseLog,
     level: DecompositionLevelCount,
+    log2_modulus: u32,
 ) -> Variance
 where
-    T: UnsignedInteger,
     D1: DispersionParameter,
     D2: DispersionParameter,
     D3: DispersionParameter,
     K: KeyDispersion,
 {
     // res 1
-    let res_1: Variance = estimate_tensor_product_noise::<T, _, _, K>(
+    let res_1: Variance = estimate_tensor_product_noise::<_, _, K>(
         poly_size,
         mask_size,
         dispersion_glwe1,
@@ -377,19 +406,22 @@ where
         delta_2,
         max_msg_1,
         max_msg_2,
+        log2_modulus,
     );
 
     // res 2
-    let res_2: Variance = estimate_relinearization_noise::<T, _, K>(
+    let res_2: Variance = estimate_relinearization_noise::<_, K>(
         poly_size,
         mask_size,
         dispersion_rlk,
         base_log,
         level,
+        log2_modulus,
     );
 
-    Variance::from_modular_variance::<T>(
-        res_1.get_modular_variance::<T>() + res_2.get_modular_variance::<T>(),
+    Variance::from_modular_variance(
+        res_1.get_modular_variance(log2_modulus) + res_2.get_modular_variance(log2_modulus),
+        log2_modulus,
     )
 }
 
@@ -402,28 +434,30 @@ where
 /// let lwe_mask_size = LweDimension(630);
 /// let number_of_most_significant_bit: usize = 4;
 /// let dispersion_input = Variance(2_f64.powi(-40));
-/// let var_out = estimate_modulus_switching_noise_with_binary_key::<u64, _>(
+/// let var_out = estimate_modulus_switching_noise_with_binary_key::<_>(
 ///     lwe_mask_size,
 ///     number_of_most_significant_bit,
 ///     dispersion_input,
+///     64,
 /// );
 /// ```
-pub fn estimate_modulus_switching_noise_with_binary_key<T, D>(
+pub fn estimate_modulus_switching_noise_with_binary_key<D>(
     lwe_mask_size: LweDimension,
     nb_msb: usize,
     var_in: D,
+    log2_modulus: u32,
 ) -> Variance
 where
-    T: UnsignedInteger,
     D: DispersionParameter,
 {
     let w = 2_f64.powi(nb_msb as i32);
     let n = lwe_mask_size.0 as f64;
-    let q_square = 2_f64.powi((2 * T::BITS) as i32);
-    Variance::from_modular_variance::<T>(
-        var_in.get_modular_variance::<T>() + 1. / 12. * q_square / square(w) - 1. / 12.
+    let q_square = 2_f64.powi((2 * log2_modulus) as i32);
+    Variance::from_modular_variance(
+        var_in.get_modular_variance(log2_modulus) + 1. / 12. * q_square / square(w) - 1. / 12.
             + n / 24. * q_square / square(w)
             + n / 48.,
+        log2_modulus,
     )
 }
 
@@ -442,24 +476,24 @@ where
 /// let base_log = DecompositionBaseLog(7);
 /// let dispersion_lwe = Variance(2_f64.powi(-38));
 /// let dispersion_ks = Variance(2_f64.powi(-40));
-/// let var_ks = estimate_keyswitch_noise_lwe_to_glwe_with_constant_terms::<u64, _, _,
-/// BinaryKeyKind>(
+/// let var_ks = estimate_keyswitch_noise_lwe_to_glwe_with_constant_terms::<_, _, BinaryKeyKind>(
 ///     lwe_mask_size,
 ///     dispersion_lwe,
 ///     dispersion_ks,
 ///     base_log,
 ///     l_ks,
+///     64,
 /// );
 /// ```
-pub fn estimate_keyswitch_noise_lwe_to_glwe_with_constant_terms<T, D1, D2, K>(
+pub fn estimate_keyswitch_noise_lwe_to_glwe_with_constant_terms<D1, D2, K>(
     lwe_mask_size: LweDimension,
     dispersion_lwe: D1,
     dispersion_ksk: D2,
     base_log: DecompositionBaseLog,
     level: DecompositionLevelCount,
+    log2_modulus: u32,
 ) -> Variance
 where
-    T: UnsignedInteger,
     D1: DispersionParameter,
     D2: DispersionParameter,
     K: KeyDispersion,
@@ -467,26 +501,29 @@ where
     let n = lwe_mask_size.0 as f64;
     let base = 2_f64.powi(base_log.0 as i32);
     let b2l = 2_f64.powi((base_log.0 * 2 * level.0) as i32);
-    let q_square = 2_f64.powi((2 * T::BITS) as i32);
+    let q_square = 2_f64.powi((2 * log2_modulus) as i32);
 
     // res 1
-    let res_1 = dispersion_lwe.get_modular_variance::<T>();
+    let res_1 = dispersion_lwe.get_modular_variance(log2_modulus);
 
     // res 2
     let res_2 = n
         * (q_square / (12. * b2l) - 1. / 12.)
-        * (K::variance_key_coefficient::<T>().get_modular_variance::<T>()
+        * (K::variance_key_coefficient(log2_modulus).get_modular_variance(log2_modulus)
             + square(K::expectation_key_coefficient()));
 
     // res 3
-    let res_3 = n / 4. * K::variance_key_coefficient::<T>().get_modular_variance::<T>();
+    let res_3 =
+        n / 4. * K::variance_key_coefficient(log2_modulus).get_modular_variance(log2_modulus);
 
     // res 4
-    let res_4 =
-        n * (level.0 as f64) * dispersion_ksk.get_modular_variance::<T>() * (square(base) + 2.)
-            / 12.;
+    let res_4 = n
+        * (level.0 as f64)
+        * dispersion_ksk.get_modular_variance(log2_modulus)
+        * (square(base) + 2.)
+        / 12.;
 
-    Variance::from_modular_variance::<T>(res_1 + res_2 + res_3 + res_4)
+    Variance::from_modular_variance(res_1 + res_2 + res_3 + res_4, log2_modulus)
 }
 
 /// Computes the dispersion of the constant terms of a GLWE after an LWE
@@ -536,21 +573,22 @@ where
     let n = lwe_mask_size.0 as f64;
     let base = 2_f64.powi(base_log.0 as i32);
     let b2l = 2_f64.powi((base_log.0 * 2 * level.0) as i32);
-    let q_square = 2_f64.powi((2 * T::BITS) as i32);
+    let q_square = 2_f64.powi((2 * T::BITS as u32) as i32);
     let r2 = square(function_lipschitz_bound);
 
     // res 1
-    let res_1 = r2 * dispersion_lwe.get_modular_variance::<T>();
+    let res_1 = r2 * dispersion_lwe.get_modular_variance(T::BITS as u32);
 
     // res 2
     let res_2 = r2
         * n
         * (q_square / (12. * b2l) - 1. / 12.)
-        * (K::variance_key_coefficient::<T>().get_modular_variance::<T>()
+        * (K::variance_key_coefficient(T::BITS as u32).get_modular_variance(T::BITS as u32)
             + square(K::expectation_key_coefficient()));
 
     // res 3
-    let res_3 = r2 * n / 4. * K::variance_key_coefficient::<T>().get_modular_variance::<T>();
+    let res_3 = r2 * n / 4.
+        * K::variance_key_coefficient(T::BITS as u32).get_modular_variance(T::BITS as u32);
 
     // res 4
     let res_4 = r2 * (q_square / (12. * b2l) - 1. / 12.);
@@ -558,11 +596,11 @@ where
     // res 5
     let res_5 = (n + 1.)
         * (level.0 as f64)
-        * dispersion_ksk.get_modular_variance::<T>()
+        * dispersion_ksk.get_modular_variance(T::BITS as u32)
         * (square(base) + 2.)
         / 12.;
 
-    Variance::from_modular_variance::<T>(res_1 + res_2 + res_3 + res_4 + res_5)
+    Variance::from_modular_variance(res_1 + res_2 + res_3 + res_4 + res_5, T::BITS as u32)
 }
 
 /// Computes the dispersion of the non-constant GLWE terms after an LWE to GLWE keyswitch.
@@ -579,31 +617,34 @@ where
 /// let base_log = DecompositionBaseLog(7);
 /// let dispersion_ks = Variance(2_f64.powi(-40));
 /// // Compute the noise
-/// let var_ks = estimate_keyswitch_noise_lwe_to_glwe_with_non_constant_terms::<u64, _>(
+/// let var_ks = estimate_keyswitch_noise_lwe_to_glwe_with_non_constant_terms::<_>(
 ///     lwe_mask_size,
 ///     dispersion_ks,
 ///     base_log,
 ///     l_ks,
+///     64,
 /// );
 /// ```
-pub fn estimate_keyswitch_noise_lwe_to_glwe_with_non_constant_terms<T, D>(
+pub fn estimate_keyswitch_noise_lwe_to_glwe_with_non_constant_terms<D>(
     lwe_mask_size: LweDimension,
     dispersion_ksk: D,
     base_log: DecompositionBaseLog,
     level: DecompositionLevelCount,
+    log2_modulus: u32,
 ) -> Variance
 where
-    T: UnsignedInteger,
     D: DispersionParameter,
 {
     let n = lwe_mask_size.0 as f64;
     let square_base = 2_f64.powi(2 * base_log.0 as i32);
 
-    let res =
-        n * (level.0 as f64) * dispersion_ksk.get_modular_variance::<T>() * (square_base + 2.)
-            / 12.;
+    let res = n
+        * (level.0 as f64)
+        * dispersion_ksk.get_modular_variance(log2_modulus)
+        * (square_base + 2.)
+        / 12.;
 
-    Variance::from_modular_variance::<T>(res)
+    Variance::from_modular_variance(res, log2_modulus)
 }
 
 /// Computes the dispersion of the bits greater than $q$ after a modulus switching.
@@ -615,24 +656,25 @@ where
 /// use concrete_npe::estimate_msb_noise_rlwe;
 /// use std::fmt::Binary;
 /// let rlwe_mask_size = PolynomialSize(1024);
-/// let var_out = estimate_msb_noise_rlwe::<u64, BinaryKeyKind>(rlwe_mask_size);
+/// let var_out = estimate_msb_noise_rlwe::<BinaryKeyKind>(rlwe_mask_size, 64);
 /// ```
-pub fn estimate_msb_noise_rlwe<T, K>(poly_size: PolynomialSize) -> Variance
+pub fn estimate_msb_noise_rlwe<K>(poly_size: PolynomialSize, log2_modulus: u32) -> Variance
 where
-    T: UnsignedInteger,
     K: KeyDispersion,
 {
-    let q_square = 2_f64.powi((2 * T::BITS) as i32);
+    let q_square = 2_f64.powi((2 * log2_modulus) as i32);
 
-    Variance::from_modular_variance::<T>(
+    Variance::from_modular_variance(
         1. / q_square
             * ((q_square - 1.) / 12.
                 * (1.
                     + (poly_size.0 as f64)
-                        * K::variance_key_coefficient::<T>().get_modular_variance::<T>()
+                        * K::variance_key_coefficient(log2_modulus)
+                            .get_modular_variance(log2_modulus)
                     + (poly_size.0 as f64) * square(K::expectation_key_coefficient()))
                 + (poly_size.0 as f64) / 4.
-                    * K::variance_key_coefficient::<T>().get_modular_variance::<T>()),
+                    * K::variance_key_coefficient(log2_modulus).get_modular_variance(log2_modulus)),
+        log2_modulus,
     )
 }
 
@@ -652,25 +694,26 @@ where
 /// let dispersion_rlwe = Variance(2_f64.powi(-40));
 /// let dispersion_rgsw = Variance(2_f64.powi(-40));
 /// let base_log = DecompositionBaseLog(7);
-/// let var_ks = estimate_external_product_noise_with_binary_ggsw::<u64, _, _, BinaryKeyKind>(
+/// let var_ks = estimate_external_product_noise_with_binary_ggsw::<_, _, BinaryKeyKind>(
 ///     poly_size,
 ///     mask_size,
 ///     dispersion_rlwe,
 ///     dispersion_rgsw,
 ///     base_log,
 ///     level,
+///     64,
 /// );
 /// ```
-pub fn estimate_external_product_noise_with_binary_ggsw<T, D1, D2, K>(
+pub fn estimate_external_product_noise_with_binary_ggsw<D1, D2, K>(
     poly_size: PolynomialSize,
     rlwe_mask_size: GlweDimension,
     var_glwe: D1,
     var_ggsw: D2,
     base_log: DecompositionBaseLog,
     level: DecompositionLevelCount,
+    log2_modulus: u32,
 ) -> Variance
 where
-    T: UnsignedInteger,
     D1: DispersionParameter,
     D2: DispersionParameter,
     K: KeyDispersion,
@@ -680,19 +723,20 @@ where
     let big_n = poly_size.0 as f64;
     let b = 2_f64.powi(base_log.0 as i32);
     let b2l = 2_f64.powi((base_log.0 * 2 * level.0) as i32);
-    let q_square = 2_f64.powi(2 * T::BITS as i32);
+    let q_square = 2_f64.powi(2 * log2_modulus as i32);
 
     let res_1 =
-        l * (k + 1.) * big_n * var_ggsw.get_modular_variance::<T>() * (square(b) + 2.) / 12.;
-    let res_2 = var_glwe.get_modular_variance::<T>() / 2.;
+        l * (k + 1.) * big_n * var_ggsw.get_modular_variance(log2_modulus) * (square(b) + 2.) / 12.;
+    let res_2 = var_glwe.get_modular_variance(log2_modulus) / 2.;
     let res_3 = (q_square - b2l) / (24. * b2l)
         * (1.
             + k * big_n
-                * (K::variance_key_coefficient::<T>().get_modular_variance::<T>()
+                * (K::variance_key_coefficient(log2_modulus).get_modular_variance(log2_modulus)
                     + square(K::expectation_key_coefficient())));
-    let res_4 = k * big_n / 8. * K::variance_key_coefficient::<T>().get_modular_variance::<T>();
+    let res_4 = k * big_n / 8.
+        * K::variance_key_coefficient(log2_modulus).get_modular_variance(log2_modulus);
     let res_5 = 1. / 16. * square(1. - k * big_n * K::expectation_key_coefficient());
-    Variance::from_modular_variance::<T>(res_1 + res_2 + res_3 + res_4 + res_5)
+    Variance::from_modular_variance(res_1 + res_2 + res_3 + res_4 + res_5, log2_modulus)
 }
 
 /// Computes the dispersion of a CMUX controlled with a GGSW encrypting binary keys.
@@ -708,11 +752,11 @@ where
 /// let l_gadget = DecompositionLevelCount(4);
 /// let base_log = DecompositionBaseLog(7);
 /// let polynomial_size = PolynomialSize(1024);
-/// let dispersion_rgsw = Variance::from_modular_variance::<u64>(2_f64.powi(26));
-/// let dispersion_rlwe_0 = Variance::from_modular_variance::<u64>(2_f64.powi(25));
-/// let dispersion_rlwe_1 = Variance::from_modular_variance::<u64>(2_f64.powi(25));
+/// let dispersion_rgsw = Variance::from_modular_variance(2_f64.powi(26), 64);
+/// let dispersion_rlwe_0 = Variance::from_modular_variance(2_f64.powi(25), 64);
+/// let dispersion_rlwe_1 = Variance::from_modular_variance(2_f64.powi(25), 64);
 /// // Compute the noise
-/// let var_cmux = estimate_cmux_noise_with_binary_ggsw::<u64, _, _, _, BinaryKeyKind>(
+/// let var_cmux = estimate_cmux_noise_with_binary_ggsw::<_, _, _, BinaryKeyKind>(
 ///     dimension,
 ///     polynomial_size,
 ///     base_log,
@@ -720,9 +764,11 @@ where
 ///     dispersion_rlwe_0,
 ///     dispersion_rlwe_1,
 ///     dispersion_rgsw,
+///     64,
 /// );
 /// ```
-pub fn estimate_cmux_noise_with_binary_ggsw<T, D1, D2, D3, K>(
+#[allow(clippy::too_many_arguments)]
+pub fn estimate_cmux_noise_with_binary_ggsw<D1, D2, D3, K>(
     dimension: GlweDimension,
     polynomial_size: PolynomialSize,
     base_log: DecompositionBaseLog,
@@ -730,23 +776,24 @@ pub fn estimate_cmux_noise_with_binary_ggsw<T, D1, D2, D3, K>(
     dispersion_rlwe_0: D1,
     dispersion_rlwe_1: D2,
     dispersion_rgsw: D3,
+    log2_modulus: u32,
 ) -> Variance
 where
-    T: UnsignedInteger,
     D1: DispersionParameter,
     D2: DispersionParameter,
     D3: DispersionParameter,
     K: KeyDispersion,
 {
-    let var_external_product = estimate_external_product_noise_with_binary_ggsw::<T, _, _, K>(
+    let var_external_product = estimate_external_product_noise_with_binary_ggsw::<_, _, K>(
         polynomial_size,
         dimension,
-        estimate_addition_noise::<T, _, _>(dispersion_rlwe_0, dispersion_rlwe_1),
+        estimate_addition_noise::<_, _>(dispersion_rlwe_0, dispersion_rlwe_1, log2_modulus),
         dispersion_rgsw,
         base_log,
         l_gadget,
+        log2_modulus,
     );
-    estimate_addition_noise::<T, _, _>(var_external_product, dispersion_rlwe_0)
+    estimate_addition_noise::<_, _>(var_external_product, dispersion_rlwe_0, log2_modulus)
 }
 
 /// Computes the dispersion of a PBS *a la TFHE* (i.e., the GGSW encrypts a
@@ -765,25 +812,26 @@ where
 /// let level = DecompositionLevelCount(4);
 /// let dispersion_rgsw = Variance(2_f64.powi(-40));
 /// let base_log = DecompositionBaseLog(7);
-/// let var_ks = estimate_pbs_noise::<u64, _, BinaryKeyKind>(
+/// let var_ks = estimate_pbs_noise::<_, BinaryKeyKind>(
 ///     mask_size,
 ///     poly_size,
 ///     rlwe_mask_size,
 ///     base_log,
 ///     level,
 ///     dispersion_rgsw,
+///     64,
 /// );
 /// ```
-pub fn estimate_pbs_noise<T, D, K>(
+pub fn estimate_pbs_noise<D, K>(
     lwe_mask_size: LweDimension,
     poly_size: PolynomialSize,
     rlwe_mask_size: GlweDimension,
     base_log: DecompositionBaseLog,
     level: DecompositionLevelCount,
     dispersion_bsk: D,
+    log2_modulus: u32,
 ) -> Variance
 where
-    T: UnsignedInteger,
     D: DispersionParameter,
     K: KeyDispersion,
 {
@@ -793,18 +841,19 @@ where
     let b2l = 2_f64.powi((base_log.0 * 2 * level.0) as i32);
     let l = level.0 as f64;
     let big_n = poly_size.0 as f64;
-    let q_square = 2_f64.powi(2 * T::BITS as i32);
+    let q_square = 2_f64.powi(2 * log2_modulus as i32);
 
     let res_1 = n * l * (k + 1.) * big_n * (square(b) + 2.) / 12.
-        * dispersion_bsk.get_modular_variance::<T>();
+        * dispersion_bsk.get_modular_variance(log2_modulus);
     let res_2 = n * (q_square - b2l) / (24. * b2l)
         * (1.
             + k * big_n
-                * (K::variance_key_coefficient::<T>().get_modular_variance::<T>()
+                * (K::variance_key_coefficient(log2_modulus).get_modular_variance(log2_modulus)
                     + square(K::expectation_key_coefficient())))
-        + n * k * big_n / 8. * K::variance_key_coefficient::<T>().get_modular_variance::<T>()
+        + n * k * big_n / 8.
+            * K::variance_key_coefficient(log2_modulus).get_modular_variance(log2_modulus)
         + n / 16. * square(1. - k * big_n * K::expectation_key_coefficient());
-    Variance::from_modular_variance::<T>(res_1 + res_2)
+    Variance::from_modular_variance(res_1 + res_2, log2_modulus)
 }
 
 #[cfg(test)]

--- a/concrete-npe/src/tools.rs
+++ b/concrete-npe/src/tools.rs
@@ -1,16 +1,14 @@
 use concrete_commons::dispersion::DispersionParameter;
-use concrete_commons::numeric::UnsignedInteger;
 use std::ops::Mul;
 
 /// Computes the number of bits affected by the noise with a dispersion
 /// describing a normal distribution.
-pub fn estimate_number_of_noise_bits<T, D>(dispersion: D) -> usize
+pub fn estimate_number_of_noise_bits<D>(dispersion: D, log2_modulus: u32) -> usize
 where
     D: DispersionParameter,
-    T: UnsignedInteger,
 {
     // get the standard deviation
-    let std_dev: f64 = dispersion.get_modular_standard_dev::<T>();
+    let std_dev: f64 = dispersion.get_modular_standard_dev(log2_modulus);
 
     // the constant used for the computation
     let z: f64 = 4.;
@@ -27,7 +25,7 @@ where
 /// Computes the square of the input value.
 pub(super) fn square<T>(x: T) -> T
 where
-    T: Mul<T, Output = T> + Copy,
+    T: Mul<Output = T> + Copy,
 {
     x * x
 }


### PR DESCRIPTION
### Description

Replace remove torus type generics by a function parameter log2_modulus in all relevant functions in concrete-npe.

- the generics torus type in only ever used to extract the number of bits, so we don't loose any useful information by only giving the log2_modulus
- we only ask for the information we need so it's less constraining for callers
- the generics are contaminating, which forces us to use generics too in the optimizer (log2_modulus -> generic type) is not possible (or very ugly: match log2_modulus {32 => f::<u32>(...), 64 => f::<u64>(...))
- for another client of concrete-npe using generics, it's possible to get the log2_modulus from the generic type (genric_type -> log2_modulus) is clean (f(..., T::BITS))
- we add a function parameter but we also remove a generic type, so we slightly reduce signature complexity
- with generics, monomorphisation is done (for each type we call generic a function with, the compiler creates a separate version) which may increase compile times and binary size
- theoretical future advantage: with the log2_modulus, we can call the functions for any number of bits, which may be useful for a FPGA implementation which doesn't use 16, 32, 64 or 128 bits

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer