### PR TITLE
feat(concrete_core_representation): add concrete-core sources analysis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "concrete-core-fixture",
     "concrete-core-test",
     "concrete-core-wasm",
+    "concrete-core-representation",
     "concrete-cuda",
 ]
 

--- a/concrete-core-representation/Cargo.toml
+++ b/concrete-core-representation/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "concrete-core-representation"
+version = "0.0.0"
+edition = "2021"
+authors = ["Zama team"]
+license = "BSD-3-Clause-Clear"
+readme = "README.md"
+
+[dependencies]
+syn={version="1.0", features=["full", "extra-traits"]}
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+quote = "1.0"
+
+[[bin]]
+name = "summary"
+path = "bin/summary.rs"
+
+[[bin]]
+name = "dump"
+path = "bin/dump.rs"

--- a/concrete-core-representation/LICENSE
+++ b/concrete-core-representation/LICENSE
@@ -1,0 +1,33 @@
+BSD 3-Clause Clear License
+
+Copyright © 2022 ZAMA.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or other
+materials provided with the distribution.
+
+3. Neither the name of ZAMA nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS LICENSE*.
+THIS SOFTWARE IS PROVIDED BY THE ZAMA AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ZAMA OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*In addition to the rights carried by this license, ZAMA grants to the user a non-exclusive,
+free and non-commercial license on all patents filed in its name relating to the open-source
+code (the "Patents") for the sole purpose of evaluation, development, research, prototyping
+and experimentation.

--- a/concrete-core-representation/README.md
+++ b/concrete-core-representation/README.md
@@ -1,0 +1,28 @@
+# Concrete Core Representation
+
+This library contains tools to perform source-code analysis on the `concrete-core` repository.
+
+## Output a human readable summary of the local sources
+
+You can output a human readable summary of the local sources with the following command:
+```shell
+cargo run --release -p concrete-core-representation --bin summary
+```
+
+## Dump the representation of the local repository
+
+Alternatively, for a finer grained picture of the source code (and for debugging), you can dump a 
+json representation of the sources in `/tmp/ccr_dump.json`
+```shell
+cargo run --release -p concrete-core-representation --bin dump
+```
+
+Firefox has a nice built-in json viewer:
+```shell
+firefox /tmp/ccr_dump.json
+```
+
+## License
+
+This software is distributed under the BSD-3-Clause-Clear license. If you have any questions,
+please contact us at `hello@zama.ai`.

--- a/concrete-core-representation/bin/dump.rs
+++ b/concrete-core-representation/bin/dump.rs
@@ -1,0 +1,10 @@
+use concrete_core_representation::{dump_ccr_to_file, load_ccr};
+
+mod root;
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| String::from("/tmp/ccr_dump.json"));
+    dump_ccr_to_file(path.as_str(), load_ccr(root::get_concrete_core_root()));
+}

--- a/concrete-core-representation/bin/root.rs
+++ b/concrete-core-representation/bin/root.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+
+pub fn get_concrete_core_root() -> PathBuf {
+    PathBuf::from(file!())
+        .parent()
+        .unwrap()
+        .join("../..")
+        .canonicalize()
+        .unwrap()
+        .join("concrete-core/src/lib.rs")
+}

--- a/concrete-core-representation/bin/summary.rs
+++ b/concrete-core-representation/bin/summary.rs
@@ -1,0 +1,8 @@
+use concrete_core_representation::{load_ccr, print_ccr};
+
+mod root;
+
+fn main() {
+    let ccr = load_ccr(root::get_concrete_core_root());
+    print_ccr(&ccr);
+}

--- a/concrete-core-representation/src/ccr/abstract_engine_trait_impl.rs
+++ b/concrete-core-representation/src/ccr/abstract_engine_trait_impl.rs
@@ -1,0 +1,111 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing an implementation of the `AbstractEngine` trait.
+#[derive(Serialize, Clone, Debug)]
+pub struct AbstractEngineTraitImpl {
+    pub cfg: CfgStack,
+    #[serde(serialize_with = "serialize_with_token_string")]
+    pub item_impl: syn::ItemImpl,
+    #[serde(serialize_with = "serialize_with_token_string")]
+    pub engine_type_ident: syn::Ident,
+}
+
+impl AbstractEngineTraitImpl {
+    /// From an `ItemMod` syn ast node, pointing to a module in a backend, recursively extracts all
+    /// the `AbstractEngineTraitImpl`.
+    pub fn extract_all(
+        cfg_stack_so_far: &CfgStack,
+        module: &syn::ItemMod,
+    ) -> Vec<AbstractEngineTraitImpl> {
+        // INVARIANT: engine types are identified with their original identifier in the abstract
+        // engine impl, not with a path, nor an alias.
+        // INVARIANT: the abstract engine trait is identified by its original identifier
+        // `AbstractEngine`
+        let mut output = Vec::new();
+        if module.content.is_none() {
+            return output;
+        }
+
+        for item in module.content.as_ref().unwrap().1.iter() {
+            // If the item is a module, we recurse:
+            if let syn::Item::Mod(item_mod) = item {
+                output.extend(
+                    AbstractEngineTraitImpl::extract_all(
+                        &cfg_stack_so_far.concat_attrs(item_mod.attrs.as_slice()),
+                        item_mod,
+                    )
+                    .into_iter(),
+                );
+                continue;
+            }
+
+            // If the item is an abstract engine impl, we add it.
+            let maybe_item_impl = probe!(
+                Some(item),
+                syn::Item::Impl(item_impl) => item_impl
+            );
+            let maybe_abstract_engine_impl = probe!(
+                maybe_item_impl,
+                item_impl >> item_impl.trait_.as_ref(),
+                trait_ >> trait_.1.segments.first(),
+                trait_path -> &trait_path.ident,
+                trait_ident ?> *trait_ident == "AbstractEngine",
+                X> maybe_item_impl,
+                item_impl -> item_impl.self_ty.as_ref(),
+                syn::Type::Path(self_path) => self_path,
+                self_path ?> self_path.path.segments.len() == 1,
+                self_path >> self_path.path.segments.first(),
+                self_segment -> &self_segment.ident,
+                self_ident >> pack_somes!(Some(self_ident), maybe_item_impl),
+                tuple -> {
+                    let (engine_type_ident, item_impl) = tuple;
+                    AbstractEngineTraitImpl{
+                        cfg: cfg_stack_so_far.concat_attrs(item_impl.attrs.as_slice()),
+                        item_impl: item_impl.to_owned(),
+                        engine_type_ident: engine_type_ident.to_owned()
+                    }
+                }
+            );
+            if let Some(abstract_engine_trait_impl) = maybe_abstract_engine_impl {
+                output.push(abstract_engine_trait_impl);
+            }
+        }
+        output
+    }
+
+    /// Returns the `syn` node pointing to the constructor of the implementation.
+    pub fn get_constructor(&self) -> &syn::ImplItemMethod {
+        // INVARIANT: The constructor is called `new`
+        self.item_impl
+            .items
+            .iter()
+            .find_map(|item| {
+                probe!(
+                    Some(item),
+                    syn::ImplItem::Method(impl_item_method) => impl_item_method,
+                    impl_item_method ?> impl_item_method.sig.ident == "new"
+                )
+            })
+            .unwrap()
+    }
+
+    /// Returns the `syn` node pointing to the `Parameters` associated type of the implementation.
+    pub fn get_parameters_associated_type(&self) -> &syn::Type {
+        // INVARIANT: The constructor take a single parameter whose type is the associated
+        // `Parameters` type.
+        // INVARIANT: The `Parameters` type is either a Path or a tuple of paths.
+        self.item_impl
+            .items
+            .iter()
+            .find_map(|item| {
+                probe!(
+                    Some(item),
+                    syn::ImplItem::Type(impl_item_type) => impl_item_type,
+                    impl_item_type ?> impl_item_type.ident == "Parameters",
+                    impl_item_type -> &impl_item_type.ty
+                )
+            })
+            .unwrap()
+    }
+}

--- a/concrete-core-representation/src/ccr/abstract_entity_trait_impl.rs
+++ b/concrete-core-representation/src/ccr/abstract_entity_trait_impl.rs
@@ -1,0 +1,74 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing an implementation of the `AbstractEntity` trait.
+#[derive(Serialize, Clone, Debug)]
+pub struct AbstractEntityTraitImpl {
+    pub cfg: CfgStack,
+    #[serde(serialize_with = "serialize_with_token_string")]
+    pub item_impl: syn::ItemImpl,
+    #[serde(serialize_with = "serialize_with_token_string")]
+    pub entity_type_ident: syn::Ident,
+}
+
+impl AbstractEntityTraitImpl {
+    /// From an `ItemMod` syn ast node, pointing to a module in a backend, recursively extracts all
+    /// the `AbstractEntityTraitImpl`.
+    pub(crate) fn extract_all(
+        cfg_stack_so_far: &CfgStack,
+        module: &syn::ItemMod,
+    ) -> Vec<AbstractEntityTraitImpl> {
+        // INVARIANT: entity types are identified with their original identifier in the abstract
+        // entity impl, not with a path, nor an alias.
+        // INVARIANT: the abstract entity trait is identified by its original identifier
+        // `AbstractEntity`
+
+        let mut output = Vec::new();
+        if module.content.is_none() {
+            return output;
+        }
+
+        for item in module.content.as_ref().unwrap().1.iter() {
+            // If the item is a module, we recurse.
+            if let syn::Item::Mod(item_mod) = item {
+                output.extend(AbstractEntityTraitImpl::extract_all(
+                    &cfg_stack_so_far.concat_attrs(item_mod.attrs.as_slice()),
+                    item_mod,
+                ));
+                continue;
+            }
+
+            // If the item is an abstract entity impl, we add it to the output.
+            let maybe_item_impl = probe!(
+                Some(item),
+                syn::Item::Impl(item_impl) => item_impl
+            );
+            let maybe_abstract_entity_impl = probe!(
+                maybe_item_impl,
+                item_impl >> item_impl.trait_.as_ref(),
+                trait_ >> trait_.1.segments.first(),
+                trait_path -> &trait_path.ident,
+                trait_ident ?> *trait_ident == "AbstractEntity",
+                X> maybe_item_impl,
+                item_impl -> item_impl.self_ty.as_ref(),
+                syn::Type::Path(self_path) => self_path,
+                self_path ?> self_path.path.segments.len() == 1,
+                self_path >> self_path.path.segments.first(),
+                self_segment -> &self_segment.ident,
+                self_ident >> pack_somes!(Some(self_ident), maybe_item_impl),
+                tuple -> {
+                    let (entity_type_ident, item_impl) = tuple;
+                    AbstractEntityTraitImpl{
+                        cfg: cfg_stack_so_far.concat_attrs(item_impl.attrs.as_slice()),
+                        item_impl: item_impl.to_owned(),
+                        entity_type_ident: entity_type_ident.to_owned()
+                    }
+                }
+            );
+            if let Some(node) = maybe_abstract_entity_impl {
+                output.push(node);
+            }
+        }
+        output
+    }
+}

--- a/concrete-core-representation/src/ccr/backend.rs
+++ b/concrete-core-representation/src/ccr/backend.rs
@@ -1,0 +1,63 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing a concrete-core backend.
+#[derive(Serialize, Clone, Debug)]
+pub struct Backend {
+    pub cfg: CfgStack,
+    #[serde(serialize_with = "serialize_with_token_string")]
+    pub ident: syn::Ident,
+    pub engines: Vec<Engine>,
+    pub entities: Vec<Entity>,
+    pub configs: Vec<Config>,
+}
+
+impl Backend {
+    /// From an `ItemMod` syn ast node, pointing to the `backends` module, extracts a vec of
+    /// `Backend`.
+    pub(crate) fn extract_all(
+        cfg_stack_so_far: &CfgStack,
+        backends_module: &syn::ItemMod,
+    ) -> Vec<Backend> {
+        // INVARIANT: All modules in the `backends` module, are backends.
+        backends_module
+            .content
+            .as_ref()
+            .expect("The `backends` module has no content...")
+            .1
+            .iter()
+            .filter_map(|item| {
+                if let syn::Item::Mod(item_mod) = item {
+                    Some(Backend::extract_one(cfg_stack_so_far, item_mod))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// From an `ItemMod` syn ast node, pointing to a backend module, extract a `Backend`.
+    pub(crate) fn extract_one(
+        cfg_stack_so_far: &CfgStack,
+        backend_module: &syn::ItemMod,
+    ) -> Backend {
+        // INVARIANT: The attributes of the backend modules are cfg feature configurations
+        let cfg = cfg_stack_so_far.concat_attrs(backend_module.attrs.as_slice());
+        let ident = backend_module.ident.clone();
+
+        // Gather the entity items
+        let entities = Entity::extract_all(&cfg, backend_module);
+        // Gather the config items
+        let configs = Config::extract_all(&cfg, backend_module);
+        // Gather the engine items
+        let engines = Engine::extract_all(&cfg, backend_module);
+
+        Backend {
+            cfg,
+            ident,
+            configs,
+            engines,
+            entities,
+        }
+    }
+}

--- a/concrete-core-representation/src/ccr/cfg_stack.rs
+++ b/concrete-core-representation/src/ccr/cfg_stack.rs
@@ -1,0 +1,46 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing a stack of `cfg` attributes.
+///
+/// As we go deeper in the nesting of modules and items, we apply more and more cfg attributes. This
+/// structure represents that.
+#[derive(Serialize, Clone, Debug)]
+pub struct CfgStack(#[serde(serialize_with = "serialize_vec_with_token_string")] Vec<TokenStream2>);
+
+impl CfgStack {
+    /// Creates an empty stack.
+    pub fn empty() -> CfgStack {
+        CfgStack(Vec::new())
+    }
+
+    /// Creates a stack from a slice of syn attributes.
+    pub fn from_attr(attrs: &[syn::Attribute]) -> Self {
+        let mut stack = Self::empty();
+        stack.push_attrs(attrs);
+        stack
+    }
+
+    /// Adds a set of syn attributes to an existing stack.
+    pub fn push_attrs(&mut self, attrs: &[syn::Attribute]) {
+        attrs
+            .iter()
+            .filter_map(|att| {
+                probe!(
+                    Some(att),
+                    att >> att.path.get_ident(),
+                    ident ?> *ident == "cfg",
+                    X> Some(att.tokens.clone())
+                )
+            })
+            .for_each(|ts| self.0.push(ts));
+    }
+
+    /// Creates a new stack which is a copy of the current stack, to which the `attrs` attributes
+    /// were pushed.
+    pub fn concat_attrs(&self, attrs: &[syn::Attribute]) -> CfgStack {
+        let mut output = self.clone();
+        output.push_attrs(attrs);
+        output
+    }
+}

--- a/concrete-core-representation/src/ccr/concrete_core.rs
+++ b/concrete-core-representation/src/ccr/concrete_core.rs
@@ -1,0 +1,801 @@
+use super::*;
+
+/// The top node of the `ccr`, representing a whole `concrete-core` repository.
+#[derive(Serialize, Clone, Debug)]
+pub struct ConcreteCore {
+    pub backends: Vec<Backend>,
+}
+
+/// A private enum used to classify the identifiers.
+enum IdentKind {
+    OwnedEntity,
+    ViewEntity,
+    MutViewEntity,
+    Config(syn::Ident),
+    Parameter,
+    Dispersion,
+    Numeric(syn::Ident),
+    Unknown,
+}
+
+impl ConcreteCore {
+    /// From a `File` syn ast node, pointing to the root file of the `concrete-core` sources,
+    /// extract the top `ConcreteCore` node.
+    pub(crate) fn extract(cfg_stack_so_far: &CfgStack, root: &syn::File) -> ConcreteCore {
+        // INVARIANT: The root module contains a `backend` module
+        // INVARIANT: Two backends can not export items with the same name
+        let backends_module = root
+            .items
+            .iter()
+            .cloned()
+            .find_map(|item| {
+                if let syn::Item::Mod(item_mod) = item {
+                    if item_mod.ident == "backends" {
+                        return Some(item_mod);
+                    }
+                }
+                None
+            })
+            .expect("Failed to retrieve the `backends` module.");
+
+        // Gather the backends
+        let mut backends = Backend::extract_all(cfg_stack_so_far, &backends_module);
+
+        // Now that we have gathered all the items of the different backends, we can push the
+        // analysis further
+        let all_entities: Vec<Entity> = backends
+            .iter()
+            .flat_map(|backend| backend.entities.iter().cloned())
+            .collect();
+        let all_config: Vec<Config> = backends
+            .iter()
+            .flat_map(|backend| backend.configs.iter().cloned())
+            .collect();
+        let mut all_engines: Vec<&mut Engine> = backends
+            .iter_mut()
+            .flat_map(|backend| backend.engines.iter_mut())
+            .collect();
+        let ident_classifier = |ident: &syn::Ident| -> IdentKind {
+            if all_entities
+                .iter()
+                .filter(|ent| matches!(ent.definition.ownership, EntityOwnership::Owned))
+                .any(|ent| ident == ent.definition.get_ident())
+            {
+                IdentKind::OwnedEntity
+            } else if all_entities
+                .iter()
+                .filter(|ent| matches!(ent.definition.ownership, EntityOwnership::View))
+                .any(|ent| ident == ent.definition.get_ident())
+            {
+                IdentKind::ViewEntity
+            } else if all_entities
+                .iter()
+                .filter(|ent| matches!(ent.definition.ownership, EntityOwnership::MutView))
+                .any(|ent| ident == ent.definition.get_ident())
+            {
+                IdentKind::MutViewEntity
+            } else if all_config
+                .iter()
+                .any(|conf| ident == &conf.item_struct.ident)
+            {
+                IdentKind::Config(ident.to_owned())
+            } else if PARAMETERS_IDENTS.iter().any(|param| ident == param) {
+                IdentKind::Parameter
+            } else if DISPERSION_IDENTS.iter().any(|disp| ident == disp) {
+                IdentKind::Dispersion
+            } else if NUMERIC_IDENTS.iter().any(|num| ident == num) {
+                IdentKind::Numeric(ident.to_owned())
+            } else {
+                IdentKind::Unknown
+            }
+        };
+
+        // Perform classification of engine impl generic args
+        classify_engine_trait_impl_generic_args(&mut all_engines, ident_classifier);
+        // Perform classification of checked method args
+        classify_engine_trait_impl_args(&mut all_engines, ident_classifier);
+        // Perform classification of checked method return
+        classify_engine_trait_impl_return(&mut all_engines, ident_classifier);
+
+        ConcreteCore { backends }
+    }
+}
+
+fn classify_engine_trait_impl_generic_args(
+    engines: &mut [&mut Engine],
+    classifier: impl FnOnce(&syn::Ident) -> IdentKind + Copy,
+) {
+    // INVARIANT: Config and entity types generic arguments are provided as identifiers in the
+    // engine trait impls.
+    for engine_impl in engines
+        .iter_mut()
+        .flat_map(|eng| eng.engine_impls.iter_mut())
+    {
+        engine_impl.engine_trait_parameters.prepare(|param| {
+            param.args.iter().map(|arg| {
+                // We check if the argument is an owned entity
+                let maybe_owned_entity = probe!(
+                    Some(arg),
+                    syn::GenericArgument::Type(type_) => type_,
+                    syn::Type::Path(path) => path,
+                    path >> path.path.segments.last(),
+                    segment -> &segment.ident,
+                    ident -> classifier(ident),
+                    IdentKind::OwnedEntity => (),
+                    X> Some(arg),
+                    syn::GenericArgument::Type(arg) => arg,
+                    arg -> EngineTraitImplGenericArgument::OwnedEntity(arg.to_owned())
+                );
+                if let Some(owned_entity) = maybe_owned_entity {return owned_entity }
+
+                // We check if the argument is a view entity
+                let maybe_view_entity = probe!(
+                    Some(arg),
+                    syn::GenericArgument::Type(type_) => type_,
+                    syn::Type::Path(path) => path,
+                    path >> path.path.segments.last(),
+                    segment -> &segment.ident,
+                    ident -> classifier(ident),
+                    IdentKind::ViewEntity => (),
+                    X> Some(arg),
+                    syn::GenericArgument::Type(arg) => arg,
+                    arg -> EngineTraitImplGenericArgument::ViewEntity(arg.to_owned())
+                );
+                if let Some(view_entity) = maybe_view_entity {return view_entity }
+
+                // We check if the argument is a mut view entity
+                let maybe_mut_view_entity = probe!(
+                    Some(arg),
+                    syn::GenericArgument::Type(type_) => type_,
+                    syn::Type::Path(path) => path,
+                    path >> path.path.segments.last(),
+                    segment -> &segment.ident,
+                    ident -> classifier(ident),
+                    IdentKind::MutViewEntity => (),
+                    X> Some(arg),
+                    syn::GenericArgument::Type(arg) => arg,
+                    arg -> EngineTraitImplGenericArgument::MutViewEntity(arg.to_owned())
+                );
+                if let Some(mut_view_entity) = maybe_mut_view_entity {return mut_view_entity }
+
+                // We check if the argument is a config
+                let maybe_config = probe!(
+                    Some(arg),
+                    syn::GenericArgument::Type(type_) => type_,
+                    syn::Type::Path(path) => path,
+                    path >> path.path.segments.last(),
+                    segment -> &segment.ident,
+                    ident -> classifier(ident),
+                    IdentKind::Config(_) => (),
+                    X> Some(arg),
+                    syn::GenericArgument::Type(arg) => arg,
+                    arg -> EngineTraitImplGenericArgument::Config(arg.to_owned())
+                );
+                if let Some(config) = maybe_config {return config }
+
+                // We check if the argument is a numeric
+                let maybe_numeric = probe!(
+                    Some(arg),
+                    syn::GenericArgument::Type(type_) => type_,
+                    syn::Type::Path(path) => path,
+                    path >> path.path.segments.last(),
+                    segment -> &segment.ident,
+                    ident -> classifier(ident),
+                    IdentKind::Numeric(_) => (),
+                    X> Some(arg),
+                    syn::GenericArgument::Type(arg) => arg,
+                    arg -> EngineTraitImplGenericArgument::Numeric(arg.to_owned())
+                );
+                if let Some(numeric) = maybe_numeric {return numeric }
+
+                // We check if the argument is a slice of numeric
+                let maybe_numeric_slice = probe!(
+                    Some(arg),
+                    syn::GenericArgument::Type(type_) => type_,
+                    syn::Type::Reference(ref_) => ref_,
+                    ref_ ?> ref_.mutability.is_none(),
+                    ref_ -> ref_.elem.as_ref(),
+                    syn::Type::Slice(slice) => slice,
+                    slice -> slice.elem.as_ref(),
+                    syn::Type::Path(path) => path,
+                    path >> path.path.segments.last(),
+                    segment -> &segment.ident,
+                    ident -> classifier(ident),
+                    IdentKind::Numeric(_) => (),
+                    X> Some(arg),
+                    syn::GenericArgument::Type(arg) => arg,
+                    arg -> EngineTraitImplGenericArgument::NumericSlice(arg.to_owned())
+                );
+                if let Some(numeric_slice) = maybe_numeric_slice {return numeric_slice }
+
+                // We check if the argument is a mut slice of numeric
+                let maybe_numeric_slice_mut = probe!(
+                    Some(arg),
+                    syn::GenericArgument::Type(type_) => type_,
+                    syn::Type::Reference(ref_) => ref_,
+                    ref_ ?> ref_.mutability.is_some(),
+                    ref_ -> ref_.elem.as_ref(),
+                    syn::Type::Slice(slice) => slice,
+                    slice -> slice.elem.as_ref(),
+                    syn::Type::Path(path) => path,
+                    path >> path.path.segments.last(),
+                    segment -> &segment.ident,
+                    ident -> classifier(ident),
+                    IdentKind::Numeric(_) => (),
+                    X> Some(arg),
+                    syn::GenericArgument::Type(arg) => arg,
+                    arg -> EngineTraitImplGenericArgument::NumericSliceMut(arg.to_owned())
+                );
+                if let Some(numeric_slice_mut) = maybe_numeric_slice_mut {return numeric_slice_mut }
+
+                // We check if the argument is a mut slice of numeric
+                let maybe_numeric_vec = probe!(
+                    Some(arg),
+                    syn::GenericArgument::Type(type_) => type_,
+                    syn::Type::Path(path) => path,
+                    path >> path.path.segments.last(),
+                    segment ?> segment.ident == "Vec",
+                    segment -> &segment.arguments,
+                    syn::PathArguments::AngleBracketed(v) => v,
+                    arguments >> arguments.args.first(),
+                    syn::GenericArgument::Type(v) => v,
+                    syn::Type::Path(path) => path,
+                    path >> path.path.segments.last(),
+                    segment -> &segment.ident,
+                    ident -> classifier(ident),
+                    IdentKind::Numeric(_) => (),
+                    X> Some(arg),
+                    syn::GenericArgument::Type(arg) => arg,
+                    arg -> EngineTraitImplGenericArgument::NumericVec(arg.to_owned())
+                );
+                if let Some(numeric_vec) = maybe_numeric_vec {return numeric_vec }
+
+                // We could not recognize the argument :(
+                if let syn::GenericArgument::Type(arg) = arg {
+                    EngineTraitImplGenericArgument::Unknown(arg.to_owned())
+                } else {
+                    panic!("Only types are allowed to be passed as generic argument to the trait in an *Engine trait implementation.")
+                }
+            }).collect()
+        });
+    }
+}
+
+fn classify_engine_trait_impl_args(
+    engines: &mut [&mut Engine],
+    classifier: impl FnOnce(&syn::Ident) -> IdentKind + Copy,
+) {
+    // INVARIANT: Config and entity types arguments are provided as identifiers in the checked
+    // method. INVARIANT: The pattern side of the argument is an identifier (not a pattern).
+    // INVARIANT: Entities and config arguments to checked method  can only appear as path or
+    // reference.
+
+    // We loop through the engines impl blocks
+    for engine_impl in engines
+        .iter_mut()
+        .flat_map(|eng| eng.engine_impls.iter_mut())
+    {
+        // We finish the analysis
+        engine_impl.checked_method.args.prepare(|sig| {
+            sig.inputs
+                .iter()
+                .filter_map(|arg| {
+                    if let syn::FnArg::Receiver(_) = arg {
+                        // The argument is &mut self, we don't treat this one.
+                        return None;
+                    }
+
+                    let pat_type = probe!(Some(arg), syn::FnArg::Typed(n) => n).unwrap();
+                    let pat_ident =
+                        probe!(Some(pat_type.pat.as_ref()), syn::Pat::Ident(p) => p).unwrap();
+
+                    // Detect if the argument is an owned entity
+                    let maybe_owned_entity = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Path(path) => path,
+                        path >> path.path.segments.last(),
+                        segment -> classifier(&segment.ident),
+                        IdentKind::OwnedEntity =>
+                            EngineTraitImplArg::OwnedEntity(
+                                pat_ident.to_owned(),
+                                *pat_type.ty.clone()
+                            )
+                    );
+                    if maybe_owned_entity.is_some() {
+                        return maybe_owned_entity;
+                    }
+
+                    // Detect if the argument is a view entity
+                    let maybe_view_entity = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Path(path) => path,
+                        path >> path.path.segments.last(),
+                        segment -> classifier(&segment.ident),
+                        IdentKind::ViewEntity =>
+                            EngineTraitImplArg::ViewEntity(
+                                pat_ident.to_owned(),
+                                *pat_type.ty.clone()
+                            )
+                    );
+                    if maybe_view_entity.is_some() {
+                        return maybe_view_entity;
+                    }
+
+                    // Detect if the argument is a mut view entity
+                    let maybe_mut_view_entity = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Path(path) => path,
+                        path >> path.path.segments.last(),
+                        segment -> classifier(&segment.ident),
+                        IdentKind::MutViewEntity =>
+                            EngineTraitImplArg::MutViewEntity(
+                                pat_ident.to_owned(),
+                                *pat_type.ty.clone()
+                            )
+                    );
+                    if maybe_mut_view_entity.is_some() {
+                        return maybe_mut_view_entity;
+                    }
+
+                    // Detect if the argument is a parameter
+                    let maybe_parameter = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Path(path) => path,
+                        path >> path.path.segments.last(),
+                        segment -> classifier(&segment.ident),
+                        IdentKind::Parameter =>
+                            EngineTraitImplArg::Parameter(
+                                pat_ident.to_owned(),
+                                *pat_type.ty.clone()
+                            )
+                    );
+                    if maybe_parameter.is_some() {
+                        return maybe_parameter;
+                    }
+
+                    // Detect if the argument is a dispersion
+                    let maybe_dispersion = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Path(path) => path,
+                        path >> path.path.segments.last(),
+                        segment -> classifier(&segment.ident),
+                        IdentKind::Dispersion =>
+                            EngineTraitImplArg::Dispersion(
+                                pat_ident.to_owned(),
+                                *pat_type.ty.clone()
+                            )
+                    );
+                    if maybe_dispersion.is_some() {
+                        return maybe_dispersion;
+                    }
+
+                    // Detect if the argument is a numeric
+                    let maybe_numeric = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Path(path) => path,
+                        path >> path.path.segments.last(),
+                        segment -> classifier(&segment.ident),
+                        IdentKind::Numeric(_) =>
+                            EngineTraitImplArg::Numeric(
+                                pat_ident.to_owned(),
+                                *pat_type.ty.clone()
+                            )
+                    );
+                    if maybe_numeric.is_some() {
+                        return maybe_numeric;
+                    }
+
+                    // Detect if the argument is a vec of numeric
+                    let maybe_numeric_vec = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Path(path) => path,
+                        path >> path.path.segments.last(),
+                        segment ?> segment.ident == "Vec",
+                        segment -> &segment.arguments,
+                        syn::PathArguments::AngleBracketed(v) => v,
+                        arguments >> arguments.args.first(),
+                        syn::GenericArgument::Type(v) => v,
+                        syn::Type::Path(v) => v,
+                        path >> path.path.segments.last(),
+                        segment -> classifier(&segment.ident),
+                        IdentKind::Numeric(ident) =>
+                            EngineTraitImplArg::NumericVec(
+                                pat_ident.to_owned(),
+                                *pat_type.ty.clone(),
+                                ident
+                            )
+                    );
+                    if maybe_numeric_vec.is_some() {
+                        return maybe_numeric_vec;
+                    }
+
+                    // Detect if the argument is a numeric mut ref.
+                    let maybe_numeric_mut_ref = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Reference(ref_) => ref_,
+                        ref_ ?> ref_.mutability.is_some(),
+                        ref_ -> ref_.elem.as_ref(),
+                        syn::Type::Path(ref_type) => ref_type,
+                        ref_type >> ref_type.path.segments.last(),
+                        ref_type -> &ref_type.ident,
+                        ref_type_ident -> classifier(ref_type_ident),
+                        IdentKind::Numeric(ident) =>
+                            EngineTraitImplArg::NumericRefMut(
+                                pat_ident.to_owned(),
+                                *pat_type.ty.clone(),
+                                ident
+                            )
+                    );
+                    if maybe_numeric_mut_ref.is_some() {
+                        return maybe_numeric_mut_ref;
+                    }
+
+                    // Detect if the argument is a owned entity mut ref.
+                    let maybe_owned_entity_mut_ref = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Reference(ref_) => ref_,
+                        ref_ ?> ref_.mutability.is_some(),
+                        ref_ -> ref_.elem.as_ref(),
+                        syn::Type::Path(ref_type) => ref_type,
+                        ref_type >> ref_type.path.segments.last(),
+                        ref_type -> &ref_type.ident,
+                        ref_type_ident -> classifier(ref_type_ident),
+                        IdentKind::OwnedEntity =>
+                            EngineTraitImplArg::OwnedEntityRefMut(
+                                        pat_ident.to_owned(),
+                                        *pat_type.ty.clone(),
+                            )
+                    );
+                    if maybe_owned_entity_mut_ref.is_some() {
+                        return maybe_owned_entity_mut_ref;
+                    }
+
+                    // Detect if the argument is a mut view entity mut ref.
+                    let maybe_owned_entity_mut_ref = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Reference(ref_) => ref_,
+                        ref_ ?> ref_.mutability.is_some(),
+                        ref_ -> ref_.elem.as_ref(),
+                        syn::Type::Path(ref_type) => ref_type,
+                        ref_type >> ref_type.path.segments.last(),
+                        ref_type -> &ref_type.ident,
+                        ref_type_ident -> classifier(ref_type_ident),
+                        IdentKind::MutViewEntity =>
+                            EngineTraitImplArg::MutViewEntityRefMut(
+                                        pat_ident.to_owned(),
+                                        *pat_type.ty.clone(),
+                            )
+                    );
+                    if maybe_owned_entity_mut_ref.is_some() {
+                        return maybe_owned_entity_mut_ref;
+                    }
+
+                    // Detect if the argument is a numeric ref.
+                    let maybe_numeric_ref = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Reference(ref_) => ref_,
+                        ref_ ?> ref_.mutability.is_none(),
+                        ref_ -> ref_.elem.as_ref(),
+                        syn::Type::Path(ref_type) => ref_type,
+                        ref_type >> ref_type.path.segments.last(),
+                        ref_type -> &ref_type.ident,
+                        ref_type_ident -> classifier(ref_type_ident),
+                        IdentKind::Numeric(ident) =>
+                            EngineTraitImplArg::NumericRef(
+                                pat_ident.to_owned(),
+                                *pat_type.ty.clone(),
+                                ident
+                            )
+                    );
+                    if maybe_numeric_ref.is_some() {
+                        return maybe_numeric_ref;
+                    }
+
+                    // Detect if the argument is an owned entity ref.
+                    let maybe_owned_entity_ref = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Reference(ref_) => ref_,
+                        ref_ ?> ref_.mutability.is_none(),
+                        ref_ -> ref_.elem.as_ref(),
+                        syn::Type::Path(ref_type) => ref_type,
+                        ref_type >> ref_type.path.segments.last(),
+                        ref_type -> &ref_type.ident,
+                        ref_type_ident -> classifier(ref_type_ident),
+                        IdentKind::OwnedEntity =>
+                            EngineTraitImplArg::OwnedEntityRef(
+                                        pat_ident.to_owned(),
+                                        *pat_type.ty.clone(),
+                            )
+                    );
+                    if maybe_owned_entity_ref.is_some() {
+                        return maybe_owned_entity_ref;
+                    }
+
+                    // Detect if the argument is a view entity ref.
+                    let maybe_view_entity_ref = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Reference(ref_) => ref_,
+                        ref_ ?> ref_.mutability.is_none(),
+                        ref_ -> ref_.elem.as_ref(),
+                        syn::Type::Path(ref_type) => ref_type,
+                        ref_type >> ref_type.path.segments.last(),
+                        ref_type -> &ref_type.ident,
+                        ref_type_ident -> classifier(ref_type_ident),
+                        IdentKind::ViewEntity =>
+                            EngineTraitImplArg::ViewEntityRef(
+                                        pat_ident.to_owned(),
+                                        *pat_type.ty.clone(),
+                            )
+                    );
+                    if maybe_view_entity_ref.is_some() {
+                        return maybe_view_entity_ref;
+                    }
+
+                    // Detect if the argument is a config ref.
+                    let maybe_config_ref = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Reference(ref_) => ref_,
+                        ref_ ?> ref_.mutability.is_none(),
+                        ref_ -> ref_.elem.as_ref(),
+                        syn::Type::Path(ref_type) => ref_type,
+                        ref_type >> ref_type.path.segments.last(),
+                        ref_type -> &ref_type.ident,
+                        ref_type_ident -> classifier(ref_type_ident),
+                        IdentKind::Config(ident) =>
+                            EngineTraitImplArg::ConfigRef(
+                                pat_ident.to_owned(),
+                                *pat_type.ty.clone(),
+                                ident
+                            )
+                    );
+                    if maybe_config_ref.is_some() {
+                        return maybe_config_ref;
+                    }
+
+                    // Detect if the argument is a numeric mut slice.
+                    let maybe_numeric_mut_slice = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Reference(ref_) => ref_,
+                        ref_ ?> ref_.mutability.is_some(),
+                        ref_ -> ref_.elem.as_ref(),
+                        syn::Type::Slice(slice_type) => slice_type,
+                        slice_type -> slice_type.elem.as_ref(),
+                        syn::Type::Path(slice_type) => slice_type,
+                        slice_type >> slice_type.path.segments.last(),
+                        slice_type -> &slice_type.ident,
+                        slice_type_ident -> classifier(slice_type_ident),
+                        IdentKind::Numeric(ident) =>
+                            EngineTraitImplArg::NumericSliceMut(
+                                pat_ident.to_owned(),
+                                *pat_type.ty.clone(),
+                                ident
+                            )
+                    );
+                    if maybe_numeric_mut_slice.is_some() {
+                        return maybe_numeric_mut_slice;
+                    }
+
+                    // Detect if the argument is a numeric slice.
+                    let maybe_numeric_slice = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Reference(ref_) => ref_,
+                        ref_ ?> ref_.mutability.is_none(),
+                        ref_ -> ref_.elem.as_ref(),
+                        syn::Type::Slice(slice_type) => slice_type,
+                        slice_type -> slice_type.elem.as_ref(),
+                        syn::Type::Path(slice_type) => slice_type,
+                        slice_type >> slice_type.path.segments.last(),
+                        slice_type -> &slice_type.ident,
+                        slice_type_ident -> classifier(slice_type_ident),
+                        IdentKind::Numeric(ident) =>
+                            EngineTraitImplArg::NumericSlice(
+                                pat_ident.to_owned(),
+                                *pat_type.ty.clone(),
+                                ident
+                            )
+                    );
+                    if maybe_numeric_slice.is_some() {
+                        return maybe_numeric_slice;
+                    }
+
+                    // Detect if the argument is a numeric slice.
+                    let maybe_config_slice = probe!(
+                        Some(pat_type.ty.as_ref()),
+                        syn::Type::Reference(ref_) => ref_,
+                        ref_ ?> ref_.mutability.is_none(),
+                        ref_ -> ref_.elem.as_ref(),
+                        syn::Type::Slice(slice_type) => slice_type,
+                        slice_type -> slice_type.elem.as_ref(),
+                        syn::Type::Path(slice_type) => slice_type,
+                        slice_type >> slice_type.path.segments.last(),
+                        slice_type -> &slice_type.ident,
+                        slice_type_ident -> classifier(slice_type_ident),
+                        IdentKind::Config(ident) =>
+                            EngineTraitImplArg::ConfigSlice(
+                                pat_ident.to_owned(),
+                                *pat_type.ty.clone(),
+                                ident
+                            )
+                    );
+                    if maybe_config_slice.is_some() {
+                        return maybe_config_slice;
+                    }
+
+                    // We did not recognize the argument :(
+                    Some(EngineTraitImplArg::Unknown(
+                        pat_ident.to_owned(),
+                        *pat_type.ty.clone(),
+                    ))
+                })
+                .collect()
+        });
+    }
+}
+
+fn classify_engine_trait_impl_return(
+    engines: &mut [&mut Engine],
+    classifier: impl FnOnce(&syn::Ident) -> IdentKind + Copy,
+) {
+    // INVARIANT: Config and entity types arguments are provided as identifiers in the checked
+    // method. INVARIANT: Checked method always return a Result written as an identifier.
+    for engine_impl in engines
+        .iter_mut()
+        .flat_map(|eng| eng.engine_impls.iter_mut())
+    {
+        engine_impl.checked_method.return_.prepare(|sig| {
+            // We retrieve the ok type of the return result.
+            let ok_type = probe!(
+                Some(&sig),
+                sig -> &sig.output,
+                syn::ReturnType::Type(_, n) => n,
+                return_type -> return_type.as_ref(),
+                syn::Type::Path(p) => p,
+                path -> &path.path.segments.last().unwrap().arguments,
+                syn::PathArguments::AngleBracketed(args) => args.args.first().unwrap(),
+                syn::GenericArgument::Type(t) => t
+            )
+            .unwrap();
+
+            // Detects if the ok type is the unit type.
+            let maybe_unit = probe!(
+                Some(&ok_type),
+                syn::Type::Tuple(tuple) => tuple,
+                tuple ?> tuple.elems.is_empty(),
+                X> Some(ok_type),
+                ok_type -> EngineTraitImplReturn::Unit(ok_type.to_owned())
+            );
+            if let Some(v) = maybe_unit {
+                return v;
+            }
+
+            // Detects if the ok type is an owned entity
+            let maybe_owned_entity = probe!(
+                Some(&ok_type),
+                syn::Type::Path(path) => path,
+                path >> path.path.segments.last(),
+                segment -> &segment.ident,
+                ident -> classifier(ident),
+                IdentKind::OwnedEntity => EngineTraitImplReturn::OwnedEntity(ok_type.to_owned())
+            );
+            if let Some(v) = maybe_owned_entity {
+                return v;
+            }
+
+            // Detects if the ok type is a view entity
+            let maybe_view_entity = probe!(
+                Some(&ok_type),
+                syn::Type::Path(path) => path,
+                path >> path.path.segments.last(),
+                segment -> &segment.ident,
+                ident -> classifier(ident),
+                IdentKind::ViewEntity => EngineTraitImplReturn::ViewEntity(ok_type.to_owned())
+            );
+            if let Some(v) = maybe_view_entity {
+                return v;
+            }
+
+            // Detects if the ok type is a mut view entity
+            let maybe_mut_view_entity = probe!(
+                Some(&ok_type),
+                syn::Type::Path(path) => path,
+                path >> path.path.segments.last(),
+                segment -> &segment.ident,
+                ident -> classifier(ident),
+                IdentKind::MutViewEntity => EngineTraitImplReturn::MutViewEntity(ok_type.to_owned())
+            );
+            if let Some(v) = maybe_mut_view_entity {
+                return v;
+            }
+
+            // Detects if the ok type is a config
+            let maybe_config = probe!(
+                Some(&ok_type),
+                syn::Type::Path(path) => path,
+                path >> path.path.segments.last(),
+                segment -> &segment.ident,
+                ident -> classifier(ident),
+                IdentKind::Config(_) => EngineTraitImplReturn::Config(ok_type.to_owned())
+            );
+            if let Some(v) = maybe_config {
+                return v;
+            }
+
+            // Detects if the ok type is a numeric
+            let maybe_numeric = probe!(
+                Some(&ok_type),
+                syn::Type::Path(path) => path,
+                path >> path.path.segments.last(),
+                segment -> &segment.ident,
+                ident -> classifier(ident),
+                IdentKind::Numeric(_) => EngineTraitImplReturn::Numeric(ok_type.to_owned())
+            );
+            if let Some(v) = maybe_numeric {
+                return v;
+            }
+
+            // Detects if the ok type is a numeric vec
+            let maybe_numeric_vec = probe!(
+                Some(&ok_type),
+                syn::Type::Path(path) => path,
+                path >> path.path.segments.last(),
+                segment ?> segment.ident == "Vec",
+                segment -> &segment.arguments,
+                syn::PathArguments::AngleBracketed(args) => args,
+                args >> args.args.last(),
+                syn::GenericArgument::Type(t) => t,
+                syn::Type::Path(p) => p,
+                path >> path.path.segments.last(),
+                arg -> classifier(&arg.ident),
+                IdentKind::Numeric(_) => EngineTraitImplReturn::NumericVec(ok_type.to_owned())
+            );
+            if let Some(v) = maybe_numeric_vec {
+                return v;
+            }
+
+            // Detects if the ok type is a numeric mut slice
+            let maybe_numeric_slice_mut = probe!(
+                Some(&ok_type),
+                syn::Type::Reference(ref_) => ref_,
+                ref_ ?> ref_.mutability.is_some(),
+                ref_ -> ref_.elem.as_ref(),
+                syn::Type::Slice(slice_type) => slice_type,
+                slice_type -> slice_type.elem.as_ref(),
+                syn::Type::Path(slice_type) => slice_type,
+                slice_type >> slice_type.path.segments.last(),
+                slice_type -> &slice_type.ident,
+                slice_type_ident -> classifier(slice_type_ident),
+                IdentKind::Numeric(_) =>
+                    EngineTraitImplReturn::NumericSliceMut(
+                        ok_type.to_owned()
+                    )
+            );
+            if let Some(v) = maybe_numeric_slice_mut {
+                return v;
+            }
+
+            // Detects if the ok type is a numeric slice
+            let maybe_numeric_slice = probe!(
+                Some(&ok_type),
+                syn::Type::Reference(ref_) => ref_,
+                ref_ ?> ref_.mutability.is_none(),
+                ref_ -> ref_.elem.as_ref(),
+                syn::Type::Slice(slice_type) => slice_type,
+                slice_type -> slice_type.elem.as_ref(),
+                syn::Type::Path(slice_type) => slice_type,
+                slice_type >> slice_type.path.segments.last(),
+                slice_type -> &slice_type.ident,
+                slice_type_ident -> classifier(slice_type_ident),
+                IdentKind::Numeric(_) =>
+                    EngineTraitImplReturn::NumericSlice(
+                        ok_type.to_owned()
+                    )
+            );
+            if let Some(v) = maybe_numeric_slice {
+                return v;
+            }
+
+            // We did not recognize the return type :(
+            EngineTraitImplReturn::Unknown(ok_type.to_owned())
+        });
+    }
+}

--- a/concrete-core-representation/src/ccr/config.rs
+++ b/concrete-core-representation/src/ccr/config.rs
@@ -1,0 +1,35 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing a config object.
+#[derive(Serialize, Clone, Debug)]
+pub struct Config {
+    pub cfg: CfgStack,
+    #[serde(serialize_with = "serialize_with_token_string")]
+    pub item_struct: syn::ItemStruct,
+}
+
+impl Config {
+    /// From an `ItemMod` syn ast node, pointing to a module in a backend, recursively extracts all
+    /// the `Config`.
+    pub fn extract_all(cfg_stack_so_far: &CfgStack, module: &syn::ItemMod) -> Vec<Config> {
+        // INVARIANT: All the config objects contain `Config` in their names.
+        // INVARIANT: All the config objects are declared with `pub` visibility.
+
+        // Gather all struct definitions
+        let struct_definitions = StructDefinition::extract_all(cfg_stack_so_far, module);
+        struct_definitions
+            .into_iter()
+            .filter_map(|struct_def| {
+                probe!(
+                    Some(struct_def),
+                    struct_def ?> struct_def.item_struct.ident.to_string().contains("Config"),
+                    struct_def -> Config{
+                        cfg: struct_def.cfg,
+                        item_struct: struct_def.item_struct
+                    }
+                )
+            })
+            .collect()
+    }
+}

--- a/concrete-core-representation/src/ccr/engine.rs
+++ b/concrete-core-representation/src/ccr/engine.rs
@@ -1,0 +1,44 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing a `concrete-core` engine.
+#[derive(Serialize, Clone, Debug)]
+pub struct Engine {
+    pub definition: EngineTypeDefinition,
+    pub abstract_engine_impl: AbstractEngineTraitImpl,
+    pub engine_impls: Vec<EngineTraitImpl>,
+}
+
+impl Engine {
+    /// From an `ItemMod` syn ast node, pointing to a module in a backend, recursively extracts all
+    /// the `Engine`.
+    pub fn extract_all(cfg_stack_so_far: &CfgStack, module: &syn::ItemMod) -> Vec<Engine> {
+        // INVARIANT: All the engine objects contain `Engine` in their names.
+        // INVARIANT: All the engine objects are declared with `pub` visibility.
+
+        // Gather abstract engine impls
+        let abstract_engine_impls = AbstractEngineTraitImpl::extract_all(cfg_stack_so_far, module);
+        // Gather all struct definitions
+        let mut engine_definitions = EngineTypeDefinition::extract_all(cfg_stack_so_far, module);
+        // Gather engine impls
+        let mut engine_impls = EngineTraitImpl::extract_all(cfg_stack_so_far, module);
+
+        // Match the definitions, abstract engine impls and engine impls
+        abstract_engine_impls
+            .into_iter()
+            .map(|abstract_engine_impl| {
+                let engine_impls = pull_all_matches(&mut engine_impls, |engine_impl| {
+                    engine_impl.engine_type_ident == abstract_engine_impl.engine_type_ident
+                });
+                let definition = pull_first_match(&mut engine_definitions, |engine_def| {
+                    engine_def.item_struct.ident == abstract_engine_impl.engine_type_ident
+                });
+                Engine {
+                    engine_impls,
+                    abstract_engine_impl,
+                    definition,
+                }
+            })
+            .collect()
+    }
+}

--- a/concrete-core-representation/src/ccr/engine_trait_impl.rs
+++ b/concrete-core-representation/src/ccr/engine_trait_impl.rs
@@ -1,0 +1,132 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing an implementation of an `*Engine` trait.
+#[derive(Serialize, Clone, Debug)]
+pub struct EngineTraitImpl {
+    pub cfg: CfgStack,
+    #[serde(serialize_with = "serialize_with_token_string")]
+    pub engine_trait_ident: syn::Ident,
+    #[serde(serialize_with = "serialize_with_token_string")]
+    pub engine_type_ident: syn::Ident,
+    pub checked_method: EngineTraitImplCheckedMethod,
+    pub unchecked_method: EngineTraitImplUncheckedMethod,
+    pub(crate) engine_trait_parameters:
+        ReadyOrNot<Vec<EngineTraitImplGenericArgument>, syn::AngleBracketedGenericArguments>,
+}
+
+impl EngineTraitImpl {
+    /// Return the generic parameters of the engine trait.
+    pub fn engine_trait_parameters(&self) -> &[EngineTraitImplGenericArgument] {
+        self.engine_trait_parameters.as_ref().unwrap().as_slice()
+    }
+}
+
+impl EngineTraitImpl {
+    /// From an `ItemMod` syn ast node, pointing to a module in a backend, recursively extracts all
+    /// the `EngineTraitImpl`.
+    pub fn extract_all(cfg_stack_so_far: &CfgStack, module: &syn::ItemMod) -> Vec<EngineTraitImpl> {
+        // INVARIANT: engine types are identified with their original identifier in the engine impl,
+        // not with a path, nor an alias.
+        // INVARIANT: the engine trait is identified by its original identifier containing `Engine`
+        let mut output = Vec::new();
+        if module.content.is_none() {
+            return output;
+        }
+
+        for item in module.content.as_ref().unwrap().1.iter() {
+            // If the item is a module, we recurse:
+            if let syn::Item::Mod(item_mod) = item {
+                output.extend(
+                    EngineTraitImpl::extract_all(
+                        &cfg_stack_so_far.concat_attrs(item_mod.attrs.as_slice()),
+                        item_mod,
+                    )
+                    .into_iter(),
+                );
+                continue;
+            }
+
+            // If the item is an engine impl, we add it.
+            let maybe_item_impl = probe!(
+                Some(item),
+                syn::Item::Impl(item_impl) => item_impl
+            );
+            let maybe_engine_impl = probe!(
+                maybe_item_impl,
+                item_impl >> item_impl.trait_.as_ref(),
+                trait_ >> trait_.1.segments.first(),
+                trait_path -> &trait_path.ident,
+                trait_ident ?> *trait_ident != "AbstractEngine",
+                trait_ident ?> *trait_ident != "AbstractEngineSeal",
+                trait_ident ?> trait_ident.to_string().contains("Engine"),
+                X> maybe_item_impl
+            );
+            let maybe_engine_trait_ident = probe!(
+                maybe_engine_impl,
+                item_impl >> item_impl.trait_.as_ref(),
+                trait_ >> trait_.1.segments.last(),
+                trait_segment -> trait_segment.ident.to_owned()
+            );
+            let maybe_engine_type_ident = probe!(
+                maybe_engine_impl,
+                item_impl -> item_impl.self_ty.as_ref(),
+                syn::Type::Path(self_ty_path) => self_ty_path,
+                self_ty_path >> self_ty_path.path.segments.first(),
+                self_segment -> self_segment.ident.to_owned()
+            );
+            let maybe_checked_method = probe!(
+                maybe_engine_impl,
+                item_impl -> EngineTraitImplCheckedMethod::extract(cfg_stack_so_far, item_impl)
+            );
+            let maybe_unchecked_method = probe!(
+                maybe_engine_impl,
+                item_impl -> EngineTraitImplUncheckedMethod::extract(cfg_stack_so_far, item_impl)
+            );
+            // The generic arguments can not be processed right away, because we don't yet
+            // know all the items exported by the backend (hence we can not properly sort
+            // them).
+            let maybe_engine_trait_parameters = probe!(
+                maybe_engine_impl,
+                item_impl >> item_impl.trait_.as_ref(),
+                trait_ >> trait_.1.segments.last(),
+                trait_segment -> &trait_segment.arguments,
+                syn::PathArguments::AngleBracketed(generics) => generics,
+                generics -> ReadyOrNot::Not(generics.to_owned())
+            );
+            let maybe_engine_trait_impl = probe!(
+                pack_somes!(
+                    maybe_engine_impl,
+                    maybe_engine_trait_ident,
+                    maybe_checked_method,
+                    maybe_unchecked_method,
+                    maybe_engine_trait_parameters,
+                    maybe_engine_type_ident
+                ),
+                tuple -> {
+                    let (
+                        engine_impl,
+                        engine_trait_ident,
+                        checked_method,
+                        unchecked_method,
+                        engine_trait_parameters,
+                        engine_type_ident
+                    ) = tuple;
+                    EngineTraitImpl{
+                        cfg: cfg_stack_so_far.concat_attrs(engine_impl.attrs.as_slice()),
+                        engine_trait_ident,
+                        checked_method,
+                        unchecked_method,
+                        engine_trait_parameters,
+                        engine_type_ident
+                    }
+                }
+            );
+            if let Some(engine_trait_impl) = maybe_engine_trait_impl {
+                output.push(engine_trait_impl);
+                continue;
+            }
+        }
+        output
+    }
+}

--- a/concrete-core-representation/src/ccr/engine_trait_impl_arg.rs
+++ b/concrete-core-representation/src/ccr/engine_trait_impl_arg.rs
@@ -1,0 +1,134 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing a function argument of an implementation of an `*Engine` trait.
+#[derive(Serialize, Clone, Debug)]
+pub enum EngineTraitImplArg {
+    // The argument is an owned entity passed by value.
+    #[serde(serialize_with = "serialize_with_token_string_2")]
+    OwnedEntity(syn::PatIdent, syn::Type),
+    // The argument is an owned entity passed by reference.
+    #[serde(serialize_with = "serialize_with_token_string_2")]
+    OwnedEntityRef(syn::PatIdent, syn::Type),
+    // The argument is an owned entity passed by mutable reference.
+    #[serde(serialize_with = "serialize_with_token_string_2")]
+    OwnedEntityRefMut(syn::PatIdent, syn::Type),
+    // The argument is a view entity passed by value.
+    #[serde(serialize_with = "serialize_with_token_string_2")]
+    ViewEntity(syn::PatIdent, syn::Type),
+    // The argument is a view entity passed by reference.
+    #[serde(serialize_with = "serialize_with_token_string_2")]
+    ViewEntityRef(syn::PatIdent, syn::Type),
+    // The argument is a mutable view entity passed by value.
+    #[serde(serialize_with = "serialize_with_token_string_2")]
+    MutViewEntity(syn::PatIdent, syn::Type),
+    // The argument is a mutable view entity passed by mutable reference.
+    #[serde(serialize_with = "serialize_with_token_string_2")]
+    MutViewEntityRefMut(syn::PatIdent, syn::Type),
+    // The argument is a config passed by value.
+    #[serde(serialize_with = "serialize_with_token_string_2")]
+    Config(syn::PatIdent, syn::Type),
+    // The argument is a config passed by reference.
+    #[serde(serialize_with = "serialize_with_token_string_3")]
+    ConfigRef(syn::PatIdent, syn::Type, syn::Ident),
+    // The argument is a slice of configs.
+    #[serde(serialize_with = "serialize_with_token_string_3")]
+    ConfigSlice(syn::PatIdent, syn::Type, syn::Ident),
+    // The argument is a commons parameter.
+    #[serde(serialize_with = "serialize_with_token_string_2")]
+    Parameter(syn::PatIdent, syn::Type),
+    // The argument is a commons dispersion.
+    #[serde(serialize_with = "serialize_with_token_string_2")]
+    Dispersion(syn::PatIdent, syn::Type),
+    // The argument is a rust numeric type passed by value.
+    #[serde(serialize_with = "serialize_with_token_string_2")]
+    Numeric(syn::PatIdent, syn::Type),
+    // The argument is a rust numeric type passed by reference.
+    #[serde(serialize_with = "serialize_with_token_string_3")]
+    NumericRef(syn::PatIdent, syn::Type, syn::Ident),
+    // The argument is a rust numeric type passed by mutable reference.
+    #[serde(serialize_with = "serialize_with_token_string_3")]
+    NumericRefMut(syn::PatIdent, syn::Type, syn::Ident),
+    // The argument is a slice of rust numeric types.
+    #[serde(serialize_with = "serialize_with_token_string_3")]
+    NumericSlice(syn::PatIdent, syn::Type, syn::Ident),
+    // The argument is a mutable slice of rust numeric types.
+    #[serde(serialize_with = "serialize_with_token_string_3")]
+    NumericSliceMut(syn::PatIdent, syn::Type, syn::Ident),
+    // The argument is a vec of rust numeric types.
+    #[serde(serialize_with = "serialize_with_token_string_3")]
+    NumericVec(syn::PatIdent, syn::Type, syn::Ident),
+    // The argument can not be properly parsed into a category.
+    #[serde(serialize_with = "serialize_with_token_string_2")]
+    Unknown(syn::PatIdent, syn::Type),
+}
+
+impl EngineTraitImplArg {
+    /// Returns the left hand side of the argument (the pattern).
+    pub fn pat_ident(&self) -> &syn::PatIdent {
+        macro_rules! _impl {
+            ($($variant:ident,)*) => {
+                match self {
+                    $(
+                        EngineTraitImplArg::$variant(pi, ..) => pi,
+                    )*
+                }
+            };
+        }
+        _impl!(
+            OwnedEntity,
+            OwnedEntityRef,
+            OwnedEntityRefMut,
+            ViewEntity,
+            ViewEntityRef,
+            MutViewEntity,
+            MutViewEntityRefMut,
+            Config,
+            ConfigRef,
+            ConfigSlice,
+            Parameter,
+            Dispersion,
+            Numeric,
+            NumericRef,
+            NumericRefMut,
+            NumericSlice,
+            NumericSliceMut,
+            NumericVec,
+            Unknown,
+        )
+    }
+
+    /// Returns the right hand side of the argument (the type).
+    pub fn type_(&self) -> &syn::Type {
+        macro_rules! _impl {
+            ($($variant:ident,)*) => {
+                match self {
+                    $(
+                        EngineTraitImplArg:: $variant (_, ty, ..) => ty,
+                    )*
+                }
+            };
+        }
+        _impl!(
+            OwnedEntity,
+            OwnedEntityRef,
+            OwnedEntityRefMut,
+            ViewEntity,
+            ViewEntityRef,
+            MutViewEntity,
+            MutViewEntityRefMut,
+            Config,
+            ConfigRef,
+            ConfigSlice,
+            Parameter,
+            Dispersion,
+            Numeric,
+            NumericRef,
+            NumericRefMut,
+            NumericSlice,
+            NumericSliceMut,
+            NumericVec,
+            Unknown,
+        )
+    }
+}

--- a/concrete-core-representation/src/ccr/engine_trait_impl_checked_method.rs
+++ b/concrete-core-representation/src/ccr/engine_trait_impl_checked_method.rs
@@ -1,0 +1,53 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing the checked method of an implementation of an `*Engine` trait.
+#[derive(Serialize, Clone, Debug)]
+pub struct EngineTraitImplCheckedMethod {
+    pub cfg: CfgStack,
+    pub(crate) args: ReadyOrNot<Vec<EngineTraitImplArg>, syn::Signature>,
+    pub(crate) return_: ReadyOrNot<EngineTraitImplReturn, syn::Signature>,
+    #[serde(serialize_with = "serialize_with_token_string")]
+    pub ident: syn::Ident,
+    #[serde(serialize_with = "serialize_with_token_string")]
+    pub body: syn::Block,
+}
+
+impl EngineTraitImplCheckedMethod {
+    /// From an `ItemImpl` syn ast node, pointing to an engine trait impl block, extracts the
+    /// `EngineTraitImplCheckedMethod`.
+    pub fn extract(
+        cfg_stack_so_far: &CfgStack,
+        impl_block: &syn::ItemImpl,
+    ) -> EngineTraitImplCheckedMethod {
+        // INVARIANT: The checked entry point is the only safe method.
+        impl_block
+            .items
+            .iter()
+            .find_map(|impl_item| {
+                probe!(
+                    Some(impl_item),
+                    syn::ImplItem::Method(method) => method,
+                    method ?> method.sig.unsafety.is_none(),
+                    method -> EngineTraitImplCheckedMethod{
+                        cfg: cfg_stack_so_far.to_owned(),
+                        args: ReadyOrNot::Not(method.sig.clone()),
+                        return_: ReadyOrNot::Not(method.sig.clone()),
+                        ident: method.sig.ident.clone(),
+                        body: method.block.clone()
+                    }
+                )
+            })
+            .unwrap()
+    }
+
+    /// Returns the arguments of the checked method.
+    pub fn args(&self) -> &[EngineTraitImplArg] {
+        self.args.as_ref().unwrap()
+    }
+
+    /// Returns the return type of the checked method.
+    pub fn return_(&self) -> &EngineTraitImplReturn {
+        self.return_.as_ref().unwrap()
+    }
+}

--- a/concrete-core-representation/src/ccr/engine_trait_impl_generic_argument.rs
+++ b/concrete-core-representation/src/ccr/engine_trait_impl_generic_argument.rs
@@ -1,0 +1,51 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing a generic argument of an implementation of an `*Engine` trait.
+#[derive(Serialize, Clone, Debug)]
+pub enum EngineTraitImplGenericArgument {
+    /// The generic argument is an owned entity
+    #[serde(serialize_with = "serialize_with_token_string")]
+    OwnedEntity(syn::Type),
+    /// The generic argument is a view entity
+    #[serde(serialize_with = "serialize_with_token_string")]
+    ViewEntity(syn::Type),
+    /// The generic argument is a mut view entity
+    #[serde(serialize_with = "serialize_with_token_string")]
+    MutViewEntity(syn::Type),
+    /// The generic argument is a config
+    #[serde(serialize_with = "serialize_with_token_string")]
+    Config(syn::Type),
+    /// The generic argument is a numeric
+    #[serde(serialize_with = "serialize_with_token_string")]
+    Numeric(syn::Type),
+    /// The generic argument is a numeric slice
+    #[serde(serialize_with = "serialize_with_token_string")]
+    NumericSlice(syn::Type),
+    /// The generic argument is a numeric mutable slice
+    #[serde(serialize_with = "serialize_with_token_string")]
+    NumericSliceMut(syn::Type),
+    /// The generic argument is a numeric vec
+    #[serde(serialize_with = "serialize_with_token_string")]
+    NumericVec(syn::Type),
+    // The generic argument can not be properly parsed into a category.
+    #[serde(serialize_with = "serialize_with_token_string")]
+    Unknown(syn::Type),
+}
+
+impl EngineTraitImplGenericArgument {
+    /// Returns `syn` node pointing to the generic argument.
+    pub fn get_type(&self) -> &syn::Type {
+        match self {
+            EngineTraitImplGenericArgument::OwnedEntity(t) => t,
+            EngineTraitImplGenericArgument::ViewEntity(t) => t,
+            EngineTraitImplGenericArgument::MutViewEntity(t) => t,
+            EngineTraitImplGenericArgument::Config(t) => t,
+            EngineTraitImplGenericArgument::Numeric(t) => t,
+            EngineTraitImplGenericArgument::NumericSlice(t) => t,
+            EngineTraitImplGenericArgument::NumericSliceMut(t) => t,
+            EngineTraitImplGenericArgument::NumericVec(t) => t,
+            EngineTraitImplGenericArgument::Unknown(t) => t,
+        }
+    }
+}

--- a/concrete-core-representation/src/ccr/engine_trait_impl_return.rs
+++ b/concrete-core-representation/src/ccr/engine_trait_impl_return.rs
@@ -1,0 +1,55 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing the return type of an implementation of an `*Engine` trait.
+#[derive(Serialize, Clone, Debug)]
+pub enum EngineTraitImplReturn {
+    /// The return type is an owned entity
+    #[serde(serialize_with = "serialize_with_token_string")]
+    OwnedEntity(syn::Type),
+    /// The return type is a view entity
+    #[serde(serialize_with = "serialize_with_token_string")]
+    ViewEntity(syn::Type),
+    /// The return type is a mutable view entity
+    #[serde(serialize_with = "serialize_with_token_string")]
+    MutViewEntity(syn::Type),
+    /// The return type is a config
+    #[serde(serialize_with = "serialize_with_token_string")]
+    Config(syn::Type),
+    /// The return type is a numeric
+    #[serde(serialize_with = "serialize_with_token_string")]
+    Numeric(syn::Type),
+    /// The return type is a numeric slice
+    #[serde(serialize_with = "serialize_with_token_string")]
+    NumericSlice(syn::Type),
+    /// The return type is a numeric mutable slice
+    #[serde(serialize_with = "serialize_with_token_string")]
+    NumericSliceMut(syn::Type),
+    /// The return type is a numeric vec
+    #[serde(serialize_with = "serialize_with_token_string")]
+    NumericVec(syn::Type),
+    /// The return type is the unit type
+    #[serde(serialize_with = "serialize_with_token_string")]
+    Unit(syn::Type),
+    /// The return type can not be properly parsed
+    #[serde(serialize_with = "serialize_with_token_string")]
+    Unknown(syn::Type),
+}
+
+impl EngineTraitImplReturn {
+    /// Returns the `syn` node pointing to the return type.
+    pub fn type_(&self) -> &syn::Type {
+        match self {
+            EngineTraitImplReturn::OwnedEntity(ty) => ty,
+            EngineTraitImplReturn::ViewEntity(ty) => ty,
+            EngineTraitImplReturn::MutViewEntity(ty) => ty,
+            EngineTraitImplReturn::Config(ty) => ty,
+            EngineTraitImplReturn::Numeric(ty) => ty,
+            EngineTraitImplReturn::NumericSlice(ty) => ty,
+            EngineTraitImplReturn::NumericSliceMut(ty) => ty,
+            EngineTraitImplReturn::NumericVec(ty) => ty,
+            EngineTraitImplReturn::Unit(ty) => ty,
+            EngineTraitImplReturn::Unknown(ty) => ty,
+        }
+    }
+}

--- a/concrete-core-representation/src/ccr/engine_trait_impl_unchecked_method.rs
+++ b/concrete-core-representation/src/ccr/engine_trait_impl_unchecked_method.rs
@@ -1,0 +1,36 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing the unchecked method of an implementation of an `*Engine` trait.
+#[derive(Serialize, Clone, Debug)]
+pub struct EngineTraitImplUncheckedMethod {
+    pub cfg: CfgStack,
+    #[serde(serialize_with = "serialize_with_token_string")]
+    pub method: syn::ImplItemMethod,
+}
+
+impl EngineTraitImplUncheckedMethod {
+    /// From an `ItemImpl` syn ast node, pointing to an engine trait impl block, extracts the
+    /// `EngineTraitImplUncheckedMethod`.
+    pub fn extract(
+        cfg_stack_so_far: &CfgStack,
+        impl_block: &syn::ItemImpl,
+    ) -> EngineTraitImplUncheckedMethod {
+        // INVARIANT: The unchecked entry point is the first unsafe method.
+        impl_block
+            .items
+            .iter()
+            .find_map(|impl_item| {
+                probe!(
+                    Some(impl_item),
+                    syn::ImplItem::Method(method) => method,
+                    method ?> method.sig.unsafety.is_some(),
+                    method -> EngineTraitImplUncheckedMethod{
+                        cfg: cfg_stack_so_far.to_owned(),
+                        method: method.to_owned()
+                    }
+                )
+            })
+            .unwrap()
+    }
+}

--- a/concrete-core-representation/src/ccr/engine_type_definition.rs
+++ b/concrete-core-representation/src/ccr/engine_type_definition.rs
@@ -1,0 +1,43 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing the definition of an engine type.
+#[derive(Serialize, Clone, Debug)]
+pub struct EngineTypeDefinition {
+    pub cfg: CfgStack,
+    #[serde(serialize_with = "serialize_with_token_string")]
+    pub item_struct: syn::ItemStruct,
+}
+
+impl EngineTypeDefinition {
+    /// From an `ItemMod` syn ast node, pointing to a module in a backend, recursively extracts all
+    /// the `Engine` type definitions.
+    pub fn extract_all(
+        cfg_stack_so_far: &CfgStack,
+        module: &syn::ItemMod,
+    ) -> Vec<EngineTypeDefinition> {
+        // INVARIANT: All the engine objects contain `Engine` in their names.
+        // INVARIANT: All the engine objects are declared with `pub` visibility.
+
+        // Gather all struct definitions
+        let struct_definitions = StructDefinition::extract_all(cfg_stack_so_far, module);
+        struct_definitions
+            .into_iter()
+            .filter_map(|struct_def| {
+                probe!(
+                    Some(struct_def),
+                    struct_def ?> struct_def.item_struct.ident.to_string().contains("Engine"),
+                    struct_def -> EngineTypeDefinition{
+                        cfg: struct_def.cfg,
+                        item_struct: struct_def.item_struct
+                    }
+                )
+            })
+            .collect()
+    }
+
+    /// Returns the `syn` node pointing to the engine identifier.
+    pub fn get_name(&self) -> &syn::Ident {
+        &self.item_struct.ident
+    }
+}

--- a/concrete-core-representation/src/ccr/entity.rs
+++ b/concrete-core-representation/src/ccr/entity.rs
@@ -1,0 +1,61 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing a `concrete-core` entity.
+#[derive(Serialize, Clone, Debug)]
+pub struct Entity {
+    pub definition: EntityTypeDefinition,
+    pub abstract_entity_impl: AbstractEntityTraitImpl,
+    pub entity_impl: EntityTraitImpl,
+}
+
+impl Entity {
+    /// From an `ItemMod` syn ast node, pointing to a backend module, extracts all the `Entity`
+    /// nodes.
+    pub(crate) fn extract_all(cfg_stack_so_far: &CfgStack, module: &syn::ItemMod) -> Vec<Entity> {
+        // Gather all struct definitions
+        let mut struct_definitions = StructDefinition::extract_all(cfg_stack_so_far, module);
+        // Gather abstract entity trait impls
+        let abstract_entity_trait_impls =
+            AbstractEntityTraitImpl::extract_all(cfg_stack_so_far, module);
+        // Gather entity trait impls
+        let mut entity_trait_impls = EntityTraitImpl::extract_all(cfg_stack_so_far, module);
+
+        // Match the different pieces of the entities
+        abstract_entity_trait_impls
+            .into_iter()
+            .map(|abstract_entity_impl| {
+                let entity_impl = pull_first_match(&mut entity_trait_impls, |entity_impl| {
+                    entity_impl.item_impl.self_ty == abstract_entity_impl.item_impl.self_ty
+                });
+                let definition = pull_first_match(&mut struct_definitions, |definition| {
+                    if let syn::Type::Path(type_path) =
+                        abstract_entity_impl.item_impl.self_ty.as_ref()
+                    {
+                        type_path.path.segments.last().unwrap().ident
+                            == definition.item_struct.ident
+                    } else {
+                        false
+                    }
+                });
+                let ownership = if definition.item_struct.ident.to_string().contains("MutView") {
+                    EntityOwnership::MutView
+                } else if definition.item_struct.ident.to_string().contains("View") {
+                    EntityOwnership::View
+                } else {
+                    EntityOwnership::Owned
+                };
+                let definition = EntityTypeDefinition {
+                    cfg: definition.cfg,
+                    item_struct: definition.item_struct,
+                    ownership,
+                };
+                Entity {
+                    entity_impl,
+                    abstract_entity_impl,
+                    definition,
+                }
+            })
+            .collect()
+    }
+}

--- a/concrete-core-representation/src/ccr/entity_ownership.rs
+++ b/concrete-core-representation/src/ccr/entity_ownership.rs
@@ -1,0 +1,20 @@
+use serde::Serialize;
+
+/// A node representing the ownership of an entity.
+///
+/// When generating some apis, different entities must be treated differently depending on their
+/// ownership:
+/// + In the wasm api, we don't want to expose views and mut views because it does not work with
+///   wasm_bindgen.
+/// + In the c api, we have to expose a lifetime parameter when we expose a view, but not when we
+///   expose a owned entity.
+
+#[derive(Serialize, Clone, Debug)]
+pub enum EntityOwnership {
+    /// The entity has the ownership of the underlying memory.
+    Owned,
+    /// The entity borrows the underlying memory.
+    View,
+    /// The entity mutably borrows the underlying memory.
+    MutView,
+}

--- a/concrete-core-representation/src/ccr/entity_trait_impl.rs
+++ b/concrete-core-representation/src/ccr/entity_trait_impl.rs
@@ -1,0 +1,67 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing an implementation of an `*Entity` trait.
+#[derive(Serialize, Clone, Debug)]
+pub struct EntityTraitImpl {
+    pub cfg: CfgStack,
+    #[serde(serialize_with = "serialize_with_token_string")]
+    pub item_impl: syn::ItemImpl,
+}
+
+impl EntityTraitImpl {
+    /// From an `ItemMod` syn ast node, pointing to a module inside a backend, recursively extract
+    /// all the `EntityTraitImpl` nodes.
+    pub fn extract_all(cfg_stack_so_far: &CfgStack, module: &syn::ItemMod) -> Vec<EntityTraitImpl> {
+        // INVARIANT: entity types are identified with their original identifier in the entity impl,
+        // not with a path, nor an alias.
+        // INVARIANT: the entity trait is identified by its original identifier containing `Entity`
+        let mut output = Vec::new();
+        if module.content.is_none() {
+            return output;
+        }
+
+        let module_items = &module.content.as_ref().unwrap().1;
+        for item in module_items.iter() {
+            // If the item is a module, we recurse.
+            if let syn::Item::Mod(item_mod) = item {
+                output.extend(
+                    EntityTraitImpl::extract_all(
+                        &cfg_stack_so_far.concat_attrs(item_mod.attrs.as_slice()),
+                        item_mod,
+                    )
+                    .into_iter(),
+                );
+                continue;
+            }
+
+            // If the item is an entity impl, we add it to the output.
+            let maybe_item_impl = probe!(
+                Some(item),
+                syn::Item::Impl(item_impl) => item_impl
+            );
+            let maybe_entity_impl = probe!(
+                maybe_item_impl,
+                item_impl >> item_impl.trait_.as_ref(),
+                trait_ >> trait_.1.segments.first(),
+                trait_path -> &trait_path.ident,
+                trait_ident ?> *trait_ident != "AbstractEntity",
+                trait_ident ?> trait_ident.to_string().contains("Entity"),
+                X> maybe_item_impl,
+                item_impl -> item_impl.self_ty.as_ref(),
+                syn::Type::Path(self_path) => self_path,
+                self_path ?> self_path.path.segments.len() == 1,
+                X> maybe_item_impl,
+                item_impl -> EntityTraitImpl {
+                        cfg: cfg_stack_so_far.concat_attrs(item_impl.attrs.as_slice()),
+                        item_impl: item_impl.to_owned(),
+                    }
+            );
+            if let Some(node) = maybe_entity_impl {
+                output.push(node);
+                continue;
+            }
+        }
+        output
+    }
+}

--- a/concrete-core-representation/src/ccr/entity_type_definition.rs
+++ b/concrete-core-representation/src/ccr/entity_type_definition.rs
@@ -1,0 +1,18 @@
+use super::*;
+use serde::Serialize;
+
+/// A node representing the definition of an entity type.
+#[derive(Serialize, Clone, Debug)]
+pub struct EntityTypeDefinition {
+    pub cfg: CfgStack,
+    #[serde(serialize_with = "serialize_with_token_string")]
+    pub item_struct: syn::ItemStruct,
+    pub ownership: EntityOwnership,
+}
+
+impl EntityTypeDefinition {
+    /// Returns the `syn` node pointing to the identifier of the entity.
+    pub fn get_ident(&self) -> &syn::Ident {
+        &self.item_struct.ident
+    }
+}

--- a/concrete-core-representation/src/ccr/inline.rs
+++ b/concrete-core-representation/src/ccr/inline.rs
@@ -1,0 +1,66 @@
+//! A module containing functions to load a crate as a syn ast, and inline all modules.
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use syn::spanned::Spanned;
+use syn::token::Brace;
+
+pub(crate) fn read_crate<P: AsRef<Path>>(path: P) -> syn::File {
+    read_file_and_inline_modules(path, |path| {
+        let forbidden_files = ["commons", "private"];
+        for f in forbidden_files.iter() {
+            if path.as_os_str().to_str().unwrap().contains(f) {
+                return false;
+            }
+        }
+        true
+    })
+}
+
+fn read_file_and_inline_modules<P>(path: P, filter: fn(&Path) -> bool) -> syn::File
+where
+    P: AsRef<Path>,
+{
+    let mut file = File::open(&path).unwrap();
+    let mut content = String::new();
+    file.read_to_string(&mut content).unwrap();
+    let mut ast = syn::parse_file(&content).unwrap();
+
+    for item in ast.items.iter_mut() {
+        if let syn::Item::Mod(ref mut module) = item {
+            if module.content.is_none() {
+                *module = inline_module(path.as_ref(), module, filter);
+            }
+        }
+    }
+
+    ast
+}
+
+fn inline_module<P>(
+    super_file_path: P,
+    input: &syn::ItemMod,
+    filter: fn(&Path) -> bool,
+) -> syn::ItemMod
+where
+    P: AsRef<Path>,
+{
+    let mut output = input.to_owned();
+    let super_folder_path = super_file_path.as_ref().parent().unwrap();
+    let as_file_path = super_folder_path.join(format!("{}.rs", input.ident));
+    let as_folder_path = super_folder_path.join(format!("{}/mod.rs", input.ident));
+    let module_path = if as_file_path.exists() {
+        as_file_path
+    } else {
+        as_folder_path
+    };
+    if !filter(module_path.as_path()) {
+        return output;
+    }
+
+    let ast = read_file_and_inline_modules(module_path, filter);
+    let brace = Brace { span: ast.span() };
+    output.content.replace((brace, ast.items));
+
+    output
+}

--- a/concrete-core-representation/src/ccr/misc.rs
+++ b/concrete-core-representation/src/ccr/misc.rs
@@ -1,0 +1,423 @@
+use quote::ToTokens;
+use serde::ser::{SerializeSeq, SerializeTupleVariant};
+use serde::Serialize;
+use std::fmt::Debug;
+
+/// A type used as a placeholder for a piece of data that can not be placed just yet.
+///
+/// # Example use
+///
+/// The `EngineTraitImpl` node represents a code region such as:
+/// ```rust,ignore
+/// impl LweCiphertextCreationEngine<Vec<32>, LweCiphertext32> for DefaultEngine {
+///     ...
+/// }
+/// ```
+///
+/// We want to be able to classify the generic arguments `<Vec<32>, LweCiphertext32>` for what they
+/// are (a certain number of cases exist, for instance here, a vec of numeric and an entity).
+///
+/// The thing is, we can only say what kind of object a generic parameter is, once all the code
+/// regions of interests have been extracted from the codebase. For instance, we need to have
+/// gathered all the EntityTypeDefinition to know the identifier of all the entities in the crate,
+/// before we can say if this or that generic parameter is an entity.
+///
+/// For this reason, this classification can only happen in a second time. For the time being
+/// though, we can store the `syn::AngleBracketedGenericArguments` node, which correspond to the
+/// `<Vec<32>, LweCiphertext32>` region, so as to be able to classify the content after.
+#[derive(Serialize, Clone, Debug)]
+pub(crate) enum ReadyOrNot<R, N> {
+    Ready(R),
+    #[serde(skip)]
+    Not(N),
+}
+
+impl<R, N> ReadyOrNot<R, N> {
+    /// Borrows the content of the `ReadyOrNot` and wrap it in the corresponding variant of a new
+    /// one.
+    pub fn as_ref(&self) -> ReadyOrNot<&R, &N> {
+        match self {
+            ReadyOrNot::Ready(r) => ReadyOrNot::Ready(r),
+            ReadyOrNot::Not(n) => ReadyOrNot::Not(n),
+        }
+    }
+}
+
+impl<R, N: Debug> ReadyOrNot<R, N> {
+    /// If the content is read, reaturn the content, and panic otherwise.
+    pub fn unwrap(self) -> R {
+        match self {
+            ReadyOrNot::Ready(r) => r,
+            ReadyOrNot::Not(n) => panic!("Tried to unwrap a ReadyOrNot::Not value: {:?}", n),
+        }
+    }
+}
+
+impl<R: Debug, N: Clone> ReadyOrNot<R, N> {
+    /// Turns a `ReadyOrNot::Not` variant into a `ReadyOrNot::Ready` variant by applying a closure.
+    pub fn prepare<F: FnOnce(N) -> R>(&mut self, f: F) {
+        match self {
+            ReadyOrNot::Ready(r) => panic!("Tried to finish a ReadyOrNot::Ready value: {:?}", r),
+            ReadyOrNot::Not(n) => *self = ReadyOrNot::Ready(f(n.to_owned())),
+        }
+    }
+}
+
+/// Removes the first item matching a filter from a vec, and returns it.
+pub(crate) fn pull_first_match<T, F>(vec: &mut Vec<T>, f: F) -> T
+where
+    F: Fn(&T) -> bool,
+{
+    let index = vec.iter().position(f).unwrap();
+    vec.remove(index)
+}
+
+/// Removes all the items matching a filter from a vec, and returns them.
+pub(crate) fn pull_all_matches<T, F>(vec: &mut Vec<T>, f: F) -> Vec<T>
+where
+    F: Fn(&T) -> bool,
+{
+    let mut output = Vec::new();
+    for index in (0..vec.len()).rev() {
+        if f(&vec[index]) {
+            output.push(vec.remove(index));
+        }
+    }
+    output
+}
+
+pub(crate) fn serialize_vec_with_token_string<T, S>(
+    input: &Vec<T>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+    T: ToTokens,
+{
+    let mut tv = serializer.serialize_seq(Some(input.len()))?;
+    for elm in input.iter() {
+        tv.serialize_element(&elm.to_token_stream().to_string())?;
+    }
+    tv.end()
+}
+
+pub(crate) fn serialize_with_token_string<T, S>(input: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+    T: ToTokens,
+{
+    serializer.serialize_str(&input.to_token_stream().to_string())
+}
+
+pub(crate) fn serialize_with_token_string_2<T1, T2, S>(
+    input1: &T1,
+    input2: &T2,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+    T1: ToTokens,
+    T2: ToTokens,
+{
+    let mut tv = serializer.serialize_tuple_variant("", 0, "", 2)?;
+    tv.serialize_field(&input1.to_token_stream().to_string())?;
+    tv.serialize_field(&input2.to_token_stream().to_string())?;
+    tv.end()
+}
+
+pub(crate) fn serialize_with_token_string_3<T1, T2, T3, S>(
+    input1: &T1,
+    input2: &T2,
+    input3: &T3,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+    T1: ToTokens,
+    T2: ToTokens,
+    T3: ToTokens,
+{
+    let mut tv = serializer.serialize_tuple_variant("", 0, "", 3)?;
+    tv.serialize_field(&input1.to_token_stream().to_string())?;
+    tv.serialize_field(&input2.to_token_stream().to_string())?;
+    tv.serialize_field(&input3.to_token_stream().to_string())?;
+    tv.end()
+}
+
+/// A macro that packs multiple options if they are all `Some` and returns `None` otherwise.
+///
+/// # Example
+/// ```rust
+/// # use concrete_core_representation::pack_somes;
+/// assert_eq!(Some((1,2,3)), pack_somes!(Some(1), Some(2), Some(3)));
+/// assert_eq!(None, pack_somes!(None, Some(2), Some(3)));
+/// assert_eq!(None, pack_somes!(Some(1), None, Some(3)));
+/// assert_eq!(None, pack_somes!(Some(1), Some(2), None));
+#[macro_export]
+macro_rules! pack_somes {
+    ($i: expr, $ii:expr) => {
+        if let (Some(i), Some(ii)) = ($i, $ii) {
+            Some((i, ii))
+        } else {
+            None
+        }
+    };
+    ($i: expr, $ii:expr, $iii:expr) => {
+        if let (Some(i), Some(ii), Some(iii)) = ($i, $ii, $iii) {
+            Some((i, ii, iii))
+        } else {
+            None
+        }
+    };
+    ($i: expr, $ii:expr, $iii:expr, $iv:expr) => {
+        if let (Some(i), Some(ii), Some(iii), Some(iv)) = ($i, $ii, $iii, $iv) {
+            Some((i, ii, iii, iv))
+        } else {
+            None
+        }
+    };
+    ($i: expr, $ii:expr, $iii:expr, $iv:expr, $v:expr) => {
+        if let (Some(i), Some(ii), Some(iii), Some(iv), Some(v)) = ($i, $ii, $iii, $iv, $v) {
+            Some((i, ii, iii, iv, v))
+        } else {
+            None
+        }
+    };
+    ($i: expr, $ii:expr, $iii:expr, $iv:expr, $v:expr, $vi:expr) => {
+        if let (Some(i), Some(ii), Some(iii), Some(iv), Some(v), Some(vi)) =
+            ($i, $ii, $iii, $iv, $v, $vi)
+        {
+            Some((i, ii, iii, iv, v, vi))
+        } else {
+            None
+        }
+    };
+}
+pub(crate) use pack_somes;
+
+/// A macro to write compact queries on deeply nested data structures (such as asts).
+///
+/// A `syn` ast is a deeply nested structure, that is based on a combination of struct with
+/// optional and non-optional fields, rebinding enums, and potentially empty collections. It quickly
+/// gets tedious (and boring) to extract the relevant pieces of the ast given this deep nesting. The
+/// same tasks got repeated over and over again:
+///     - following trails of non-optional fields
+///     - checking for existence of optional fields
+///     - checking for emptyness of collections
+///     - properly matching the rebinding enumerations along the way
+///
+/// The code can get really messy really quick.
+///
+/// To simplify this situation, we provide the `probe` macro, which allows to write compact queries
+/// over nested structures.
+///
+/// # Gist
+///
+/// The `probe` macro takes an `Option` as input, applies a serie of _pipes_, and returns an
+/// `Option` as output. The output will be `Some(value)`, if the input was `Some`, and all the pipes
+/// executed along the way were successful:
+/// ```rust
+/// # use concrete_core_representation::probe;
+/// enum IntegerParity{
+///     Even(usize),
+///     Odd(usize)
+/// }
+/// let output = probe!(
+///     Some(10),
+///     val -> val * 2,                            // Applying a map pipe.
+///     new_val ?> new_val % 2 == 0,               // Applying a filter pipe.
+///     X> Some(IntegerParity::Odd(9))             // Applying a reboot pipe.
+///     IntegerParity::Odd(val) => val,            // Applying the variant pipe.
+///     val >> val.checked_add(55),                // Applying a then pipe.
+/// );
+/// assert_eq!(output, Some(64));
+/// ```
+///
+/// ## `->` : Map pipe
+///
+/// The map pipe applies a function to the content of a `Some` variant:
+/// ```rust
+/// # use concrete_core_representation::probe;
+/// let output = probe!(
+///     Some(10),
+///     val -> val*2
+/// );
+/// assert_eq!(output, Some(20));
+///
+/// let output = probe!(
+///     None,
+///     val -> val*2
+/// );
+/// assert_eq!(output, None);
+/// ```
+///
+/// ## `?>` : filter pipe
+///
+/// The filter pipe verifies that a `Some` variant verifies a given condition:
+/// ```rust
+/// # use concrete_core_representation::probe;
+/// let output = probe!(
+///     Some(10),
+///     val ?> val < 20
+/// );
+/// assert_eq!(output, Some(10));
+///
+/// let output = probe!(
+///     Some(10),
+///     val ?> val > 20
+/// );
+/// assert_eq!(output, None);
+///
+/// let output = probe!(
+///     None,
+///     val ?> val > 20
+/// );
+/// assert_eq!(output, None);
+/// ```
+///
+/// ## `>>` : then pipe
+///
+/// The then pipe applies an option-returning function to the content of a `Some` variant:
+/// ```rust
+/// # use concrete_core_representation::probe;
+/// let output = probe!(Some(i32::MAX), val >> val.checked_mul(1));
+/// assert_eq!(output, Some(i32::MAX));
+///
+/// let output = probe!(Some(i32::MAX), val >> val.checked_mul(2));
+/// assert_eq!(output, None);
+///
+/// let output = probe!(None, val >> val.checked_mul(2));
+/// assert_eq!(output, None);
+/// ```
+///
+/// ## `=>` : variant pipe
+///
+/// The variant pipe unwraps a given variant of an enumeration:
+/// ```rust
+/// # use concrete_core_representation::probe;
+/// enum MyEnum{
+///     First(usize),
+///     Second(())
+/// }
+/// let output = probe!(
+///     Some(MyEnum::First(5)),
+///     MyEnum::First(val) => val
+/// );
+/// assert_eq!(output, Some(5));
+///
+/// let output = probe!(
+///     Some(MyEnum::First(5)),
+///     MyEnum::Second(val) => val
+/// );
+/// assert_eq!(output, None);
+///
+/// let output = probe!(
+///     None,
+///     MuEnum::Second(val) => val
+/// );
+/// assert_eq!(output, None);
+/// ```
+///
+/// ## `X>` : reboot pipe
+///
+/// The reboot pipe allows to replace the current value with a new option if the previous one was
+/// `Some`:
+/// ```rust
+/// # use concrete_core_representation::probe;
+/// let output = probe!(Some(1), X > Some(2));
+/// assert_eq!(output, Some(2));
+///
+/// let output = probe!(Some(1), X > None);
+/// assert_eq!(output, None);
+///
+/// let output = probe!(None, X > Some(2));
+/// assert_eq!(output, None);
+/// ```
+#[macro_export]
+macro_rules! probe {
+    ($($tail:tt)*) => {
+        __probe!($($tail)*)
+    };
+}
+pub(crate) use probe;
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __probe {
+    ($init: expr, $($tail:tt)*) => {
+        {
+            let local = || -> Option<_>{
+                let running = $init;
+                __probe!(running @ $($tail)*)
+            };
+            local()
+        }
+    };
+    ($running:ident @ $pattern:pat => $exp:expr) => {
+            if let $pattern = $running? {
+                Some($exp)
+            } else {
+                None
+            }
+    };
+    ($running:ident @ $pattern:pat => $exp:expr, $($tail:tt)*) => {
+        {
+            let running = if let $pattern = $running? {
+                Some($exp)
+            } else {
+                None
+            };
+            __probe!(running @ $($tail)*)
+        }
+    };
+    ($running:ident @ $ident:ident -> $exp:expr) => {
+            $running.map(|$ident| {
+                $exp
+            })
+    };
+    ($running:ident @ $ident:ident -> $exp:expr, $($tail:tt)*) => {
+        {
+            let running = $running.map(|$ident| {
+                $exp
+            });
+            __probe!(running @ $($tail)*)
+        }
+    };
+    ($running:ident @ $ident:ident >> $exp:expr) => {
+            $running.and_then(|$ident| {
+                $exp
+            })
+    };
+    ($running:ident @ $ident:ident >> $exp:expr, $($tail:tt)*) => {
+        {
+            let running = $running.and_then(|$ident| {
+                $exp
+            });
+            __probe!(running @ $($tail)*)
+        }
+    };
+    ($running:ident @ $ident:ident ?> $exp:expr) => {
+            $running.filter(|$ident| {
+                $exp
+            })
+    };
+    ($running:ident @ $ident:ident ?> $exp:expr, $($tail:tt)*) => {
+        {
+            let running = $running.filter(|$ident| {
+                $exp
+            });
+            __probe!(running @ $($tail)*)
+        }
+    };
+    ($running:ident @ X> $exp:expr) => {
+        $running.and($exp)
+    };
+    ($running:ident @ X> $exp:expr, $($tail:tt)*) => {
+        {
+            let running = $running.and($exp);
+            __probe!(running @ $($tail)*)
+        }
+    };
+
+}
+pub(crate) use __probe;

--- a/concrete-core-representation/src/ccr/mod.rs
+++ b/concrete-core-representation/src/ccr/mod.rs
@@ -1,0 +1,91 @@
+//! A module containing a representation for the concrete-core repository.
+use serde::Serialize;
+use std::fmt::Debug;
+use std::path::Path;
+use syn::__private::TokenStream2;
+
+mod abstract_engine_trait_impl;
+mod abstract_entity_trait_impl;
+mod backend;
+mod cfg_stack;
+mod concrete_core;
+mod config;
+mod engine;
+mod engine_trait_impl;
+mod engine_trait_impl_arg;
+mod engine_trait_impl_checked_method;
+mod engine_trait_impl_generic_argument;
+mod engine_trait_impl_return;
+mod engine_trait_impl_unchecked_method;
+mod engine_type_definition;
+mod entity;
+mod entity_ownership;
+mod entity_trait_impl;
+mod entity_type_definition;
+mod inline;
+mod misc;
+mod struct_definition;
+
+pub use abstract_engine_trait_impl::*;
+pub use abstract_entity_trait_impl::*;
+pub use backend::*;
+pub use cfg_stack::*;
+pub use concrete_core::*;
+pub use config::*;
+pub use engine::*;
+pub use engine_trait_impl::*;
+pub use engine_trait_impl_arg::*;
+pub use engine_trait_impl_checked_method::*;
+pub use engine_trait_impl_generic_argument::*;
+pub use engine_trait_impl_return::*;
+pub use engine_trait_impl_unchecked_method::*;
+pub use engine_type_definition::*;
+pub use entity::*;
+pub use entity_ownership::*;
+pub use entity_trait_impl::*;
+pub use entity_type_definition::*;
+pub(crate) use misc::*;
+pub(crate) use struct_definition::*;
+
+/// Builds a representation of concrete-core from the path of the root file.
+pub fn load_ccr<P: AsRef<Path>>(path: P) -> ConcreteCore {
+    let root = inline::read_crate(path);
+    let empty_cfg_stack = CfgStack::empty();
+    ConcreteCore::extract(&empty_cfg_stack, &root)
+}
+
+// TODO: Once reintegrated into concrete-core, those parameters should be parsed from the sources as
+// well.
+const PARAMETERS_IDENTS: [&str; 25] = [
+    "PlaintextCount",
+    "EncoderCount",
+    "CleartextCount",
+    "CiphertextCount",
+    "LweCiphertextCount",
+    "LweCiphertextIndex",
+    "LweCiphertextRange",
+    "GlweCiphertextCount",
+    "GswCiphertextCount",
+    "GgswCiphertextCount",
+    "LweSize",
+    "LweDimension",
+    "GlweSize",
+    "GlweDimension",
+    "PolynomialSize",
+    "PolynomialSizeLog",
+    "PolynomialCount",
+    "MonomialDegree",
+    "MonomialIndex",
+    "DecompositionBaseLog",
+    "DecompositionLevelCount",
+    "LutCountLog",
+    "ModulusSwitchOffset",
+    "DeltaLog",
+    "ExtractedBitsCount",
+];
+
+const DISPERSION_IDENTS: [&str; 3] = ["LogStandardDev", "StandardDev", "Variance"];
+
+const NUMERIC_IDENTS: [&str; 12] = [
+    "u8", "u16", "u32", "u64", "u128", "i8", "i16", "i32", "i64", "i128", "f32", "f64",
+];

--- a/concrete-core-representation/src/ccr/struct_definition.rs
+++ b/concrete-core-representation/src/ccr/struct_definition.rs
@@ -1,0 +1,52 @@
+use super::*;
+
+/// A temporary structure that stores a struct definition before it is casted to a `ccr` node.
+#[derive(Clone)]
+pub(crate) struct StructDefinition {
+    pub(crate) cfg: CfgStack,
+    pub(crate) item_struct: syn::ItemStruct,
+}
+
+impl StructDefinition {
+    /// From a `ItemMod` syn ast node, pointing to a module in a backend, recursively extract all
+    /// the public structure definitions.
+    pub(crate) fn extract_all(
+        cfg_stack_so_far: &CfgStack,
+        module: &syn::ItemMod,
+    ) -> Vec<StructDefinition> {
+        // INVARIANT: concrete-core items are publicly visible.
+        let mut output = Vec::new();
+        if module.content.is_none() {
+            return output;
+        }
+
+        for item in module.content.as_ref().unwrap().1.iter() {
+            // If the item is a module, we recurse:
+            if let syn::Item::Mod(item_mod) = item {
+                output.extend(
+                    StructDefinition::extract_all(
+                        &cfg_stack_so_far.concat_attrs(item_mod.attrs.as_slice()),
+                        item_mod,
+                    )
+                    .into_iter(),
+                );
+                continue;
+            }
+
+            // If the item is a pub struct, we add it.
+            let maybe_struct = probe!(
+                Some(item),
+                syn::Item::Struct(item_struct) => item_struct,
+                item_struct ?> matches!(item_struct.vis, syn::Visibility::Public(_)),
+                item_struct -> item_struct
+            );
+            if let Some(item_struct) = maybe_struct {
+                output.push(StructDefinition {
+                    cfg: cfg_stack_so_far.concat_attrs(item_struct.attrs.as_slice()),
+                    item_struct: item_struct.to_owned(),
+                });
+            }
+        }
+        output
+    }
+}

--- a/concrete-core-representation/src/lib.rs
+++ b/concrete-core-representation/src/lib.rs
@@ -1,0 +1,26 @@
+//! A crate that builds a representation of `concrete-core` sources for automatic api generation.
+//!
+//! This crate contains the tools to build a _Concrete-Core Representation_ (abreviated `ccr` in the
+//! code) from the sources of `concrete-core`. That is, a tree that builds on top of the `syn` ast,
+//! to better represents `concrete-core` sources. This representation then makes it simple to
+//! generate an api that binds to `concrete-core`.
+//!
+//! # A note on vocabulary
+//!
+//! We use the following names in the representation node names:
+//!     + engine trait = An `*Engine` trait. In the specification.
+//!     + engine trait impl = An `impl *Engine for *` block. In a backend
+//!     + engine type = A type that implement some `*Engine` traits. In a backend.
+//!     + engine type definition = A `pub struct *Engine{...}` definition of a type that implements
+//!       `*Engine` traits. In a backend.
+//!     + entity trait = An `*Entity` trait. In the specification.
+//!     + entity trait impl = An `impl *Entity for *` block. In a backend
+//!     + entity type = A type that implement an `*Entity` traits. In a backend.
+//!     + entity type definition = A `pub struct *{...}` definition of a type that implements an
+//!       `*Entity` trait. In a backend.
+
+mod ccr;
+pub use ccr::*;
+
+mod misc;
+pub use misc::*;

--- a/concrete-core-representation/src/misc.rs
+++ b/concrete-core-representation/src/misc.rs
@@ -1,0 +1,94 @@
+use crate::{Backend, ConcreteCore, Engine, EngineTraitImpl, Entity};
+use quote::ToTokens;
+use std::borrow::Borrow;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+/// Dumps the `ccr` to a json file. For debugging purpose.
+pub fn dump_ccr_to_file<P: AsRef<Path>, CC: Borrow<ConcreteCore>>(path: P, ccr: CC) {
+    let mut file = File::create(path.as_ref()).unwrap();
+    let output = serde_json::to_string(ccr.borrow()).unwrap();
+    file.write_all(output.as_bytes()).unwrap();
+}
+
+/// Dumps the `ccr` to a "/tmp/ccr_dump.json" file. For debugging purpose.
+pub fn dump_ccr<CC: Borrow<ConcreteCore>>(ccr: CC) {
+    dump_ccr_to_file("/tmp/ccr_dump.json", ccr);
+}
+
+/// Prints a human-readable summary of the input `ccr` to the output.
+pub fn print_ccr<CC: Borrow<ConcreteCore>>(ccr: CC) {
+    println!("Concrete Core");
+    println!("=============");
+    println!();
+    for backend in ccr.borrow().backends.iter() {
+        print_backend(1, backend)
+    }
+}
+
+fn print_backend(indent: usize, backend: &Backend) {
+    let indent_str = "    ".repeat(indent);
+    let backend_title = format!("{} backend", backend.ident);
+    println!("{}{}", indent_str, backend_title);
+    println!("{}{}", indent_str, "-".repeat(backend_title.len()));
+    println!();
+    print_all_engines(indent + 1, &backend.engines);
+    println!();
+    print_all_entities(indent + 1, &backend.entities);
+    println!();
+}
+
+fn print_all_engines(indent: usize, engines: &[Engine]) {
+    let indent_str = "    ".repeat(indent);
+    let engine_title = format!("Engines ({}):", engines.len());
+    println!("{}{}", indent_str, engine_title);
+    for engine in engines.iter() {
+        print_engine(indent + 1, engine);
+    }
+}
+
+fn print_all_entities(indent: usize, entities: &[Entity]) {
+    let indent_str = "    ".repeat(indent);
+    let entity_title = format!("Entities ({}):", entities.len());
+    println!("{}{}", indent_str, entity_title);
+    for entity in entities.iter() {
+        print_entity(indent + 1, entity);
+    }
+}
+
+fn print_engine(indent: usize, engine: &Engine) {
+    let indent_str = "    ".repeat(indent);
+    let engine_title = format!("=> {}", engine.definition.item_struct.ident);
+    println!("{}{}", indent_str, engine_title);
+    for engine_impl in engine.engine_impls.iter() {
+        print_engine_impl(indent + 1, engine_impl);
+    }
+}
+
+fn print_engine_impl(indent: usize, engine_impl: &EngineTraitImpl) {
+    let indent_str = "    ".repeat(indent);
+    let engine_title = format!(
+        "+ {}<{}>",
+        engine_impl.engine_trait_ident.to_string().replace(' ', ""),
+        engine_impl
+            .engine_trait_parameters
+            .as_ref()
+            .unwrap()
+            .iter()
+            .fold(String::new(), |mut st, param| {
+                st.push_str(param.get_type().to_token_stream().to_string().as_str());
+                st.push(',');
+                st
+            })
+            .replace(' ', "")
+    )
+    .replace(",>", ">");
+    println!("{}{}", indent_str, engine_title);
+}
+
+fn print_entity(indent: usize, entity: &Entity) {
+    let indent_str = "    ".repeat(indent);
+    let entity_title = format!("=> {}", entity.definition.item_struct.ident);
+    println!("{}{}", indent_str, entity_title);
+}


### PR DESCRIPTION
### Resolves:

closes zama-ai/concrete-core-internal#385

### Description

This commit introduces a new crate `concrete-core-representation` that contains tools to analyze the `concrete-core` sources, and build a _Concrete Core Represetation_ out of it. This representation is a tree that builds on top of a `syn` ast with specific nodes that better describes the architecture of the `concrete-core` sources. This representation can then be used for various tasks, among which, automatically generating apis.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
