### PR TITLE
fix(cuda): fix multi-GPU implementation when there are few inputs

### DIFF
--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_amortized_engine/lwe_ciphertext_vector_discarding_bootstrap.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_amortized_engine/lwe_ciphertext_vector_discarding_bootstrap.rs
@@ -4,12 +4,11 @@ use crate::backends::cuda::implementation::entities::{
     CudaFourierLweBootstrapKey32, CudaFourierLweBootstrapKey64, CudaGlweCiphertextVector32,
     CudaGlweCiphertextVector64, CudaLweCiphertextVector32, CudaLweCiphertextVector64,
 };
-use crate::backends::cuda::private::device::NumberOfSamples;
+use crate::backends::cuda::private::crypto::bootstrap::execute_lwe_ciphertext_vector_amortized_bootstrap_on_gpu;
 use crate::specification::engines::{
     LweCiphertextVectorDiscardingBootstrapEngine, LweCiphertextVectorDiscardingBootstrapError,
 };
-use crate::specification::entities::{LweBootstrapKeyEntity, LweCiphertextVectorEntity};
-use concrete_commons::parameters::LweCiphertextIndex;
+use crate::specification::entities::LweBootstrapKeyEntity;
 
 /// # Description
 /// A discard bootstrap on a vector of input ciphertext vectors with 32 bits of precision.
@@ -137,38 +136,15 @@ impl
         acc: &CudaGlweCiphertextVector32,
         bsk: &CudaFourierLweBootstrapKey32,
     ) {
-        let samples_per_gpu = input.lwe_ciphertext_count().0 / self.get_number_of_gpus();
-
-        for gpu_index in 0..self.get_number_of_gpus() {
-            let mut samples = samples_per_gpu;
-            if gpu_index == self.get_number_of_gpus() - 1
-                && input.lwe_ciphertext_count().0 % self.get_number_of_gpus() as usize != 0
-            {
-                samples +=
-                    input.lwe_ciphertext_count().0 - samples_per_gpu * self.get_number_of_gpus();
-            }
-            let stream = &self.streams.get(gpu_index).unwrap();
-            // FIXME this is hard set at the moment because concrete-default does not support a more
-            //   general API for the bootstrap
-            let test_vector_indexes = (0..samples as u32).collect::<Vec<u32>>();
-            let mut d_test_vector_indexes = stream.malloc::<u32>(samples as u32);
-            stream.copy_to_gpu(&mut d_test_vector_indexes, test_vector_indexes.as_slice());
-
-            stream.discard_bootstrap_amortized_lwe_ciphertext_vector_32(
-                output.0.d_vecs.get_mut(gpu_index).unwrap(),
-                acc.0.d_vecs.get(gpu_index).unwrap(),
-                &d_test_vector_indexes,
-                input.0.d_vecs.get(gpu_index).unwrap(),
-                bsk.0.d_vecs.get(gpu_index).unwrap(),
-                input.0.lwe_dimension,
-                bsk.polynomial_size(),
-                bsk.decomposition_base_log(),
-                bsk.decomposition_level_count(),
-                NumberOfSamples(samples),
-                LweCiphertextIndex(samples_per_gpu * gpu_index),
-                self.get_cuda_shared_memory(),
-            );
-        }
+        execute_lwe_ciphertext_vector_amortized_bootstrap_on_gpu::<u32>(
+            self.get_cuda_streams(),
+            &mut output.0,
+            &input.0,
+            &acc.0,
+            &bsk.0,
+            self.get_number_of_gpus(),
+            self.get_cuda_shared_memory(),
+        );
     }
 }
 
@@ -298,37 +274,14 @@ impl
         acc: &CudaGlweCiphertextVector64,
         bsk: &CudaFourierLweBootstrapKey64,
     ) {
-        let samples_per_gpu = input.lwe_ciphertext_count().0 / self.get_number_of_gpus();
-
-        for gpu_index in 0..self.get_number_of_gpus() {
-            let mut samples = samples_per_gpu;
-            if gpu_index == self.get_number_of_gpus() - 1
-                && input.lwe_ciphertext_count().0 % self.get_number_of_gpus() as usize != 0
-            {
-                samples +=
-                    input.lwe_ciphertext_count().0 - samples_per_gpu * self.get_number_of_gpus();
-            }
-            let stream = self.streams.get(gpu_index).unwrap();
-            // FIXME this is hard set at the moment because concrete-default does not support a more
-            //   general API for the bootstrap
-            let test_vector_indexes = (0..samples as u32).collect::<Vec<u32>>();
-            let mut d_test_vector_indexes = stream.malloc::<u32>(samples as u32);
-            stream.copy_to_gpu(&mut d_test_vector_indexes, test_vector_indexes.as_slice());
-
-            stream.discard_bootstrap_amortized_lwe_ciphertext_vector_64(
-                output.0.d_vecs.get_mut(gpu_index).unwrap(),
-                acc.0.d_vecs.get(gpu_index).unwrap(),
-                &d_test_vector_indexes,
-                input.0.d_vecs.get(gpu_index).unwrap(),
-                bsk.0.d_vecs.get(gpu_index).unwrap(),
-                input.lwe_dimension(),
-                bsk.polynomial_size(),
-                bsk.decomposition_base_log(),
-                bsk.decomposition_level_count(),
-                NumberOfSamples(samples),
-                LweCiphertextIndex(samples_per_gpu * gpu_index),
-                self.get_cuda_shared_memory(),
-            );
-        }
+        execute_lwe_ciphertext_vector_amortized_bootstrap_on_gpu::<u64>(
+            self.get_cuda_streams(),
+            &mut output.0,
+            &input.0,
+            &acc.0,
+            &bsk.0,
+            self.get_number_of_gpus(),
+            self.get_cuda_shared_memory(),
+        );
     }
 }

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_amortized_engine/mod.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_amortized_engine/mod.rs
@@ -1,5 +1,5 @@
 use crate::backends::cuda::engines::CudaError;
-use crate::backends::cuda::private::device::{CudaStream, GpuIndex};
+use crate::backends::cuda::private::device::{CudaStream, GpuIndex, NumberOfGpus};
 use crate::prelude::sealed::AbstractEngineSeal;
 use crate::prelude::{AbstractEngine, SharedMemoryAmount};
 use concrete_cuda::cuda_bind::cuda_get_number_of_gpus;
@@ -28,7 +28,7 @@ impl AbstractEngine for AmortizedCudaEngine {
             Err(CudaError::DeviceNotFound)
         } else {
             let mut streams: Vec<CudaStream> = Vec::new();
-            for gpu_index in 0..number_of_gpus as u32 {
+            for gpu_index in 0..number_of_gpus {
                 streams.push(CudaStream::new(GpuIndex(gpu_index))?);
             }
             let max_shared_memory = streams[0].get_max_shared_memory()?;
@@ -43,8 +43,8 @@ impl AbstractEngine for AmortizedCudaEngine {
 
 impl AmortizedCudaEngine {
     /// Get the number of available GPUs from the engine
-    pub fn get_number_of_gpus(&self) -> usize {
-        self.streams.len()
+    pub fn get_number_of_gpus(&self) -> NumberOfGpus {
+        NumberOfGpus(self.streams.len())
     }
     /// Get the Cuda streams from the engine
     pub fn get_cuda_streams(&self) -> &Vec<CudaStream> {

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/glwe_ciphertext_vector_conversion.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/glwe_ciphertext_vector_conversion.rs
@@ -69,7 +69,7 @@ impl GlweCiphertextVectorConversionEngine<GlweCiphertextVector32, CudaGlweCipher
         &mut self,
         input: &GlweCiphertextVector32,
     ) -> Result<CudaGlweCiphertextVector32, GlweCiphertextVectorConversionError<CudaError>> {
-        for gpu_index in 0..self.get_number_of_gpus() {
+        for gpu_index in 0..self.get_number_of_gpus().0 {
             let stream = &self.streams[gpu_index];
             let data_per_gpu = input.glwe_dimension().to_glwe_size().0
                 * input.glwe_ciphertext_count().0
@@ -85,11 +85,11 @@ impl GlweCiphertextVectorConversionEngine<GlweCiphertextVector32, CudaGlweCipher
         input: &GlweCiphertextVector32,
     ) -> CudaGlweCiphertextVector32 {
         // Copy the entire input vector over all GPUs
-        let mut vecs = Vec::with_capacity(self.get_number_of_gpus() as usize);
+        let mut vecs = Vec::with_capacity(self.get_number_of_gpus().0);
         let data_per_gpu = input.glwe_ciphertext_count().0
             * input.glwe_dimension().to_glwe_size().0
             * input.polynomial_size().0;
-        for gpu_index in 0..self.get_number_of_gpus() {
+        for gpu_index in 0..self.get_number_of_gpus().0 {
             let stream = &self.streams[gpu_index];
             let mut vec = stream.malloc::<u32>(data_per_gpu as u32);
             let input_slice = input.0.as_tensor().as_slice();
@@ -235,7 +235,7 @@ impl GlweCiphertextVectorConversionEngine<GlweCiphertextVector64, CudaGlweCipher
         &mut self,
         input: &GlweCiphertextVector64,
     ) -> Result<CudaGlweCiphertextVector64, GlweCiphertextVectorConversionError<CudaError>> {
-        for gpu_index in 0..self.get_number_of_gpus() {
+        for gpu_index in 0..self.get_number_of_gpus().0 {
             let stream = &self.streams[gpu_index];
             let data_per_gpu = input.glwe_dimension().to_glwe_size().0
                 * input.glwe_ciphertext_count().0
@@ -251,11 +251,11 @@ impl GlweCiphertextVectorConversionEngine<GlweCiphertextVector64, CudaGlweCipher
         input: &GlweCiphertextVector64,
     ) -> CudaGlweCiphertextVector64 {
         // Copy the entire input vector over all GPUs
-        let mut vecs = Vec::with_capacity(self.get_number_of_gpus() as usize);
+        let mut vecs = Vec::with_capacity(self.get_number_of_gpus().0);
         let data_per_gpu = input.glwe_ciphertext_count().0
             * input.glwe_dimension().to_glwe_size().0
             * input.polynomial_size().0;
-        for gpu_index in 0..self.get_number_of_gpus() {
+        for gpu_index in 0..self.get_number_of_gpus().0 {
             let stream = &self.streams[gpu_index];
             let mut vec = stream.malloc::<u64>(data_per_gpu as u32);
             let input_slice = input.0.as_tensor().as_slice();

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_discarding_bootstrap.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_discarding_bootstrap.rs
@@ -138,7 +138,7 @@ impl
         let mut test_vector_indexes = stream.malloc::<u32>(1);
         stream.copy_to_gpu(&mut test_vector_indexes, &[0]);
 
-        stream.discard_bootstrap_low_latency_lwe_ciphertext_vector_32(
+        stream.discard_bootstrap_low_latency_lwe_ciphertext_vector::<u32>(
             &mut output.0.d_vec,
             &acc.0.d_vec,
             &test_vector_indexes,
@@ -276,7 +276,7 @@ impl
         let mut test_vector_indexes = stream.malloc::<u32>(1);
         stream.copy_to_gpu(&mut test_vector_indexes, &[0]);
 
-        stream.discard_bootstrap_low_latency_lwe_ciphertext_vector_64(
+        stream.discard_bootstrap_low_latency_lwe_ciphertext_vector::<u64>(
             &mut output.0.d_vec,
             &acc.0.d_vec,
             &test_vector_indexes,

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_discarding_keyswitch.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_discarding_keyswitch.rs
@@ -111,7 +111,7 @@ impl
     ) {
         let stream = &self.streams[0];
 
-        stream.discard_keyswitch_lwe_ciphertext_vector_32(
+        stream.discard_keyswitch_lwe_ciphertext_vector::<u32>(
             &mut output.0.d_vec,
             &input.0.d_vec,
             input.0.lwe_dimension,
@@ -220,7 +220,7 @@ impl
     ) {
         let stream = &self.streams[0];
 
-        stream.discard_keyswitch_lwe_ciphertext_vector_64(
+        stream.discard_keyswitch_lwe_ciphertext_vector::<u64>(
             &mut output.0.d_vec,
             &input.0.d_vec,
             input.0.lwe_dimension,

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_vector_discarding_bootstrap.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_vector_discarding_bootstrap.rs
@@ -4,12 +4,11 @@ use crate::backends::cuda::implementation::entities::{
     CudaFourierLweBootstrapKey32, CudaFourierLweBootstrapKey64, CudaGlweCiphertextVector32,
     CudaGlweCiphertextVector64, CudaLweCiphertextVector32, CudaLweCiphertextVector64,
 };
-use crate::backends::cuda::private::device::NumberOfSamples;
+use crate::backends::cuda::private::crypto::bootstrap::execute_lwe_ciphertext_vector_low_latency_bootstrap_on_gpu;
 use crate::specification::engines::{
     LweCiphertextVectorDiscardingBootstrapEngine, LweCiphertextVectorDiscardingBootstrapError,
 };
-use crate::specification::entities::{LweBootstrapKeyEntity, LweCiphertextVectorEntity};
-use concrete_commons::parameters::LweCiphertextIndex;
+use crate::specification::entities::LweBootstrapKeyEntity;
 
 /// # Description
 /// A discard bootstrap on a vector of input ciphertext vectors with 32 bits of precision.
@@ -138,38 +137,15 @@ impl
         acc: &CudaGlweCiphertextVector32,
         bsk: &CudaFourierLweBootstrapKey32,
     ) {
-        let samples_per_gpu = input.lwe_ciphertext_count().0 / self.get_number_of_gpus();
-
-        for gpu_index in 0..self.get_number_of_gpus() {
-            let mut samples = samples_per_gpu;
-            if gpu_index == self.get_number_of_gpus() - 1
-                && input.lwe_ciphertext_count().0 % self.get_number_of_gpus() as usize != 0
-            {
-                samples +=
-                    input.lwe_ciphertext_count().0 - samples_per_gpu * self.get_number_of_gpus();
-            }
-            let stream = &self.streams[gpu_index];
-            // FIXME this is hard set at the moment because concrete-core does not support a more
-            //   general API for the bootstrap
-            let test_vector_indexes = (0..samples as u32).collect::<Vec<u32>>();
-            let mut d_test_vector_indexes = stream.malloc::<u32>(samples as u32);
-            stream.copy_to_gpu(&mut d_test_vector_indexes, &test_vector_indexes);
-
-            stream.discard_bootstrap_low_latency_lwe_ciphertext_vector_32(
-                output.0.d_vecs.get_mut(gpu_index).unwrap(),
-                acc.0.d_vecs.get(gpu_index).unwrap(),
-                &d_test_vector_indexes,
-                input.0.d_vecs.get(gpu_index).unwrap(),
-                bsk.0.d_vecs.get(gpu_index).unwrap(),
-                input.0.lwe_dimension,
-                bsk.polynomial_size(),
-                bsk.decomposition_base_log(),
-                bsk.decomposition_level_count(),
-                NumberOfSamples(samples),
-                LweCiphertextIndex(samples_per_gpu * gpu_index),
-                self.get_cuda_shared_memory(),
-            );
-        }
+        execute_lwe_ciphertext_vector_low_latency_bootstrap_on_gpu::<u32>(
+            self.get_cuda_streams(),
+            &mut output.0,
+            &input.0,
+            &acc.0,
+            &bsk.0,
+            self.get_number_of_gpus(),
+            self.get_cuda_shared_memory(),
+        );
     }
 }
 
@@ -300,37 +276,14 @@ impl
         acc: &CudaGlweCiphertextVector64,
         bsk: &CudaFourierLweBootstrapKey64,
     ) {
-        let samples_per_gpu = input.lwe_ciphertext_count().0 / self.get_number_of_gpus();
-
-        for gpu_index in 0..self.get_number_of_gpus() {
-            let mut samples = samples_per_gpu;
-            if gpu_index == self.get_number_of_gpus() - 1
-                && input.lwe_ciphertext_count().0 % self.get_number_of_gpus() as usize != 0
-            {
-                samples +=
-                    input.lwe_ciphertext_count().0 - samples_per_gpu * self.get_number_of_gpus();
-            }
-            let stream = &self.streams[gpu_index];
-            // FIXME this is hard set at the moment because concrete-core does not support a more
-            //   general API for the bootstrap
-            let test_vector_indexes = (0..samples as u32).collect::<Vec<u32>>();
-            let mut d_test_vector_indexes = stream.malloc::<u32>(samples as u32);
-            stream.copy_to_gpu(&mut d_test_vector_indexes, test_vector_indexes.as_slice());
-
-            stream.discard_bootstrap_low_latency_lwe_ciphertext_vector_64(
-                output.0.d_vecs.get_mut(gpu_index).unwrap(),
-                acc.0.d_vecs.get(gpu_index).unwrap(),
-                &d_test_vector_indexes,
-                input.0.d_vecs.get(gpu_index).unwrap(),
-                bsk.0.d_vecs.get(gpu_index).unwrap(),
-                input.0.lwe_dimension,
-                bsk.polynomial_size(),
-                bsk.decomposition_base_log(),
-                bsk.decomposition_level_count(),
-                NumberOfSamples(samples),
-                LweCiphertextIndex(samples_per_gpu * gpu_index),
-                self.get_cuda_shared_memory(),
-            );
-        }
+        execute_lwe_ciphertext_vector_low_latency_bootstrap_on_gpu::<u64>(
+            self.get_cuda_streams(),
+            &mut output.0,
+            &input.0,
+            &acc.0,
+            &bsk.0,
+            self.get_number_of_gpus(),
+            self.get_cuda_shared_memory(),
+        );
     }
 }

--- a/concrete-core/src/backends/cuda/private/crypto/bootstrap/mod.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/bootstrap/mod.rs
@@ -1,12 +1,21 @@
 //! Bootstrap key with Cuda.
+use crate::backends::cuda::engines::SharedMemoryAmount;
+use crate::backends::cuda::private::crypto::glwe::list::CudaGlweList;
+use crate::backends::cuda::private::crypto::lwe::list::CudaLweList;
+use crate::backends::cuda::private::device::{CudaStream, GpuIndex, NumberOfGpus};
 use crate::backends::cuda::private::vec::CudaVec;
+use crate::backends::cuda::private::{compute_number_of_samples_on_gpu, number_of_active_gpus};
+use crate::commons::crypto::bootstrap::StandardBootstrapKey;
+use crate::commons::math::tensor::{AsRefSlice, AsRefTensor};
+use crate::prelude::numeric::UnsignedInteger;
+use crate::prelude::{CiphertextCount, LweCiphertextIndex};
 use concrete_commons::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
 };
 use std::marker::PhantomData;
 
 #[derive(Debug)]
-pub(crate) struct CudaBootstrapKey<T> {
+pub(crate) struct CudaBootstrapKey<T: UnsignedInteger> {
     // Pointers to GPU data: one cuda vec per GPU
     pub(crate) d_vecs: Vec<CudaVec<f64>>,
     // Input LWE dimension
@@ -21,4 +30,140 @@ pub(crate) struct CudaBootstrapKey<T> {
     pub(crate) decomp_base_log: DecompositionBaseLog,
     // Field to hold type T
     pub(crate) _phantom: PhantomData<T>,
+}
+
+pub(crate) unsafe fn convert_lwe_bootstrap_key_from_cpu_to_gpu<T: UnsignedInteger, Cont>(
+    streams: &[CudaStream],
+    input: &StandardBootstrapKey<Cont>,
+    number_of_gpus: NumberOfGpus,
+) -> Vec<CudaVec<f64>>
+where
+    Cont: AsRefSlice<Element = T>,
+{
+    // Copy the entire input vector over all GPUs
+    let mut vecs = Vec::with_capacity(number_of_gpus.0);
+    // TODO
+    //   Check if it would be better to have GPU 0 compute the BSK and copy it back to the
+    //   CPU, then copy the BSK to the other GPUs. The order of instructions varies depending on
+    //   the Cuda warp scheduling, which we cannot assume is deterministic, so we'll end up with
+    //   slightly different BSKs on the GPUs. It is unclear how significantly this affects the
+    //   noise after the bootstrap.
+    let total_polynomials =
+        input.key_size().0 * input.glwe_size().0 * input.glwe_size().0 * input.level_count().0;
+    let alloc_size = total_polynomials * input.polynomial_size().0;
+    for stream in streams.iter() {
+        let mut d_vec = stream.malloc::<f64>(alloc_size as u32);
+        let input_slice = input.as_tensor().as_slice();
+        stream.initialize_twiddles(input.polynomial_size());
+        stream.convert_lwe_bootstrap_key::<T>(
+            &mut d_vec,
+            input_slice,
+            input.key_size(),
+            input.glwe_size().to_glwe_dimension(),
+            input.level_count(),
+            input.polynomial_size(),
+        );
+        vecs.push(d_vec);
+    }
+    vecs
+}
+
+pub(crate) unsafe fn execute_lwe_ciphertext_vector_low_latency_bootstrap_on_gpu<
+    T: UnsignedInteger,
+>(
+    streams: &[CudaStream],
+    output: &mut CudaLweList<T>,
+    input: &CudaLweList<T>,
+    acc: &CudaGlweList<T>,
+    bsk: &CudaBootstrapKey<T>,
+    number_of_available_gpus: NumberOfGpus,
+    cuda_shared_memory: SharedMemoryAmount,
+) {
+    let number_of_gpus = number_of_active_gpus(
+        number_of_available_gpus,
+        CiphertextCount(input.lwe_ciphertext_count.0),
+    );
+    let samples_on_gpu_0 = compute_number_of_samples_on_gpu(
+        number_of_gpus,
+        CiphertextCount(input.lwe_ciphertext_count.0),
+        GpuIndex(0),
+    );
+
+    for (gpu_index, stream) in streams.iter().enumerate().take(number_of_gpus.0) {
+        let samples = compute_number_of_samples_on_gpu(
+            number_of_gpus,
+            CiphertextCount(input.lwe_ciphertext_count.0),
+            GpuIndex(gpu_index),
+        );
+        // FIXME this is hard set at the moment because concrete-core does not support a more
+        //   general API for the bootstrap
+        let test_vector_indexes = (0..samples.0 as u32).collect::<Vec<u32>>();
+        let mut d_test_vector_indexes = stream.malloc::<u32>(samples.0 as u32);
+        stream.copy_to_gpu(&mut d_test_vector_indexes, &test_vector_indexes);
+
+        stream.discard_bootstrap_low_latency_lwe_ciphertext_vector::<T>(
+            output.d_vecs.get_mut(gpu_index).unwrap(),
+            acc.d_vecs.get(gpu_index).unwrap(),
+            &d_test_vector_indexes,
+            input.d_vecs.get(gpu_index).unwrap(),
+            bsk.d_vecs.get(gpu_index).unwrap(),
+            input.lwe_dimension,
+            bsk.polynomial_size,
+            bsk.decomp_base_log,
+            bsk.decomp_level,
+            samples,
+            LweCiphertextIndex(samples_on_gpu_0.0 * gpu_index),
+            cuda_shared_memory,
+        );
+    }
+}
+
+pub(crate) unsafe fn execute_lwe_ciphertext_vector_amortized_bootstrap_on_gpu<
+    T: UnsignedInteger,
+>(
+    streams: &[CudaStream],
+    output: &mut CudaLweList<T>,
+    input: &CudaLweList<T>,
+    acc: &CudaGlweList<T>,
+    bsk: &CudaBootstrapKey<T>,
+    number_of_available_gpus: NumberOfGpus,
+    cuda_shared_memory: SharedMemoryAmount,
+) {
+    let number_of_gpus = number_of_active_gpus(
+        number_of_available_gpus,
+        CiphertextCount(input.lwe_ciphertext_count.0),
+    );
+    let samples_on_gpu_0 = compute_number_of_samples_on_gpu(
+        number_of_gpus,
+        CiphertextCount(input.lwe_ciphertext_count.0),
+        GpuIndex(0),
+    );
+
+    for (gpu_index, stream) in streams.iter().enumerate().take(number_of_gpus.0) {
+        let samples = compute_number_of_samples_on_gpu(
+            number_of_gpus,
+            CiphertextCount(input.lwe_ciphertext_count.0),
+            GpuIndex(gpu_index),
+        );
+        // FIXME this is hard set at the moment because concrete-core does not support a more
+        //   general API for the bootstrap
+        let test_vector_indexes = (0..samples.0 as u32).collect::<Vec<u32>>();
+        let mut d_test_vector_indexes = stream.malloc::<u32>(samples.0 as u32);
+        stream.copy_to_gpu(&mut d_test_vector_indexes, &test_vector_indexes);
+
+        stream.discard_bootstrap_amortized_lwe_ciphertext_vector::<T>(
+            output.d_vecs.get_mut(gpu_index).unwrap(),
+            acc.d_vecs.get(gpu_index).unwrap(),
+            &d_test_vector_indexes,
+            input.d_vecs.get(gpu_index).unwrap(),
+            bsk.d_vecs.get(gpu_index).unwrap(),
+            input.lwe_dimension,
+            bsk.polynomial_size,
+            bsk.decomp_base_log,
+            bsk.decomp_level,
+            samples,
+            LweCiphertextIndex(samples_on_gpu_0.0 * gpu_index),
+            cuda_shared_memory,
+        );
+    }
 }

--- a/concrete-core/src/backends/cuda/private/crypto/keyswitch/mod.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/keyswitch/mod.rs
@@ -1,5 +1,9 @@
 //! Keyswitch key with Cuda.
+use crate::backends::cuda::private::crypto::lwe::list::CudaLweList;
+use crate::backends::cuda::private::device::{CudaStream, GpuIndex, NumberOfGpus};
 use crate::backends::cuda::private::vec::CudaVec;
+use crate::backends::cuda::private::{compute_number_of_samples_on_gpu, number_of_active_gpus};
+use crate::prelude::CiphertextCount;
 use concrete_commons::numeric::UnsignedInteger;
 use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount, LweDimension};
 
@@ -15,4 +19,37 @@ pub(crate) struct CudaLweKeyswitchKey<T: UnsignedInteger> {
     pub(crate) decomp_level: DecompositionLevelCount,
     // Value of the base log for the decomposition
     pub(crate) decomp_base_log: DecompositionBaseLog,
+}
+
+pub(crate) unsafe fn execute_lwe_ciphertext_vector_keyswitch_on_gpu<T: UnsignedInteger>(
+    streams: &[CudaStream],
+    output: &mut CudaLweList<T>,
+    input: &CudaLweList<T>,
+    ksk: &CudaLweKeyswitchKey<T>,
+    number_of_available_gpus: NumberOfGpus,
+) {
+    let number_of_gpus = number_of_active_gpus(
+        number_of_available_gpus,
+        CiphertextCount(input.lwe_ciphertext_count.0),
+    );
+
+    for gpu_index in 0..number_of_gpus.0 {
+        let samples_per_gpu = compute_number_of_samples_on_gpu(
+            number_of_available_gpus,
+            CiphertextCount(input.lwe_ciphertext_count.0),
+            GpuIndex(gpu_index),
+        );
+        let stream = &streams.get(gpu_index).unwrap();
+
+        stream.discard_keyswitch_lwe_ciphertext_vector::<T>(
+            output.d_vecs.get_mut(gpu_index).unwrap(),
+            input.d_vecs.get(gpu_index).unwrap(),
+            input.lwe_dimension,
+            output.lwe_dimension,
+            ksk.d_vecs.get(gpu_index).unwrap(),
+            ksk.decomp_base_log,
+            ksk.decomp_level,
+            samples_per_gpu,
+        );
+    }
 }

--- a/concrete-core/src/backends/cuda/private/crypto/lwe/list.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/lwe/list.rs
@@ -1,4 +1,9 @@
+use crate::backends::cuda::private::device::{CudaStream, GpuIndex, NumberOfGpus};
 use crate::backends::cuda::private::vec::CudaVec;
+use crate::backends::cuda::private::{compute_number_of_samples_on_gpu, number_of_active_gpus};
+use crate::commons::crypto::lwe::LweList;
+use crate::commons::math::tensor::{AsRefSlice, AsRefTensor};
+use crate::prelude::CiphertextCount;
 use concrete_commons::numeric::UnsignedInteger;
 use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
 
@@ -26,4 +31,65 @@ pub(crate) struct CudaLweList<T: UnsignedInteger> {
     pub(crate) lwe_ciphertext_count: LweCiphertextCount,
     // Lwe dimension
     pub(crate) lwe_dimension: LweDimension,
+}
+
+pub(crate) unsafe fn copy_lwe_ciphertext_vector_from_cpu_to_gpu<T: UnsignedInteger, Cont>(
+    streams: &[CudaStream],
+    input: &LweList<Cont>,
+    number_of_available_gpus: NumberOfGpus,
+) -> Vec<CudaVec<T>>
+where
+    Cont: AsRefSlice<Element = T>,
+{
+    let input_slice = input.as_tensor().as_slice();
+    // In case there are less inputs than GPUs, we use just one GPU per input
+    let number_of_gpus = number_of_active_gpus(number_of_available_gpus, input.count());
+    let mut vecs = Vec::with_capacity(number_of_gpus.0);
+    let samples_on_gpu_0 =
+        compute_number_of_samples_on_gpu(number_of_gpus, input.count(), GpuIndex(0));
+    let data_per_gpu = samples_on_gpu_0.0 * input.lwe_size().0;
+    for (gpu_index, chunk) in input_slice.chunks_exact(data_per_gpu).enumerate() {
+        let stream = &streams[gpu_index];
+        let samples =
+            compute_number_of_samples_on_gpu(number_of_gpus, input.count(), GpuIndex(gpu_index));
+        let alloc_size = samples.0 * input.lwe_size().0;
+        if gpu_index == number_of_gpus.0 - 1 {
+            let mut d_vec = stream.malloc::<T>(alloc_size as u32);
+            let chunk_and_remainder =
+                [chunk, input_slice.chunks_exact(data_per_gpu).remainder()].concat();
+            stream.copy_to_gpu::<T>(&mut d_vec, chunk_and_remainder.as_slice());
+            vecs.push(d_vec);
+        } else {
+            let mut d_vec = stream.malloc::<T>(alloc_size as u32);
+            stream.copy_to_gpu::<T>(&mut d_vec, chunk);
+            vecs.push(d_vec);
+        }
+    }
+    vecs
+}
+
+pub(crate) unsafe fn copy_lwe_ciphertext_vector_from_gpu_to_cpu<T: UnsignedInteger>(
+    streams: &[CudaStream],
+    input: &CudaLweList<T>,
+    number_of_available_gpus: NumberOfGpus,
+) -> Vec<T> {
+    let samples_per_gpu = compute_number_of_samples_on_gpu(
+        number_of_available_gpus,
+        CiphertextCount(input.lwe_ciphertext_count.0),
+        GpuIndex(0),
+    );
+    let data_per_gpu = samples_per_gpu.0 * input.lwe_dimension.to_lwe_size().0;
+
+    let mut output =
+        vec![T::ZERO; input.lwe_dimension.to_lwe_size().0 * input.lwe_ciphertext_count.0];
+    for (gpu_index, chunks) in output.chunks_exact_mut(data_per_gpu).enumerate() {
+        let stream = &streams[gpu_index];
+        stream.copy_to_cpu::<T>(chunks, input.d_vecs.get(gpu_index).unwrap());
+    }
+    if samples_per_gpu.0 * number_of_available_gpus.0 < input.lwe_ciphertext_count.0 {
+        let last_chunk = output.chunks_exact_mut(data_per_gpu).into_remainder();
+        let last_stream = streams.last().unwrap();
+        last_stream.copy_to_cpu::<T>(last_chunk, input.d_vecs.last().unwrap());
+    }
+    output
 }

--- a/concrete-core/src/backends/cuda/private/mod.rs
+++ b/concrete-core/src/backends/cuda/private/mod.rs
@@ -1,4 +1,34 @@
+use crate::backends::cuda::private::device::{GpuIndex, NumberOfGpus, NumberOfSamples};
+use concrete_commons::parameters::CiphertextCount;
+use std::cmp::min;
+
 pub mod crypto;
 pub mod device;
 pub mod pointers;
 pub mod vec;
+
+pub(crate) fn number_of_active_gpus(
+    total_number_of_gpus: NumberOfGpus,
+    lwe_ciphertext_count: CiphertextCount,
+) -> NumberOfGpus {
+    let mut n = total_number_of_gpus.0;
+    // In case there are more GPUs than inputs, use only as many GPUs as there are inputs
+    if lwe_ciphertext_count.0 < n {
+        n = min(lwe_ciphertext_count.0, total_number_of_gpus.0)
+    }
+    NumberOfGpus(n)
+}
+
+pub(crate) fn compute_number_of_samples_on_gpu(
+    number_of_gpus: NumberOfGpus,
+    lwe_ciphertext_count: CiphertextCount,
+    gpu_index: GpuIndex,
+) -> NumberOfSamples {
+    let samples_per_gpu = lwe_ciphertext_count.0 / number_of_gpus.0;
+    let mut samples = samples_per_gpu;
+    // We add the remainder of the integer division lwe_count/num_gpus to the load of the last GPU
+    if gpu_index.0 == number_of_gpus.0 - 1 {
+        samples += lwe_ciphertext_count.0 % number_of_gpus.0;
+    }
+    NumberOfSamples(samples)
+}

--- a/concrete-core/src/commons/crypto/lwe/ciphertext.rs
+++ b/concrete-core/src/commons/crypto/lwe/ciphertext.rs
@@ -638,7 +638,7 @@ impl<Cont> LweCiphertext<Cont> {
     /// glwe_secret_key.encrypt_glwe(
     ///     &mut glwe_ct,
     ///     &plaintext_list,
-    ///     LogStandardDev(-25.),
+    ///     LogStandardDev(-50.),
     ///     &mut encryption_generator,
     /// );
     /// let lwe_secret_key = glwe_secret_key.into_lwe_secret_key();


### PR DESCRIPTION
### Resolves: https://github.com/zama-ai/concrete-core-internal/issues/382 and https://github.com/zama-ai/concrete-core-internal/issues/389
### Description
+ Fix multi GPU when there are few inputs: in case the number of GPUs is lower than the number of inputs, restrict the number of GPUs used to the number of inputs.
+ Also, change some types so that it feels more natural to use them.
### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
