### PR TITLE
chore(crates): change the way to declare deps to be git friendly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,6 @@ members = [
     "concrete-cuda",
 ]
 
-[patch.crates-io]
-concrete-npe = { path = "concrete-npe" }
-concrete-core = { path = "concrete-core" }
-concrete-csprng = { path = "concrete-csprng" }
-concrete-commons = { path = "concrete-commons" }
-concrete-cuda = { path = "concrete-cuda" }
-
 [profile.release]
 lto = "fat"
 

--- a/concrete-core/Cargo.toml
+++ b/concrete-core/Cargo.toml
@@ -12,15 +12,16 @@ readme = "README.md"
 keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
 
 [dev-dependencies]
-concrete-npe = "0.2.2"
+concrete-npe = { version = "0.3.0", path = "../concrete-npe" }
 rand = "0.7"
 kolmogorov_smirnov = "1.1.0"
 
 [dependencies]
 concrete-fftw = { version = "=0.1.3", optional = true }
-concrete-commons = "=0.2.2"
-concrete-csprng = { version = "0.2", features = [] }
-concrete-cuda = { version = "0.1.0", optional = true }
+concrete-commons = { version = "=0.2.2", path = "../concrete-commons" }
+concrete-csprng = { version = "0.2", path = "../concrete-csprng", features = [
+] }
+concrete-cuda = { version = "0.1.0", path = "../concrete-cuda", optional = true }
 serde = { version = "1.0", optional = true }
 lazy_static = "1.4.0"
 rayon = { version = "1.5.0", optional = true }

--- a/concrete-npe/Cargo.toml
+++ b/concrete-npe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concrete-npe"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 authors = ["D. Ligier", "J.B. Orfila", "A. Péré", "S. Tap", "Zama team"]
 license = "BSD-3-Clause-Clear"
@@ -14,4 +14,4 @@ keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-concrete-commons = "=0.2.2"
+concrete-commons = { version = "=0.2.2", path = "../concrete-commons" }


### PR DESCRIPTION
### Resolves:

### Description

- we use multiple location dep declaration, path is used for local builds
or for builds using the git repo
- the version is used for crates published on crates.io

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
