### PR TITLE
feat(npe): add noise propagation estimates for WoP-PBS

### DIFF
--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_glwe_ciphertext_discarding_private_functional_packing_keyswitch.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_glwe_ciphertext_discarding_private_functional_packing_keyswitch.rs
@@ -378,7 +378,6 @@ where
     let k_type_id = TypeId::of::<K>();
     if k_type_id == TypeId::of::<BinaryKeyDistribution>() {
         concrete_npe::estimate_private_functional_keyswitch_noise_lwe_to_glwe_with_constant_terms::<
-            T,
             D1,
             D2,
             BinaryKeyKind,
@@ -389,10 +388,10 @@ where
             base_log,
             level,
             function_lipschitz_bound,
+            T::BITS as u32,
         )
     } else if k_type_id == TypeId::of::<TernaryKeyDistribution>() {
         concrete_npe::estimate_private_functional_keyswitch_noise_lwe_to_glwe_with_constant_terms::<
-            T,
             D1,
             D2,
             TernaryKeyKind,
@@ -403,10 +402,10 @@ where
             base_log,
             level,
             function_lipschitz_bound,
+            T::BITS as u32,
         )
     } else if k_type_id == TypeId::of::<GaussianKeyDistribution>() {
         concrete_npe::estimate_private_functional_keyswitch_noise_lwe_to_glwe_with_constant_terms::<
-            T,
             D1,
             D2,
             GaussianKeyKind,
@@ -417,6 +416,7 @@ where
             base_log,
             level,
             function_lipschitz_bound,
+            T::BITS as u32,
         )
     } else {
         panic!("Unknown key distribution encountered.")


### PR DESCRIPTION
### Resolves:
https://github.com/zama-ai/concrete-core-internal/issues/316
https://github.com/zama-ai/concrete-core-internal/issues/317
https://github.com/zama-ai/concrete-core-internal/issues/318
https://github.com/zama-ai/concrete-core-internal/issues/319

### Description

This PR adds the noise propagation estimates for the WoP-PBS and its constituent parts: bit extraction, circuit bootstrapping and vertical packing.
This PR also updates the private functional packing keyswitch key noise propagation estimation function and the associated fixture to remove the torus type generics.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
