### PR TITLE
refactor(concrete_core): change internal api of lwe ciphertext

### DIFF
--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_cleartext_discarding_multiplication.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_cleartext_discarding_multiplication.rs
@@ -70,7 +70,10 @@ impl
         input_1: &LweCiphertext32,
         input_2: &Cleartext32,
     ) {
-        output.0.fill_with_scalar_mul(&input_1.0, &input_2.0);
+        output
+            .0
+            .as_mut()
+            .fill_with_scalar_mul(&input_1.0.as_ref(), &input_2.0);
     }
 }
 
@@ -136,7 +139,10 @@ impl
         input_1: &LweCiphertext64,
         input_2: &Cleartext64,
     ) {
-        output.0.fill_with_scalar_mul(&input_1.0, &input_2.0);
+        output
+            .0
+            .as_mut()
+            .fill_with_scalar_mul(&input_1.0.as_ref(), &input_2.0);
     }
 }
 

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_cleartext_fusing_multiplication.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_cleartext_fusing_multiplication.rs
@@ -59,7 +59,7 @@ impl LweCiphertextCleartextFusingMultiplicationEngine<LweCiphertext32, Cleartext
         output: &mut LweCiphertext32,
         input: &Cleartext32,
     ) {
-        output.0.update_with_scalar_mul(input.0);
+        output.0.as_mut().update_with_scalar_mul(input.0);
     }
 }
 
@@ -115,6 +115,6 @@ impl LweCiphertextCleartextFusingMultiplicationEngine<LweCiphertext64, Cleartext
         output: &mut LweCiphertext64,
         input: &Cleartext64,
     ) {
-        output.0.update_with_scalar_mul(input.0);
+        output.0.as_mut().update_with_scalar_mul(input.0);
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_consuming_retrieval.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_consuming_retrieval.rs
@@ -3,7 +3,6 @@ use crate::backends::default::implementation::entities::{
     LweCiphertext32, LweCiphertext64, LweCiphertextMutView32, LweCiphertextMutView64,
     LweCiphertextView32, LweCiphertextView64,
 };
-use crate::commons::math::tensor::IntoTensor;
 use crate::specification::engines::{
     LweCiphertextConsumingRetrievalEngine, LweCiphertextConsumingRetrievalError,
 };
@@ -47,7 +46,7 @@ impl LweCiphertextConsumingRetrievalEngine<LweCiphertext32, Vec<u32>> for Defaul
         &mut self,
         ciphertext: LweCiphertext32,
     ) -> Vec<u32> {
-        ciphertext.0.into_tensor().into_container()
+        ciphertext.0.to_vec()
     }
 }
 
@@ -90,7 +89,7 @@ impl LweCiphertextConsumingRetrievalEngine<LweCiphertext64, Vec<u64>> for Defaul
         &mut self,
         ciphertext: LweCiphertext64,
     ) -> Vec<u64> {
-        ciphertext.0.into_tensor().into_container()
+        ciphertext.0.to_vec()
     }
 }
 
@@ -136,7 +135,7 @@ impl<'data> LweCiphertextConsumingRetrievalEngine<LweCiphertextView32<'data>, &'
         &mut self,
         ciphertext: LweCiphertextView32<'data>,
     ) -> &'data [u32] {
-        ciphertext.0.into_tensor().into_container()
+        ciphertext.0.to_slice()
     }
 }
 
@@ -184,7 +183,7 @@ impl<'data> LweCiphertextConsumingRetrievalEngine<LweCiphertextMutView32<'data>,
         &mut self,
         ciphertext: LweCiphertextMutView32<'data>,
     ) -> &'data mut [u32] {
-        ciphertext.0.into_tensor().into_container()
+        ciphertext.0.to_mut_slice()
     }
 }
 
@@ -230,7 +229,7 @@ impl<'data> LweCiphertextConsumingRetrievalEngine<LweCiphertextView64<'data>, &'
         &mut self,
         ciphertext: LweCiphertextView64<'data>,
     ) -> &'data [u64] {
-        ciphertext.0.into_tensor().into_container()
+        ciphertext.0.to_slice()
     }
 }
 
@@ -278,6 +277,6 @@ impl<'data> LweCiphertextConsumingRetrievalEngine<LweCiphertextMutView64<'data>,
         &mut self,
         ciphertext: LweCiphertextMutView64<'data>,
     ) -> &'data mut [u64] {
-        ciphertext.0.into_tensor().into_container()
+        ciphertext.0.to_mut_slice()
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_creation.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_creation.rs
@@ -4,6 +4,8 @@ use crate::backends::default::implementation::entities::{
     LweCiphertextView32, LweCiphertextView64,
 };
 use crate::commons::crypto::lwe::LweCiphertext as ImplLweCiphertext;
+use crate::commons::crypto::lwe::LweCiphertextMutView as ImplLweCiphertextMutView;
+use crate::commons::crypto::lwe::LweCiphertextView as ImplLweCiphertextView;
 use crate::specification::engines::{LweCiphertextCreationEngine, LweCiphertextCreationError};
 
 /// # Description:
@@ -43,7 +45,7 @@ impl LweCiphertextCreationEngine<Vec<u32>, LweCiphertext32> for DefaultEngine {
         &mut self,
         container: Vec<u32>,
     ) -> LweCiphertext32 {
-        LweCiphertext32(ImplLweCiphertext::from_container(container))
+        LweCiphertext32(ImplLweCiphertext::from_vec(container))
     }
 }
 
@@ -84,7 +86,7 @@ impl LweCiphertextCreationEngine<Vec<u64>, LweCiphertext64> for DefaultEngine {
         &mut self,
         container: Vec<u64>,
     ) -> LweCiphertext64 {
-        LweCiphertext64(ImplLweCiphertext::from_container(container))
+        LweCiphertext64(ImplLweCiphertext::from_vec(container))
     }
 }
 
@@ -129,7 +131,7 @@ impl<'data> LweCiphertextCreationEngine<&'data [u32], LweCiphertextView32<'data>
         &mut self,
         container: &'data [u32],
     ) -> LweCiphertextView32<'data> {
-        LweCiphertextView32(ImplLweCiphertext::from_container(container))
+        LweCiphertextView32(ImplLweCiphertextView::from_slice(container))
     }
 }
 
@@ -174,7 +176,7 @@ impl<'data> LweCiphertextCreationEngine<&'data mut [u32], LweCiphertextMutView32
         &mut self,
         container: &'data mut [u32],
     ) -> LweCiphertextMutView32<'data> {
-        LweCiphertextMutView32(ImplLweCiphertext::from_container(container))
+        LweCiphertextMutView32(ImplLweCiphertextMutView::from_mut_slice(container))
     }
 }
 
@@ -217,7 +219,7 @@ impl<'data> LweCiphertextCreationEngine<&'data [u64], LweCiphertextView64<'data>
         &mut self,
         container: &'data [u64],
     ) -> LweCiphertextView64<'data> {
-        LweCiphertextView64(ImplLweCiphertext::from_container(container))
+        LweCiphertextView64(ImplLweCiphertextView::from_slice(container))
     }
 }
 
@@ -262,6 +264,6 @@ impl<'data> LweCiphertextCreationEngine<&'data mut [u64], LweCiphertextMutView64
         &mut self,
         container: &'data mut [u64],
     ) -> LweCiphertextMutView64<'data> {
-        LweCiphertextMutView64(ImplLweCiphertext::from_container(container))
+        LweCiphertextMutView64(ImplLweCiphertextMutView::from_mut_slice(container))
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_decryption.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_decryption.rs
@@ -52,7 +52,7 @@ impl LweCiphertextDecryptionEngine<LweSecretKey32, LweCiphertext32, Plaintext32>
         input: &LweCiphertext32,
     ) -> Plaintext32 {
         let mut plaintext = ImplPlaintext(0u32);
-        key.0.decrypt_lwe(&mut plaintext, &input.0);
+        key.0.decrypt_lwe(&mut plaintext, &input.0.as_ref());
         Plaintext32(plaintext)
     }
 }
@@ -103,7 +103,7 @@ impl LweCiphertextDecryptionEngine<LweSecretKey64, LweCiphertext64, Plaintext64>
         input: &LweCiphertext64,
     ) -> Plaintext64 {
         let mut plaintext = ImplPlaintext(0u64);
-        key.0.decrypt_lwe(&mut plaintext, &input.0);
+        key.0.decrypt_lwe(&mut plaintext, &input.0.as_ref());
         Plaintext64(plaintext)
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_addition.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_addition.rs
@@ -3,7 +3,6 @@ use crate::backends::default::implementation::entities::{
     LweCiphertext32, LweCiphertext64, LweCiphertextMutView32, LweCiphertextMutView64,
     LweCiphertextView32, LweCiphertextView64,
 };
-use crate::commons::math::tensor::{AsMutTensor, AsRefTensor};
 use crate::specification::engines::{
     LweCiphertextDiscardingAdditionEngine, LweCiphertextDiscardingAdditionError,
 };
@@ -63,11 +62,8 @@ impl LweCiphertextDiscardingAdditionEngine<LweCiphertext32, LweCiphertext32> for
         input_1: &LweCiphertext32,
         input_2: &LweCiphertext32,
     ) {
-        output
-            .0
-            .as_mut_tensor()
-            .fill_with_copy(input_1.0.as_tensor());
-        output.0.update_with_add(&input_2.0);
+        output.0.tensor.fill_with_copy(&input_1.0.as_ref().tensor);
+        output.0.as_mut().update_with_add(&input_2.0.as_ref());
     }
 }
 
@@ -126,11 +122,8 @@ impl LweCiphertextDiscardingAdditionEngine<LweCiphertext64, LweCiphertext64> for
         input_1: &LweCiphertext64,
         input_2: &LweCiphertext64,
     ) {
-        output
-            .0
-            .as_mut_tensor()
-            .fill_with_copy(input_1.0.as_tensor());
-        output.0.update_with_add(&input_2.0);
+        output.0.tensor.fill_with_copy(&input_1.0.as_ref().tensor);
+        output.0.as_mut().update_with_add(&input_2.0.as_ref());
     }
 }
 
@@ -209,10 +202,7 @@ impl LweCiphertextDiscardingAdditionEngine<LweCiphertextView32<'_>, LweCiphertex
         input_1: &LweCiphertextView32,
         input_2: &LweCiphertextView32,
     ) {
-        output
-            .0
-            .as_mut_tensor()
-            .fill_with_copy(input_1.0.as_tensor());
+        output.0.tensor.fill_with_copy(&input_1.0.tensor);
         output.0.update_with_add(&input_2.0);
     }
 }
@@ -292,10 +282,7 @@ impl LweCiphertextDiscardingAdditionEngine<LweCiphertextView64<'_>, LweCiphertex
         input_1: &LweCiphertextView64,
         input_2: &LweCiphertextView64,
     ) {
-        output
-            .0
-            .as_mut_tensor()
-            .fill_with_copy(input_1.0.as_tensor());
+        output.0.tensor.fill_with_copy(&input_1.0.tensor);
         output.0.update_with_add(&input_2.0);
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_decryption.rs
@@ -59,7 +59,7 @@ impl LweCiphertextDiscardingDecryptionEngine<LweSecretKey32, LweCiphertext32, Pl
         output: &mut Plaintext32,
         input: &LweCiphertext32,
     ) {
-        key.0.decrypt_lwe(&mut output.0, &input.0);
+        key.0.decrypt_lwe(&mut output.0, &input.0.as_ref());
     }
 }
 
@@ -116,6 +116,6 @@ impl LweCiphertextDiscardingDecryptionEngine<LweSecretKey64, LweCiphertext64, Pl
         output: &mut Plaintext64,
         input: &LweCiphertext64,
     ) {
-        key.0.decrypt_lwe(&mut output.0, &input.0);
+        key.0.decrypt_lwe(&mut output.0, &input.0.as_ref());
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_encryption.rs
@@ -65,7 +65,7 @@ impl LweCiphertextDiscardingEncryptionEngine<LweSecretKey32, Plaintext32, LweCip
         noise: Variance,
     ) {
         key.0.encrypt_lwe(
-            &mut output.0,
+            &mut output.0.as_mut(),
             &input.0,
             noise,
             &mut self.encryption_generator,
@@ -129,7 +129,7 @@ impl LweCiphertextDiscardingEncryptionEngine<LweSecretKey64, Plaintext64, LweCip
         noise: Variance,
     ) {
         key.0.encrypt_lwe(
-            &mut output.0,
+            &mut output.0.as_mut(),
             &input.0,
             noise,
             &mut self.encryption_generator,

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_extraction.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_extraction.rs
@@ -80,6 +80,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext32, LweCiphertext32> 
         #[allow(deprecated)]
         output
             .0
+            .as_mut()
             .fill_with_glwe_sample_extraction(&input.0, MonomialDegree(nth.0));
     }
 }
@@ -155,6 +156,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext64, LweCiphertext64> 
         #[allow(deprecated)]
         output
             .0
+            .as_mut()
             .fill_with_glwe_sample_extraction(&input.0, MonomialDegree(nth.0));
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_keyswitch.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_keyswitch.rs
@@ -74,7 +74,8 @@ impl LweCiphertextDiscardingKeyswitchEngine<LweKeyswitchKey32, LweCiphertext32, 
         input: &LweCiphertext32,
         ksk: &LweKeyswitchKey32,
     ) {
-        ksk.0.keyswitch_ciphertext(&mut output.0, &input.0);
+        ksk.0
+            .keyswitch_ciphertext(&mut output.0.as_mut(), &input.0.as_ref());
     }
 }
 
@@ -145,7 +146,8 @@ impl LweCiphertextDiscardingKeyswitchEngine<LweKeyswitchKey64, LweCiphertext64, 
         input: &LweCiphertext64,
         ksk: &LweKeyswitchKey64,
     ) {
-        ksk.0.keyswitch_ciphertext(&mut output.0, &input.0);
+        ksk.0
+            .keyswitch_ciphertext(&mut output.0.as_mut(), &input.0.as_ref());
     }
 }
 

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_opposite.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_opposite.rs
@@ -3,7 +3,6 @@ use crate::backends::default::implementation::entities::{
     LweCiphertext32, LweCiphertext64, LweCiphertextMutView32, LweCiphertextMutView64,
     LweCiphertextView32, LweCiphertextView64,
 };
-use crate::commons::math::tensor::{AsMutTensor, AsRefTensor};
 use crate::specification::engines::{
     LweCiphertextDiscardingOppositeEngine, LweCiphertextDiscardingOppositeError,
 };
@@ -58,8 +57,8 @@ impl LweCiphertextDiscardingOppositeEngine<LweCiphertext32, LweCiphertext32> for
         output: &mut LweCiphertext32,
         input: &LweCiphertext32,
     ) {
-        output.0.as_mut_tensor().fill_with_copy(input.0.as_tensor());
-        output.0.update_with_neg();
+        output.0.tensor.fill_with_copy(&input.0.as_ref().tensor);
+        output.0.as_mut().update_with_neg();
     }
 }
 
@@ -113,8 +112,8 @@ impl LweCiphertextDiscardingOppositeEngine<LweCiphertext64, LweCiphertext64> for
         output: &mut LweCiphertext64,
         input: &LweCiphertext64,
     ) {
-        output.0.as_mut_tensor().fill_with_copy(input.0.as_tensor());
-        output.0.update_with_neg();
+        output.0.tensor.fill_with_copy(&input.0.as_ref().tensor);
+        output.0.as_mut().update_with_neg();
     }
 }
 
@@ -182,7 +181,7 @@ impl LweCiphertextDiscardingOppositeEngine<LweCiphertextView32<'_>, LweCiphertex
         output: &mut LweCiphertextMutView32,
         input: &LweCiphertextView32,
     ) {
-        output.0.as_mut_tensor().fill_with_copy(input.0.as_tensor());
+        output.0.tensor.fill_with_copy(&input.0.tensor);
         output.0.update_with_neg();
     }
 }
@@ -251,7 +250,7 @@ impl LweCiphertextDiscardingOppositeEngine<LweCiphertextView64<'_>, LweCiphertex
         output: &mut LweCiphertextMutView64,
         input: &LweCiphertextView64,
     ) {
-        output.0.as_mut_tensor().fill_with_copy(input.0.as_tensor());
+        output.0.tensor.fill_with_copy(&input.0.tensor);
         output.0.update_with_neg();
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_subtraction.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_subtraction.rs
@@ -1,6 +1,5 @@
 use crate::backends::default::implementation::engines::DefaultEngine;
 use crate::backends::default::implementation::entities::{LweCiphertext32, LweCiphertext64};
-use crate::commons::math::tensor::{AsMutTensor, AsRefTensor};
 use crate::specification::engines::{
     LweCiphertextDiscardingSubtractionEngine, LweCiphertextDiscardingSubtractionError,
 };
@@ -60,11 +59,8 @@ impl LweCiphertextDiscardingSubtractionEngine<LweCiphertext32, LweCiphertext32> 
         input_1: &LweCiphertext32,
         input_2: &LweCiphertext32,
     ) {
-        output
-            .0
-            .as_mut_tensor()
-            .fill_with_copy(input_1.0.as_tensor());
-        output.0.update_with_sub(&input_2.0);
+        output.0.tensor.fill_with_copy(&input_1.0.as_ref().tensor);
+        output.0.as_mut().update_with_sub(&input_2.0.as_ref());
     }
 }
 
@@ -123,10 +119,7 @@ impl LweCiphertextDiscardingSubtractionEngine<LweCiphertext64, LweCiphertext64> 
         input_1: &LweCiphertext64,
         input_2: &LweCiphertext64,
     ) {
-        output
-            .0
-            .as_mut_tensor()
-            .fill_with_copy(input_1.0.as_tensor());
-        output.0.update_with_sub(&input_2.0);
+        output.0.tensor.fill_with_copy(&input_1.0.as_ref().tensor);
+        output.0.as_mut().update_with_sub(&input_2.0.as_ref());
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_encryption.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_encryption.rs
@@ -58,7 +58,7 @@ impl LweCiphertextEncryptionEngine<LweSecretKey32, Plaintext32, LweCiphertext32>
     ) -> LweCiphertext32 {
         let mut ciphertext = ImplLweCiphertext::allocate(0u32, key.lwe_dimension().to_lwe_size());
         key.0.encrypt_lwe(
-            &mut ciphertext,
+            &mut ciphertext.as_mut(),
             &input.0,
             noise,
             &mut self.encryption_generator,
@@ -117,7 +117,7 @@ impl LweCiphertextEncryptionEngine<LweSecretKey64, Plaintext64, LweCiphertext64>
     ) -> LweCiphertext64 {
         let mut ciphertext = ImplLweCiphertext::allocate(0u64, key.lwe_dimension().to_lwe_size());
         key.0.encrypt_lwe(
-            &mut ciphertext,
+            &mut ciphertext.as_mut(),
             &input.0,
             noise,
             &mut self.encryption_generator,

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_fusing_addition.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_fusing_addition.rs
@@ -56,7 +56,7 @@ impl LweCiphertextFusingAdditionEngine<LweCiphertext32, LweCiphertext32> for Def
         output: &mut LweCiphertext32,
         input: &LweCiphertext32,
     ) {
-        output.0.update_with_add(&input.0);
+        output.0.as_mut().update_with_add(&input.0.as_ref());
     }
 }
 
@@ -112,6 +112,6 @@ impl LweCiphertextFusingAdditionEngine<LweCiphertext64, LweCiphertext64> for Def
         output: &mut LweCiphertext64,
         input: &LweCiphertext64,
     ) {
-        output.0.update_with_add(&input.0);
+        output.0.as_mut().update_with_add(&input.0.as_ref());
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_fusing_opposite.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_fusing_opposite.rs
@@ -47,7 +47,7 @@ impl LweCiphertextFusingOppositeEngine<LweCiphertext32> for DefaultEngine {
     }
 
     unsafe fn fuse_opp_lwe_ciphertext_unchecked(&mut self, input: &mut LweCiphertext32) {
-        input.0.update_with_neg();
+        input.0.as_mut().update_with_neg();
     }
 }
 
@@ -94,6 +94,6 @@ impl LweCiphertextFusingOppositeEngine<LweCiphertext64> for DefaultEngine {
     }
 
     unsafe fn fuse_opp_lwe_ciphertext_unchecked(&mut self, input: &mut LweCiphertext64) {
-        input.0.update_with_neg();
+        input.0.as_mut().update_with_neg();
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_fusing_subtraction.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_fusing_subtraction.rs
@@ -56,7 +56,7 @@ impl LweCiphertextFusingSubtractionEngine<LweCiphertext32, LweCiphertext32> for 
         output: &mut LweCiphertext32,
         input: &LweCiphertext32,
     ) {
-        output.0.update_with_sub(&input.0);
+        output.0.as_mut().update_with_sub(&input.0.as_ref());
     }
 }
 
@@ -112,6 +112,6 @@ impl LweCiphertextFusingSubtractionEngine<LweCiphertext64, LweCiphertext64> for 
         output: &mut LweCiphertext64,
         input: &LweCiphertext64,
     ) {
-        output.0.update_with_sub(&input.0);
+        output.0.as_mut().update_with_sub(&input.0.as_ref());
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_plaintext_discarding_addition.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_plaintext_discarding_addition.rs
@@ -3,7 +3,6 @@ use crate::backends::default::implementation::entities::{
     LweCiphertext32, LweCiphertext64, LweCiphertextMutView32, LweCiphertextMutView64,
     LweCiphertextView32, LweCiphertextView64, Plaintext32, Plaintext64,
 };
-use crate::commons::math::tensor::{AsMutTensor, AsRefTensor};
 use crate::specification::engines::{
     LweCiphertextPlaintextDiscardingAdditionEngine, LweCiphertextPlaintextDiscardingAdditionError,
 };
@@ -62,11 +61,9 @@ impl LweCiphertextPlaintextDiscardingAdditionEngine<LweCiphertext32, Plaintext32
         input_1: &LweCiphertext32,
         input_2: &Plaintext32,
     ) {
-        output
-            .0
-            .as_mut_tensor()
-            .fill_with_copy(input_1.0.as_tensor());
-        output.0.get_mut_body().0 = output.0.get_body().0.wrapping_add(input_2.0 .0);
+        output.0.tensor.fill_with_copy(&input_1.0.as_ref().tensor);
+        output.0.as_mut().get_mut_body().0 =
+            output.0.as_ref().get_body().0.wrapping_add(input_2.0 .0);
     }
 }
 
@@ -124,11 +121,9 @@ impl LweCiphertextPlaintextDiscardingAdditionEngine<LweCiphertext64, Plaintext64
         input_1: &LweCiphertext64,
         input_2: &Plaintext64,
     ) {
-        output
-            .0
-            .as_mut_tensor()
-            .fill_with_copy(input_1.0.as_tensor());
-        output.0.get_mut_body().0 = output.0.get_body().0.wrapping_add(input_2.0 .0);
+        output.0.tensor.fill_with_copy(&input_1.0.as_ref().tensor);
+        output.0.as_mut().get_mut_body().0 =
+            output.0.as_ref().get_body().0.wrapping_add(input_2.0 .0);
     }
 }
 
@@ -201,11 +196,8 @@ impl
         input_1: &LweCiphertextView32,
         input_2: &Plaintext32,
     ) {
-        output
-            .0
-            .as_mut_tensor()
-            .fill_with_copy(input_1.0.as_tensor());
-        output.0.get_mut_body().0 = output.0.get_body().0.wrapping_add(input_2.0 .0);
+        output.0.tensor.fill_with_copy(&input_1.0.tensor);
+        output.0.get_mut_body().0 = output.0.as_ref().get_body().0.wrapping_add(input_2.0 .0);
     }
 }
 
@@ -278,10 +270,7 @@ impl
         input_1: &LweCiphertextView64,
         input_2: &Plaintext64,
     ) {
-        output
-            .0
-            .as_mut_tensor()
-            .fill_with_copy(input_1.0.as_tensor());
-        output.0.get_mut_body().0 = output.0.get_body().0.wrapping_add(input_2.0 .0);
+        output.0.tensor.fill_with_copy(&input_1.0.tensor);
+        output.0.get_mut_body().0 = output.0.as_ref().get_body().0.wrapping_add(input_2.0 .0);
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_plaintext_discarding_subtraction.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_plaintext_discarding_subtraction.rs
@@ -2,7 +2,6 @@ use crate::backends::default::implementation::engines::DefaultEngine;
 use crate::backends::default::implementation::entities::{
     LweCiphertext32, LweCiphertext64, Plaintext32, Plaintext64,
 };
-use crate::commons::math::tensor::{AsMutTensor, AsRefTensor};
 use crate::specification::engines::{
     LweCiphertextPlaintextDiscardingSubtractionEngine,
     LweCiphertextPlaintextDiscardingSubtractionError,
@@ -63,11 +62,9 @@ impl
         input_1: &LweCiphertext32,
         input_2: &Plaintext32,
     ) {
-        output
-            .0
-            .as_mut_tensor()
-            .fill_with_copy(input_1.0.as_tensor());
-        output.0.get_mut_body().0 = output.0.get_body().0.wrapping_sub(input_2.0 .0);
+        output.0.tensor.fill_with_copy(&input_1.0.as_ref().tensor);
+        output.0.as_mut().get_mut_body().0 =
+            output.0.as_ref().get_body().0.wrapping_sub(input_2.0 .0);
     }
 }
 
@@ -126,10 +123,8 @@ impl
         input_1: &LweCiphertext64,
         input_2: &Plaintext64,
     ) {
-        output
-            .0
-            .as_mut_tensor()
-            .fill_with_copy(input_1.0.as_tensor());
-        output.0.get_mut_body().0 = output.0.get_body().0.wrapping_sub(input_2.0 .0);
+        output.0.tensor.fill_with_copy(&input_1.0.as_ref().tensor);
+        output.0.as_mut().get_mut_body().0 =
+            output.0.as_ref().get_body().0.wrapping_sub(input_2.0 .0);
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_plaintext_fusing_addition.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_plaintext_fusing_addition.rs
@@ -56,7 +56,8 @@ impl LweCiphertextPlaintextFusingAdditionEngine<LweCiphertext32, Plaintext32> fo
         output: &mut LweCiphertext32,
         input: &Plaintext32,
     ) {
-        output.0.get_mut_body().0 = output.0.get_body().0.wrapping_add(input.0 .0);
+        output.0.as_mut().get_mut_body().0 =
+            output.0.as_ref().get_body().0.wrapping_add(input.0 .0);
     }
 }
 
@@ -110,6 +111,7 @@ impl LweCiphertextPlaintextFusingAdditionEngine<LweCiphertext64, Plaintext64> fo
         output: &mut LweCiphertext64,
         input: &Plaintext64,
     ) {
-        output.0.get_mut_body().0 = output.0.get_body().0.wrapping_add(input.0 .0);
+        output.0.as_mut().get_mut_body().0 =
+            output.0.as_ref().get_body().0.wrapping_add(input.0 .0);
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_plaintext_fusing_subtraction.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_plaintext_fusing_subtraction.rs
@@ -56,7 +56,8 @@ impl LweCiphertextPlaintextFusingSubtractionEngine<LweCiphertext32, Plaintext32>
         output: &mut LweCiphertext32,
         input: &Plaintext32,
     ) {
-        output.0.get_mut_body().0 = output.0.get_body().0.wrapping_sub(input.0 .0);
+        output.0.as_mut().get_mut_body().0 =
+            output.0.as_ref().get_body().0.wrapping_sub(input.0 .0);
     }
 }
 
@@ -110,6 +111,7 @@ impl LweCiphertextPlaintextFusingSubtractionEngine<LweCiphertext64, Plaintext64>
         output: &mut LweCiphertext64,
         input: &Plaintext64,
     ) {
-        output.0.get_mut_body().0 = output.0.get_body().0.wrapping_sub(input.0 .0);
+        output.0.as_mut().get_mut_body().0 =
+            output.0.as_ref().get_body().0.wrapping_sub(input.0 .0);
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_trivial_decryption.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_trivial_decryption.rs
@@ -44,7 +44,7 @@ impl LweCiphertextTrivialDecryptionEngine<LweCiphertext32, Plaintext32> for Defa
         &mut self,
         input: &LweCiphertext32,
     ) -> Plaintext32 {
-        Plaintext32(ImplPlaintext(input.0.get_body().0))
+        Plaintext32(ImplPlaintext(input.0.as_ref().get_body().0))
     }
 }
 
@@ -89,6 +89,6 @@ impl LweCiphertextTrivialDecryptionEngine<LweCiphertext64, Plaintext64> for Defa
         &mut self,
         input: &LweCiphertext64,
     ) -> Plaintext64 {
-        Plaintext64(ImplPlaintext(input.0.get_body().0))
+        Plaintext64(ImplPlaintext(input.0.as_ref().get_body().0))
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_vector_discarding_addition.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_vector_discarding_addition.rs
@@ -2,7 +2,6 @@ use crate::backends::default::implementation::engines::DefaultEngine;
 use crate::backends::default::implementation::entities::{
     LweCiphertextVector32, LweCiphertextVector64,
 };
-use crate::commons::math::tensor::{AsMutTensor, AsRefTensor};
 use crate::specification::engines::{
     LweCiphertextVectorDiscardingAdditionEngine, LweCiphertextVectorDiscardingAdditionError,
 };
@@ -73,7 +72,7 @@ impl LweCiphertextVectorDiscardingAdditionEngine<LweCiphertextVector32, LweCiphe
             .ciphertext_iter_mut()
             .zip(input_1.0.ciphertext_iter().zip(input_2.0.ciphertext_iter()))
         {
-            out.as_mut_tensor().fill_with_copy(in_1.as_tensor());
+            out.tensor.fill_with_copy(&in_1.tensor);
             out.update_with_add(&in_2);
         }
     }
@@ -145,7 +144,7 @@ impl LweCiphertextVectorDiscardingAdditionEngine<LweCiphertextVector64, LweCiphe
             .ciphertext_iter_mut()
             .zip(input_1.0.ciphertext_iter().zip(input_2.0.ciphertext_iter()))
         {
-            out.as_mut_tensor().fill_with_copy(in_1.as_tensor());
+            out.tensor.fill_with_copy(&in_1.tensor);
             out.update_with_add(&in_2);
         }
     }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_vector_discarding_affine_transformation.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_vector_discarding_affine_transformation.rs
@@ -86,6 +86,7 @@ impl
     ) {
         output
             .0
+            .as_mut()
             .fill_with_multisum_with_bias(&inputs.0, &weights.0, &bias.0);
     }
 }
@@ -168,6 +169,7 @@ impl
     ) {
         output
             .0
+            .as_mut()
             .fill_with_multisum_with_bias(&inputs.0, &weights.0, &bias.0);
     }
 }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_vector_discarding_subtraction.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_vector_discarding_subtraction.rs
@@ -2,7 +2,6 @@ use crate::backends::default::implementation::engines::DefaultEngine;
 use crate::backends::default::implementation::entities::{
     LweCiphertextVector32, LweCiphertextVector64,
 };
-use crate::commons::math::tensor::{AsMutTensor, AsRefTensor};
 use crate::specification::engines::{
     LweCiphertextVectorDiscardingSubtractionEngine, LweCiphertextVectorDiscardingSubtractionError,
 };
@@ -73,7 +72,7 @@ impl LweCiphertextVectorDiscardingSubtractionEngine<LweCiphertextVector32, LweCi
             .ciphertext_iter_mut()
             .zip(input_1.0.ciphertext_iter().zip(input_2.0.ciphertext_iter()))
         {
-            out.as_mut_tensor().fill_with_copy(in_1.as_tensor());
+            out.tensor.fill_with_copy(&in_1.tensor);
             out.update_with_sub(&in_2);
         }
     }
@@ -145,7 +144,7 @@ impl LweCiphertextVectorDiscardingSubtractionEngine<LweCiphertextVector64, LweCi
             .ciphertext_iter_mut()
             .zip(input_1.0.ciphertext_iter().zip(input_2.0.ciphertext_iter()))
         {
-            out.as_mut_tensor().fill_with_copy(in_1.as_tensor());
+            out.tensor.fill_with_copy(&in_1.tensor);
             out.update_with_sub(&in_2);
         }
     }

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_zero_encryption.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_zero_encryption.rs
@@ -56,7 +56,7 @@ impl LweCiphertextZeroEncryptionEngine<LweSecretKey32, LweCiphertext32> for Defa
     ) -> LweCiphertext32 {
         let mut ciphertext = ImplLweCiphertext::allocate(0u32, key.lwe_dimension().to_lwe_size());
         key.0.encrypt_lwe(
-            &mut ciphertext,
+            &mut ciphertext.as_mut(),
             &ImplPlaintext(0u32),
             noise,
             &mut self.encryption_generator,
@@ -110,7 +110,7 @@ impl LweCiphertextZeroEncryptionEngine<LweSecretKey64, LweCiphertext64> for Defa
     ) -> LweCiphertext64 {
         let mut ciphertext = ImplLweCiphertext::allocate(0u64, key.lwe_dimension().to_lwe_size());
         key.0.encrypt_lwe(
-            &mut ciphertext,
+            &mut ciphertext.as_mut(),
             &ImplPlaintext(0u64),
             noise,
             &mut self.encryption_generator,

--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_seeded_to_lwe_ciphertext_transformation.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_seeded_to_lwe_ciphertext_transformation.rs
@@ -66,7 +66,7 @@ impl LweSeededCiphertextToLweCiphertextTransformationEngine<LweSeededCiphertext3
             ImplLweCiphertext::allocate(0_u32, lwe_seeded_ciphertext.lwe_dimension().to_lwe_size());
         lwe_seeded_ciphertext
             .0
-            .expand_into::<_, ActivatedRandomGenerator>(&mut output_ciphertext);
+            .expand_into::<ActivatedRandomGenerator>(&mut output_ciphertext.as_mut());
 
         LweCiphertext32(output_ciphertext)
     }
@@ -128,7 +128,7 @@ impl LweSeededCiphertextToLweCiphertextTransformationEngine<LweSeededCiphertext6
             ImplLweCiphertext::allocate(0_u64, lwe_seeded_ciphertext.lwe_dimension().to_lwe_size());
         lwe_seeded_ciphertext
             .0
-            .expand_into::<_, ActivatedRandomGenerator>(&mut output_ciphertext);
+            .expand_into::<ActivatedRandomGenerator>(&mut output_ciphertext.as_mut());
 
         LweCiphertext64(output_ciphertext)
     }

--- a/concrete-core/src/backends/default/implementation/entities/lwe_ciphertext.rs
+++ b/concrete-core/src/backends/default/implementation/entities/lwe_ciphertext.rs
@@ -1,4 +1,6 @@
 use crate::commons::crypto::lwe::LweCiphertext as ImplLweCiphertext;
+use crate::commons::crypto::lwe::LweCiphertextMutView as ImplLweCiphertextMutView;
+use crate::commons::crypto::lwe::LweCiphertextView as ImplLweCiphertextView;
 use crate::specification::entities::markers::LweCiphertextKind;
 use crate::specification::entities::{AbstractEntity, LweCiphertextEntity};
 use concrete_commons::parameters::LweDimension;
@@ -7,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 /// A structure representing an LWE ciphertext with 32 bits of precision.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LweCiphertext32(pub(crate) ImplLweCiphertext<Vec<u32>>);
+pub struct LweCiphertext32(pub(crate) ImplLweCiphertext<u32>);
 impl AbstractEntity for LweCiphertext32 {
     type Kind = LweCiphertextKind;
 }
@@ -27,7 +29,7 @@ pub(crate) enum LweCiphertext32Version {
 
 /// A structure representing an LWE ciphertext with 64 bits of precision.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LweCiphertext64(pub(crate) ImplLweCiphertext<Vec<u64>>);
+pub struct LweCiphertext64(pub(crate) ImplLweCiphertext<u64>);
 impl AbstractEntity for LweCiphertext64 {
     type Kind = LweCiphertextKind;
 }
@@ -57,7 +59,7 @@ pub(crate) enum LweCiphertext64Version {
 /// This view is not Clone as Clone for a slice is not defined. It is not Deserialize either,
 /// as Deserialize of a slice is not defined. Immutable variant.
 #[derive(Debug, PartialEq, Eq)]
-pub struct LweCiphertextView32<'a>(pub(crate) ImplLweCiphertext<&'a [u32]>);
+pub struct LweCiphertextView32<'a>(pub(crate) ImplLweCiphertextView<'a, u32>);
 
 impl AbstractEntity for LweCiphertextView32<'_> {
     type Kind = LweCiphertextKind;
@@ -77,7 +79,7 @@ impl LweCiphertextEntity for LweCiphertextView32<'_> {
 /// This view is not Clone as Clone for a slice is not defined. It is not Deserialize either,
 /// as Deserialize of a slice is not defined. Mutable variant.
 #[derive(Debug, PartialEq, Eq)]
-pub struct LweCiphertextMutView32<'a>(pub(crate) ImplLweCiphertext<&'a mut [u32]>);
+pub struct LweCiphertextMutView32<'a>(pub(crate) ImplLweCiphertextMutView<'a, u32>);
 
 impl AbstractEntity for LweCiphertextMutView32<'_> {
     type Kind = LweCiphertextKind;
@@ -97,7 +99,7 @@ impl LweCiphertextEntity for LweCiphertextMutView32<'_> {
 /// This view is not Clone as Clone for a slice is not defined. It is not Deserialize either,
 /// as Deserialize of a slice is not defined. Immutable variant.
 #[derive(Debug, PartialEq, Eq)]
-pub struct LweCiphertextView64<'a>(pub(crate) ImplLweCiphertext<&'a [u64]>);
+pub struct LweCiphertextView64<'a>(pub(crate) ImplLweCiphertextView<'a, u64>);
 
 impl AbstractEntity for LweCiphertextView64<'_> {
     type Kind = LweCiphertextKind;
@@ -117,7 +119,7 @@ impl LweCiphertextEntity for LweCiphertextView64<'_> {
 /// This view is not Clone as Clone for a slice is not defined. It is not Deserialize either,
 /// as Deserialize of a slice is not defined. Mutable variant.
 #[derive(Debug, PartialEq, Eq)]
-pub struct LweCiphertextMutView64<'a>(pub(crate) ImplLweCiphertext<&'a mut [u64]>);
+pub struct LweCiphertextMutView64<'a>(pub(crate) ImplLweCiphertextMutView<'a, u64>);
 
 impl AbstractEntity for LweCiphertextMutView64<'_> {
     type Kind = LweCiphertextKind;

--- a/concrete-core/src/commons/crypto/glwe/keyswitch.rs
+++ b/concrete-core/src/commons/crypto/glwe/keyswitch.rs
@@ -1,6 +1,6 @@
 use super::{GlweCiphertext, GlweList};
 use crate::commons::crypto::encoding::PlaintextList;
-use crate::commons::crypto::lwe::{LweCiphertext, LweList};
+use crate::commons::crypto::lwe::{LweCiphertextView, LweList};
 use crate::commons::crypto::secret::generators::EncryptionRandomGenerator;
 use crate::commons::crypto::secret::{GlweSecretKey, LweSecretKey};
 use crate::commons::math::decomposition::{
@@ -549,14 +549,13 @@ impl<Cont> LwePackingKeyswitchKey<Cont> {
     /// let mut decrypted = PlaintextList::from_container(vec![0 as u64; 256]);
     /// output_key.decrypt_glwe(&mut decrypted, &switched_ciphertext);
     /// ```
-    pub fn keyswitch_ciphertext<InCont, OutCont, Scalar>(
+    pub fn keyswitch_ciphertext<OutCont, Scalar>(
         &self,
         after: &mut GlweCiphertext<OutCont>,
-        before: &LweCiphertext<InCont>,
+        before: &LweCiphertextView<Scalar>,
     ) where
         Self: AsRefTensor<Element = Scalar>,
         GlweCiphertext<OutCont>: AsMutTensor<Element = Scalar>,
-        LweCiphertext<InCont>: AsRefTensor<Element = Scalar>,
         Scalar: UnsignedTorus,
     {
         ck_dim_eq!(self.input_lwe_key_dimension().0 => before.lwe_size().to_lwe_dimension().0);
@@ -1203,14 +1202,13 @@ impl<Cont> LwePrivateFunctionalPackingKeyswitchKey<Cont> {
     /// let mut decrypted = PlaintextList::from_container(vec![0 as u64; polynomial_size.0]);
     /// output_key.decrypt_glwe(&mut decrypted, &switched_ciphertext);
     /// ```
-    pub fn private_functional_keyswitch_ciphertext<InCont, OutCont, Scalar>(
+    pub fn private_functional_keyswitch_ciphertext<OutCont, Scalar>(
         &self,
         after: &mut GlweCiphertext<OutCont>,
-        before: &LweCiphertext<InCont>,
+        before: &LweCiphertextView<Scalar>,
     ) where
         Self: AsRefTensor<Element = Scalar>,
         GlweCiphertext<OutCont>: AsMutTensor<Element = Scalar>,
-        LweCiphertext<InCont>: AsRefTensor<Element = Scalar>,
         Scalar: UnsignedTorus,
     {
         ck_dim_eq!(self.input_lwe_key_dimension().0  => before.lwe_size().to_lwe_dimension().0 );
@@ -1222,7 +1220,7 @@ impl<Cont> LwePrivateFunctionalPackingKeyswitchKey<Cont> {
         // We instantiate a decomposer
         let decomposer = SignedDecomposer::new(self.decomp_base_log, self.decomp_level_count);
 
-        for (block, input_lwe) in self.bit_decomp_iter().zip(before.as_tensor().iter()) {
+        for (block, input_lwe) in self.bit_decomp_iter().zip(before.tensor.iter()) {
             // We decompose
             let rounded = decomposer.closest_representable(*input_lwe);
             let decomp = decomposer.decompose(rounded);

--- a/concrete-core/src/commons/crypto/gsw/levels.rs
+++ b/concrete-core/src/commons/crypto/gsw/levels.rs
@@ -1,8 +1,9 @@
-use crate::commons::crypto::lwe::LweCiphertext;
+use crate::commons::crypto::lwe::LweCiphertextMutView;
 use crate::commons::math::decomposition::DecompositionLevel;
 use crate::commons::math::tensor::{
     ck_dim_eq, tensor_traits, AsMutTensor, AsRefSlice, AsRefTensor, Tensor,
 };
+use concrete_commons::numeric::UnsignedInteger;
 use concrete_commons::parameters::LweSize;
 #[cfg(feature = "__commons_parallel")]
 use rayon::prelude::*;
@@ -230,20 +231,12 @@ impl<Cont> GswLevelRow<Cont> {
     pub fn decomposition_level(&self) -> DecompositionLevel {
         self.level
     }
+}
 
-    /// Consumes the row and returns its container wrapped into an `LweCiphertext`.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use concrete_commons::parameters::LweSize;
-    /// use concrete_core::commons::crypto::gsw::GswLevelRow;
-    /// use concrete_core::commons::math::decomposition::DecompositionLevel;
-    /// let level_row = GswLevelRow::from_container(vec![0 as u8; 7], DecompositionLevel(1));
-    /// let lwe = level_row.into_lwe();
-    /// assert_eq!(lwe.lwe_size(), LweSize(7));
-    /// ```
-    pub fn into_lwe(self) -> LweCiphertext<Cont> {
-        LweCiphertext::from_container(self.tensor.into_container())
+impl<'a, Scalar: UnsignedInteger> GswLevelRow<&'a mut [Scalar]> {
+    pub fn into_lwe(self) -> LweCiphertextMutView<'a, Scalar> {
+        LweCiphertextMutView {
+            tensor: self.tensor,
+        }
     }
 }

--- a/concrete-core/src/commons/crypto/lwe/ciphertext.rs
+++ b/concrete-core/src/commons/crypto/lwe/ciphertext.rs
@@ -2,7 +2,7 @@ use super::LweList;
 use crate::commons::crypto::encoding::{Cleartext, CleartextList, Plaintext};
 use crate::commons::crypto::glwe::GlweCiphertext;
 use crate::commons::crypto::secret::LweSecretKey;
-use crate::commons::math::tensor::{tensor_traits, AsMutTensor, AsRefTensor, Tensor};
+use crate::commons::math::tensor::{AsRefSlice, AsRefTensor, Tensor};
 use crate::commons::math::torus::UnsignedTorus;
 use concrete_commons::key_kinds::KeyKind;
 use concrete_commons::numeric::{Numeric, UnsignedInteger};
@@ -10,675 +10,183 @@ use concrete_commons::parameters::{LweDimension, LweSize, MonomialDegree};
 #[cfg(feature = "__commons_serialization")]
 use serde::{Deserialize, Serialize};
 
-/// A ciphertext encrypted using the LWE scheme.
 #[cfg_attr(feature = "__commons_serialization", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LweCiphertext<Cont> {
-    pub(crate) tensor: Tensor<Cont>,
+pub struct LweCiphertext<T: UnsignedInteger> {
+    pub(crate) tensor: Tensor<Vec<T>>,
 }
 
-tensor_traits!(LweCiphertext);
+impl<Scalar: UnsignedInteger> LweCiphertext<Scalar> {
+    pub fn from_vec(v: Vec<Scalar>) -> Self {
+        LweCiphertext {
+            tensor: Tensor::from_container(v),
+        }
+    }
 
-impl<Scalar> LweCiphertext<Vec<Scalar>>
-where
-    Scalar: Copy,
-{
-    /// Allocates a new ciphertext.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_commons::parameters::{LweDimension, LweSize};
-    /// use concrete_core::commons::crypto::lwe::LweCiphertext;
-    /// let ct = LweCiphertext::allocate(0 as u8, LweSize(4));
-    /// assert_eq!(ct.lwe_size(), LweSize(4));
-    /// assert_eq!(ct.get_mask().mask_size(), LweDimension(3));
-    /// ```
+    pub fn to_vec(self) -> Vec<Scalar> {
+        self.tensor.into_container()
+    }
+
+    pub fn lwe_size(&self) -> LweSize {
+        LweSize(self.tensor.len())
+    }
+
     pub fn allocate(value: Scalar, size: LweSize) -> Self {
         LweCiphertext {
             tensor: Tensor::from_container(vec![value; size.0]),
         }
     }
-}
 
-impl<Scalar> LweCiphertext<Vec<Scalar>>
-where
-    Scalar: Numeric,
-{
-    /// Creates a new ciphertext containing the trivial encryption of the plain text
-    ///
-    /// `Trivial` means tha the LWE mask consists of zeros only.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use concrete_commons::dispersion::LogStandardDev;
-    /// use concrete_commons::parameters::{LweDimension, LweSize};
-    /// use concrete_core::commons::crypto::encoding::*;
-    /// use concrete_core::commons::crypto::lwe::*;
-    /// use concrete_core::commons::crypto::secret::generators::{
-    ///     EncryptionRandomGenerator, SecretRandomGenerator,
-    /// };
-    /// use concrete_core::commons::crypto::secret::*;
-    /// use concrete_core::commons::crypto::*;
-    /// use concrete_csprng::generators::SoftwareRandomGenerator;
-    /// use concrete_csprng::seeders::Seed;
-    ///
-    /// let mut secret_generator = SecretRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0));
-    /// let secret_key = LweSecretKey::generate_binary(LweDimension(256), &mut secret_generator);
-    ///
-    /// let encoder = RealEncoder {
-    ///     offset: 0. as f32,
-    ///     delta: 10.,
-    /// };
-    /// let clear = Cleartext(2. as f32);
-    /// let plain: Plaintext<u32> = encoder.encode(clear);
-    ///
-    /// let mut encrypted =
-    ///     LweCiphertext::new_trivial_encryption(secret_key.key_size().to_lwe_size(), &plain);
-    ///
-    /// let mut decrypted = Plaintext(0u32);
-    /// secret_key.decrypt_lwe(&mut decrypted, &encrypted);
-    /// let decoded = encoder.decode(decrypted);
-    ///
-    /// assert!((decoded.0 - clear.0).abs() < 0.1);
-    /// ```
     pub fn new_trivial_encryption(lwe_size: LweSize, plaintext: &Plaintext<Scalar>) -> Self {
         let mut ciphertext = Self::allocate(Scalar::ZERO, lwe_size);
-        ciphertext.fill_with_trivial_encryption(plaintext);
+        ciphertext.as_mut().fill_with_trivial_encryption(plaintext);
         ciphertext
+    }
+
+    pub fn as_ref(&self) -> LweCiphertextView<Scalar> {
+        LweCiphertextView {
+            tensor: Tensor::from_container(self.tensor.as_container().as_slice()),
+        }
+    }
+
+    pub fn as_mut(&mut self) -> LweCiphertextMutView<Scalar> {
+        LweCiphertextMutView {
+            tensor: Tensor::from_container(self.tensor.as_mut_container().as_mut_slice()),
+        }
     }
 }
 
-impl<Cont> LweCiphertext<Cont> {
-    /// Creates a ciphertext from a container of values.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_commons::parameters::{LweDimension, LweSize};
-    /// use concrete_core::commons::crypto::lwe::LweCiphertext;
-    /// let vector = vec![0 as u8; 10];
-    /// let ct = LweCiphertext::from_container(vector.as_slice());
-    /// assert_eq!(ct.lwe_size(), LweSize(10));
-    /// assert_eq!(ct.get_mask().mask_size(), LweDimension(9));
-    /// ```
-    pub fn from_container(cont: Cont) -> LweCiphertext<Cont> {
-        let tensor = Tensor::from_container(cont);
-        LweCiphertext { tensor }
+#[cfg_attr(feature = "__commons_serialization", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LweCiphertextView<'a, T: UnsignedInteger> {
+    pub(crate) tensor: Tensor<&'a [T]>,
+}
+
+impl<'a, Scalar: UnsignedInteger> LweCiphertextView<'a, Scalar> {
+    pub fn from_slice(v: &'a [Scalar]) -> Self {
+        LweCiphertextView {
+            tensor: Tensor::from_container(v),
+        }
     }
 
-    /// Returns the size of the cipher, e.g. the size of the mask + 1 for the body.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_commons::parameters::LweSize;
-    /// use concrete_core::commons::crypto::lwe::LweCiphertext;
-    /// let ct = LweCiphertext::allocate(0 as u8, LweSize(4));
-    /// assert_eq!(ct.lwe_size(), LweSize(4));
-    /// ```
-    pub fn lwe_size(&self) -> LweSize
-    where
-        Self: AsRefTensor,
-    {
-        LweSize(self.as_tensor().len())
+    pub fn to_slice(self) -> &'a [Scalar] {
+        self.tensor.into_container()
     }
 
-    /// Returns the body of the ciphertext.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_core::commons::crypto::lwe::{LweBody, LweCiphertext};
-    /// let ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
-    /// let body = ciphertext.get_body();
-    /// assert_eq!(body, &LweBody(0 as u8));
-    /// ```
-    pub fn get_body<Scalar>(&self) -> &LweBody<Scalar>
-    where
-        Self: AsRefTensor<Element = Scalar>,
-    {
-        unsafe { &*{ self.as_tensor().last() as *const Scalar as *const LweBody<Scalar> } }
+    pub fn lwe_size(&self) -> LweSize {
+        LweSize(self.tensor.len())
     }
 
-    /// Returns the mask of the ciphertext.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_commons::parameters::LweDimension;
-    /// use concrete_core::commons::crypto::lwe::LweCiphertext;
-    /// let ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
-    /// let mask = ciphertext.get_mask();
-    /// assert_eq!(mask.mask_size(), LweDimension(9));
-    /// ```
-    pub fn get_mask<Scalar>(&self) -> LweMask<&[Scalar]>
-    where
-        Self: AsRefTensor<Element = Scalar>,
-    {
-        let (_, mask) = self.as_tensor().split_last();
-        LweMask { tensor: mask }
+    pub fn get_body(&self) -> &LweBody<Scalar> {
+        unsafe { &*{ self.tensor.last() as *const Scalar as *const LweBody<Scalar> } }
     }
 
-    /// Returns the body and the mask of the ciphertext.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_commons::parameters::LweDimension;
-    /// use concrete_core::commons::crypto::lwe::{LweBody, LweCiphertext};
-    /// let ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
-    /// let (body, mask) = ciphertext.get_body_and_mask();
-    /// assert_eq!(body, &LweBody(0));
-    /// assert_eq!(mask.mask_size(), LweDimension(9));
-    /// ```
-    pub fn get_body_and_mask<Scalar>(&self) -> (&LweBody<Scalar>, LweMask<&[Scalar]>)
-    where
-        Self: AsRefTensor<Element = Scalar>,
-    {
-        let (body, mask) = self.as_tensor().split_last();
+    pub fn get_mask(&self) -> LweMaskView<Scalar> {
+        let (_, mask) = self.tensor.split_last();
+        LweMaskView { tensor: mask }
+    }
+
+    pub fn get_body_and_mask(&self) -> (&LweBody<Scalar>, LweMaskView<Scalar>) {
+        let (body, mask) = self.tensor.split_last();
         let body = unsafe { &*{ body as *const Scalar as *const LweBody<Scalar> } };
-        (body, LweMask { tensor: mask })
+        (body, LweMaskView { tensor: mask })
+    }
+}
+
+#[cfg_attr(feature = "__commons_serialization", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq)]
+pub struct LweCiphertextMutView<'a, T: UnsignedInteger> {
+    pub(crate) tensor: Tensor<&'a mut [T]>,
+}
+
+impl<'a, Scalar: UnsignedInteger> LweCiphertextMutView<'a, Scalar> {
+    pub fn from_mut_slice(v: &'a mut [Scalar]) -> Self {
+        LweCiphertextMutView {
+            tensor: Tensor::from_container(v),
+        }
     }
 
-    /// Returns the mutable body of the ciphertext.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_core::commons::crypto::lwe::{LweBody, LweCiphertext};
-    /// let mut ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
-    /// let mut body = ciphertext.get_mut_body();
-    /// *body = LweBody(8);
-    /// let body = ciphertext.get_body();
-    /// assert_eq!(body, &LweBody(8 as u8));
-    /// ```
-    pub fn get_mut_body<Scalar>(&mut self) -> &mut LweBody<Scalar>
-    where
-        Self: AsMutTensor<Element = Scalar>,
-    {
-        unsafe { &mut *{ self.as_mut_tensor().last_mut() as *mut Scalar as *mut LweBody<Scalar> } }
+    pub fn to_mut_slice(self) -> &'a mut [Scalar] {
+        self.tensor.into_container()
     }
 
-    /// Returns the mutable mask of the ciphertext.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_core::commons::crypto::lwe::*;
-    /// use concrete_core::commons::crypto::*;
-    /// let mut ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
-    /// let mut mask = ciphertext.get_mut_mask();
-    /// for mut elt in mask.mask_element_iter_mut() {
-    ///     *elt = 8;
-    /// }
-    /// let mask = ciphertext.get_mask();
-    /// for elt in mask.mask_element_iter() {
-    ///     assert_eq!(*elt, 8);
-    /// }
-    /// assert_eq!(mask.mask_element_iter().count(), 9);
-    /// ```
-    pub fn get_mut_mask<Scalar>(&mut self) -> LweMask<&mut [Scalar]>
-    where
-        Self: AsMutTensor<Element = Scalar>,
-    {
-        let (_, masks) = self.as_mut_tensor().split_last_mut();
-        LweMask { tensor: masks }
+    pub fn lwe_size(&self) -> LweSize {
+        LweSize(self.tensor.len())
     }
 
-    /// Returns the mutable body and mask of the ciphertext.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_commons::parameters::LweDimension;
-    /// use concrete_core::commons::crypto::lwe::*;
-    /// use concrete_core::commons::crypto::*;
-    /// let mut ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
-    /// let (body, mask) = ciphertext.get_mut_body_and_mask();
-    /// assert_eq!(body, &mut LweBody(0));
-    /// assert_eq!(mask.mask_size(), LweDimension(9));
-    /// ```
-    pub fn get_mut_body_and_mask<Scalar>(
-        &mut self,
-    ) -> (&mut LweBody<Scalar>, LweMask<&mut [Scalar]>)
-    where
-        Self: AsMutTensor<Element = Scalar>,
-    {
-        let (body, masks) = self.as_mut_tensor().split_last_mut();
+    pub fn as_ref(&self) -> LweCiphertextView<Scalar> {
+        LweCiphertextView {
+            tensor: Tensor::from_container(self.tensor.as_container()),
+        }
+    }
+
+    pub fn get_mut_body(&mut self) -> &mut LweBody<Scalar> {
+        unsafe { &mut *{ self.tensor.last_mut() as *mut Scalar as *mut LweBody<Scalar> } }
+    }
+
+    pub fn get_mut_mask(&mut self) -> LweMaskMutView<Scalar> {
+        let (_, masks) = self.tensor.split_last_mut();
+        LweMaskMutView { tensor: masks }
+    }
+
+    pub fn get_mut_body_and_mask(&mut self) -> (&mut LweBody<Scalar>, LweMaskMutView<Scalar>) {
+        let (body, masks) = self.tensor.split_last_mut();
         let body = unsafe { &mut *{ body as *mut Scalar as *mut LweBody<Scalar> } };
-        (body, LweMask { tensor: masks })
+        (body, LweMaskMutView { tensor: masks })
     }
 
-    /// Fills the ciphertext with the result of the multiplication of the `input` ciphertext by the
-    /// `scalar` cleartext.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use concrete_commons::dispersion::LogStandardDev;
-    /// use concrete_commons::parameters::LweDimension;
-    /// use concrete_core::commons::crypto::encoding::*;
-    /// use concrete_core::commons::crypto::lwe::*;
-    /// use concrete_core::commons::crypto::secret::generators::{
-    ///     EncryptionRandomGenerator, SecretRandomGenerator,
-    /// };
-    /// use concrete_core::commons::crypto::secret::LweSecretKey;
-    /// use concrete_core::commons::crypto::*;
-    /// use concrete_csprng::generators::SoftwareRandomGenerator;
-    /// use concrete_csprng::seeders::{Seed, UnixSeeder};
-    ///
-    /// let mut secret_generator = SecretRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0));
-    /// let mut encryption_generator =
-    ///     EncryptionRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0), &mut UnixSeeder::new(0));
-    ///
-    /// let secret_key = LweSecretKey::generate_binary(LweDimension(256), &mut secret_generator);
-    /// let noise = LogStandardDev::from_log_standard_dev(-15.);
-    /// let encoder = RealEncoder {
-    ///     offset: 0. as f32,
-    ///     delta: 10.,
-    /// };
-    ///
-    /// let cleartext = Cleartext(2. as f32);
-    /// let plaintext: Plaintext<u32> = encoder.encode(cleartext);
-    /// let mut ciphertext = LweCiphertext::from_container(vec![0. as u32; 257]);
-    /// secret_key.encrypt_lwe(
-    ///     &mut ciphertext,
-    ///     &plaintext,
-    ///     noise,
-    ///     &mut encryption_generator,
-    /// );
-    ///
-    /// let mut processed = LweCiphertext::from_container(vec![0 as u32; 257]);
-    /// processed.fill_with_scalar_mul(&ciphertext, &Cleartext(4));
-    ///
-    /// let mut decrypted = Plaintext(0 as u32);
-    /// secret_key.decrypt_lwe(&mut decrypted, &processed);
-    /// let decoded = encoder.decode(decrypted);
-    /// assert!((decoded.0 - (cleartext.0 * 4.)).abs() < 0.2);
-    /// ```
-    pub fn fill_with_scalar_mul<Scalar, InputCont>(
+    pub fn fill_with_scalar_mul(
         &mut self,
-        input: &LweCiphertext<InputCont>,
+        input: &LweCiphertextView<Scalar>,
         scalar: &Cleartext<Scalar>,
-    ) where
-        Self: AsMutTensor<Element = Scalar>,
-        LweCiphertext<InputCont>: AsRefTensor<Element = Scalar>,
-        Scalar: UnsignedInteger,
-    {
-        self.as_mut_tensor()
-            .fill_with_one(input.as_tensor(), |o| o.wrapping_mul(scalar.0));
+    ) {
+        self.tensor
+            .fill_with_one(&input.tensor, |o| o.wrapping_mul(scalar.0));
     }
 
-    /// Fills the ciphertext with the result of the multisum of the `input_list` with the
-    /// `weights` values, and adds a bias.
-    ///
-    /// Said differently, this function fills `self` with:
-    /// $$
-    /// bias + \sum\_i input\_list\[i\] * weights\[i\]
-    /// $$
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_commons::dispersion::LogStandardDev;
-    /// use concrete_commons::parameters::{LweDimension, LweSize};
-    /// use concrete_core::commons::crypto::encoding::*;
-    /// use concrete_core::commons::crypto::lwe::*;
-    /// use concrete_core::commons::crypto::secret::generators::{
-    ///     EncryptionRandomGenerator, SecretRandomGenerator,
-    /// };
-    /// use concrete_core::commons::crypto::secret::LweSecretKey;
-    /// use concrete_core::commons::crypto::*;
-    /// use concrete_csprng::generators::SoftwareRandomGenerator;
-    /// use concrete_csprng::seeders::{Seed, UnixSeeder};
-    ///
-    /// let mut secret_generator = SecretRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0));
-    /// let mut encryption_generator =
-    ///     EncryptionRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0), &mut UnixSeeder::new(0));
-    ///
-    /// // Insecure parameters for a toy example
-    /// let secret_key = LweSecretKey::generate_binary(LweDimension(4), &mut secret_generator);
-    /// let noise = LogStandardDev::from_log_standard_dev(-60.);
-    /// let encoder = RealEncoder {
-    ///     offset: 0. as f32,
-    ///     delta: 100.,
-    /// };
-    ///
-    /// let clear_values = CleartextList::from_container(vec![1. as f32, 2., 3.]);
-    /// let mut plain_values = PlaintextList::from_container(vec![0 as u32; 3]);
-    /// encoder.encode_list(&mut plain_values, &clear_values);
-    /// let mut ciphertext_values = LweList::from_container(vec![0. as u32; 5 * 3], LweSize(5));
-    /// secret_key.encrypt_lwe_list(
-    ///     &mut ciphertext_values,
-    ///     &plain_values,
-    ///     noise,
-    ///     &mut encryption_generator,
-    /// );
-    ///
-    /// let mut output = LweCiphertext::from_container(vec![0. as u32; 5]);
-    /// let weights = CleartextList::from_container(vec![7, 8, 9]);
-    /// let bias = encoder.encode(Cleartext(13.));
-    ///
-    /// output.fill_with_multisum_with_bias(&ciphertext_values, &weights, &bias);
-    ///
-    /// let mut decrypted = Plaintext(0 as u32);
-    /// secret_key.decrypt_lwe(&mut decrypted, &output);
-    /// let decoded = encoder.decode(decrypted);
-    /// assert!((decoded.0 - 63.).abs() < 0.1);
-    /// ```
-    pub fn fill_with_multisum_with_bias<Scalar, InputCont, WeightCont>(
+    pub fn fill_with_multisum_with_bias<InputCont, WeightCont>(
         &mut self,
         input_list: &LweList<InputCont>,
         weights: &CleartextList<WeightCont>,
         bias: &Plaintext<Scalar>,
     ) where
-        Self: AsMutTensor<Element = Scalar>,
         LweList<InputCont>: AsRefTensor<Element = Scalar>,
         CleartextList<WeightCont>: AsRefTensor<Element = Scalar>,
-        Scalar: UnsignedInteger,
     {
         // loop over the ciphertexts and the weights
         for (input_cipher, weight) in input_list.ciphertext_iter().zip(weights.cleartext_iter()) {
-            let cipher_tens = input_cipher.as_tensor();
-            self.as_mut_tensor().update_with_one(cipher_tens, |o, c| {
+            let cipher_tens = &input_cipher.tensor;
+            self.tensor.update_with_one(cipher_tens, |o, c| {
                 *o = o.wrapping_add(c.wrapping_mul(weight.0))
             });
         }
 
         // add the bias
-        let new_body = (self.get_body().0).wrapping_add(bias.0);
+        let new_body = (self.as_ref().get_body().0).wrapping_add(bias.0);
         *self.get_mut_body() = LweBody(new_body);
     }
 
-    /// Adds the `other` ciphertext to the current one.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_commons::dispersion::LogStandardDev;
-    /// use concrete_commons::parameters::LweDimension;
-    /// use concrete_core::commons::crypto::encoding::*;
-    /// use concrete_core::commons::crypto::lwe::*;
-    /// use concrete_core::commons::crypto::secret::generators::{
-    ///     EncryptionRandomGenerator, SecretRandomGenerator,
-    /// };
-    /// use concrete_core::commons::crypto::secret::LweSecretKey;
-    /// use concrete_core::commons::crypto::*;
-    /// use concrete_csprng::generators::SoftwareRandomGenerator;
-    /// use concrete_csprng::seeders::{Seed, UnixSeeder};
-    ///
-    /// let mut secret_generator = SecretRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0));
-    /// let mut encryption_generator =
-    ///     EncryptionRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0), &mut UnixSeeder::new(0));
-    ///
-    /// let secret_key = LweSecretKey::generate_binary(LweDimension(256), &mut secret_generator);
-    /// let noise = LogStandardDev::from_log_standard_dev(-15.);
-    /// let encoder = RealEncoder {
-    ///     offset: 0. as f32,
-    ///     delta: 10.,
-    /// };
-    ///
-    /// let clear_1 = Cleartext(2. as f32);
-    /// let plain_1: Plaintext<u32> = encoder.encode(clear_1);
-    /// let mut cipher_1 = LweCiphertext::from_container(vec![0. as u32; 257]);
-    /// secret_key.encrypt_lwe(&mut cipher_1, &plain_1, noise, &mut encryption_generator);
-    ///
-    /// let clear_2 = Cleartext(3. as f32);
-    /// let plain_2: Plaintext<u32> = encoder.encode(clear_2);
-    /// let mut cipher_2 = LweCiphertext::from_container(vec![0. as u32; 257]);
-    /// secret_key.encrypt_lwe(&mut cipher_2, &plain_2, noise, &mut encryption_generator);
-    ///
-    /// cipher_1.update_with_add(&cipher_2);
-    ///
-    /// let mut decrypted = Plaintext(0 as u32);
-    /// secret_key.decrypt_lwe(&mut decrypted, &cipher_1);
-    /// let decoded = encoder.decode(decrypted);
-    ///
-    /// assert!((decoded.0 - 5.).abs() < 0.1);
-    /// ```
-    pub fn update_with_add<OtherCont, Scalar>(&mut self, other: &LweCiphertext<OtherCont>)
-    where
-        Self: AsMutTensor<Element = Scalar>,
-        LweCiphertext<OtherCont>: AsRefTensor<Element = Scalar>,
-        Scalar: UnsignedTorus,
-    {
-        self.as_mut_tensor()
-            .update_with_wrapping_add(other.as_tensor())
+    pub fn update_with_add(&mut self, other: &LweCiphertextView<Scalar>) {
+        self.tensor.update_with_wrapping_add(&other.tensor)
     }
 
-    /// Subtracts the `other` ciphertext from the current one.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_commons::dispersion::LogStandardDev;
-    /// use concrete_commons::parameters::LweDimension;
-    /// use concrete_core::commons::crypto::encoding::*;
-    /// use concrete_core::commons::crypto::lwe::*;
-    /// use concrete_core::commons::crypto::secret::generators::{
-    ///     EncryptionRandomGenerator, SecretRandomGenerator,
-    /// };
-    /// use concrete_core::commons::crypto::secret::LweSecretKey;
-    /// use concrete_core::commons::crypto::*;
-    /// use concrete_csprng::generators::SoftwareRandomGenerator;
-    /// use concrete_csprng::seeders::{Seed, UnixSeeder};
-    ///
-    /// let mut secret_generator = SecretRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0));
-    /// let mut encryption_generator =
-    ///     EncryptionRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0), &mut UnixSeeder::new(0));
-    ///
-    /// let secret_key = LweSecretKey::generate_binary(LweDimension(256), &mut secret_generator);
-    /// let noise = LogStandardDev::from_log_standard_dev(-15.);
-    /// let encoder = RealEncoder {
-    ///     offset: 0. as f32,
-    ///     delta: 10.,
-    /// };
-    ///
-    /// let clear_1 = Cleartext(3. as f32);
-    /// let plain_1: Plaintext<u32> = encoder.encode(clear_1);
-    /// let mut cipher_1 = LweCiphertext::from_container(vec![0. as u32; 257]);
-    /// secret_key.encrypt_lwe(&mut cipher_1, &plain_1, noise, &mut encryption_generator);
-    ///
-    /// let clear_2 = Cleartext(2. as f32);
-    /// let plain_2: Plaintext<u32> = encoder.encode(clear_2);
-    /// let mut cipher_2 = LweCiphertext::from_container(vec![0. as u32; 257]);
-    /// secret_key.encrypt_lwe(&mut cipher_2, &plain_2, noise, &mut encryption_generator);
-    ///
-    /// cipher_1.update_with_sub(&cipher_2);
-    ///
-    /// let mut decrypted = Plaintext(0 as u32);
-    /// secret_key.decrypt_lwe(&mut decrypted, &cipher_1);
-    /// let decoded = encoder.decode(decrypted);
-    ///
-    /// assert!((decoded.0 - 1.).abs() < 0.1);
-    /// ```
-    pub fn update_with_sub<OtherCont, Scalar>(&mut self, other: &LweCiphertext<OtherCont>)
-    where
-        Self: AsMutTensor<Element = Scalar>,
-        LweCiphertext<OtherCont>: AsRefTensor<Element = Scalar>,
-        Scalar: UnsignedTorus,
-    {
-        self.as_mut_tensor()
-            .update_with_wrapping_sub(other.as_tensor())
+    pub fn update_with_sub(&mut self, other: &LweCiphertextView<Scalar>) {
+        self.tensor.update_with_wrapping_sub(&other.tensor)
     }
 
-    /// Computes the opposite of the ciphertext.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_commons::dispersion::LogStandardDev;
-    /// use concrete_commons::parameters::LweDimension;
-    /// use concrete_core::commons::crypto::encoding::*;
-    /// use concrete_core::commons::crypto::lwe::*;
-    /// use concrete_core::commons::crypto::secret::generators::{
-    ///     EncryptionRandomGenerator, SecretRandomGenerator,
-    /// };
-    /// use concrete_core::commons::crypto::secret::LweSecretKey;
-    /// use concrete_core::commons::crypto::*;
-    /// use concrete_csprng::generators::SoftwareRandomGenerator;
-    /// use concrete_csprng::seeders::{Seed, UnixSeeder};
-    ///
-    /// let mut secret_generator = SecretRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0));
-    /// let mut encryption_generator =
-    ///     EncryptionRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0), &mut UnixSeeder::new(0));
-    ///
-    /// let secret_key = LweSecretKey::generate_binary(LweDimension(256), &mut secret_generator);
-    /// let noise = LogStandardDev::from_log_standard_dev(-15.);
-    /// let encoder = RealEncoder {
-    ///     offset: -5. as f32,
-    ///     delta: 10.,
-    /// };
-    ///
-    /// let clear = Cleartext(2. as f32);
-    /// let plain: Plaintext<u32> = encoder.encode(clear);
-    /// let mut cipher = LweCiphertext::from_container(vec![0. as u32; 257]);
-    /// secret_key.encrypt_lwe(&mut cipher, &plain, noise, &mut encryption_generator);
-    ///
-    /// cipher.update_with_neg();
-    ///
-    /// let mut decrypted = Plaintext(0 as u32);
-    /// secret_key.decrypt_lwe(&mut decrypted, &cipher);
-    /// let decoded = encoder.decode(decrypted);
-    ///
-    /// assert!((decoded.0 - (-2.)).abs() < 0.1);
-    /// ```
-    pub fn update_with_neg<Scalar>(&mut self)
-    where
-        Self: AsMutTensor<Element = Scalar>,
-        Scalar: UnsignedTorus,
-    {
-        self.as_mut_tensor().update_with_wrapping_neg()
+    pub fn update_with_neg(&mut self) {
+        self.tensor.update_with_wrapping_neg()
     }
 
-    /// Multiplies the current ciphertext with a scalar value inplace.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_commons::dispersion::LogStandardDev;
-    /// use concrete_commons::parameters::LweDimension;
-    /// use concrete_core::commons::crypto::encoding::*;
-    /// use concrete_core::commons::crypto::lwe::*;
-    /// use concrete_core::commons::crypto::secret::generators::{
-    ///     EncryptionRandomGenerator, SecretRandomGenerator,
-    /// };
-    /// use concrete_core::commons::crypto::secret::LweSecretKey;
-    /// use concrete_core::commons::crypto::*;
-    /// use concrete_csprng::generators::SoftwareRandomGenerator;
-    /// use concrete_csprng::seeders::{Seed, UnixSeeder};
-    ///
-    /// let mut secret_generator = SecretRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0));
-    /// let mut encryption_generator =
-    ///     EncryptionRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0), &mut UnixSeeder::new(0));
-    ///
-    /// let secret_key = LweSecretKey::generate_binary(LweDimension(256), &mut secret_generator);
-    /// let noise = LogStandardDev::from_log_standard_dev(-15.);
-    /// let encoder = RealEncoder {
-    ///     offset: 0. as f32,
-    ///     delta: 10.,
-    /// };
-    ///
-    /// let clear = Cleartext(2. as f32);
-    /// let plain: Plaintext<u32> = encoder.encode(clear);
-    /// let mut cipher = LweCiphertext::from_container(vec![0. as u32; 257]);
-    /// secret_key.encrypt_lwe(&mut cipher, &plain, noise, &mut encryption_generator);
-    ///
-    /// cipher.update_with_scalar_mul(Cleartext(3));
-    ///
-    /// let mut decrypted = Plaintext(0 as u32);
-    /// secret_key.decrypt_lwe(&mut decrypted, &cipher);
-    /// let decoded = encoder.decode(decrypted);
-    ///
-    /// assert!((decoded.0 - 6.).abs() < 0.2);
-    /// ```
-    pub fn update_with_scalar_mul<Scalar>(&mut self, scalar: Cleartext<Scalar>)
-    where
-        Self: AsMutTensor<Element = Scalar>,
-        Scalar: UnsignedTorus,
-    {
-        self.as_mut_tensor()
-            .update_with_wrapping_scalar_mul(&scalar.0)
+    pub fn update_with_scalar_mul(&mut self, scalar: Cleartext<Scalar>) {
+        self.tensor.update_with_wrapping_scalar_mul(&scalar.0)
     }
 
-    /// Fills an LWE ciphertext with the sample extraction of one of the coefficients of a GLWE
-    /// ciphertext.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_commons::dispersion::LogStandardDev;
-    /// use concrete_commons::parameters::{GlweDimension, LweDimension, PolynomialSize};
-    /// use concrete_core::commons::crypto::encoding::{Plaintext, PlaintextList};
-    /// use concrete_core::commons::crypto::glwe::GlweCiphertext;
-    /// use concrete_core::commons::crypto::lwe::LweCiphertext;
-    /// use concrete_core::commons::crypto::secret::generators::{
-    ///     EncryptionRandomGenerator, SecretRandomGenerator,
-    /// };
-    /// use concrete_core::commons::crypto::secret::GlweSecretKey;
-    /// use concrete_core::commons::math::polynomial::MonomialDegree;
-    /// use concrete_core::commons::math::tensor::AsRefTensor;
-    /// use concrete_csprng::generators::SoftwareRandomGenerator;
-    /// use concrete_csprng::seeders::{Seed, UnixSeeder};
-    ///
-    /// let mut secret_generator = SecretRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0));
-    /// let mut encryption_generator =
-    ///     EncryptionRandomGenerator::<SoftwareRandomGenerator>::new(Seed(0), &mut UnixSeeder::new(0));
-    /// let poly_size = PolynomialSize(4);
-    /// let glwe_dim = GlweDimension(2);
-    /// let glwe_secret_key =
-    ///     GlweSecretKey::generate_binary(glwe_dim, poly_size, &mut secret_generator);
-    /// let mut plaintext_list =
-    ///     PlaintextList::from_container(vec![100000 as u32, 200000, 300000, 400000]);
-    /// let mut glwe_ct = GlweCiphertext::allocate(0u32, poly_size, glwe_dim.to_glwe_size());
-    /// let mut lwe_ct =
-    ///     LweCiphertext::allocate(0u32, LweDimension(poly_size.0 * glwe_dim.0).to_lwe_size());
-    /// glwe_secret_key.encrypt_glwe(
-    ///     &mut glwe_ct,
-    ///     &plaintext_list,
-    ///     LogStandardDev(-50.),
-    ///     &mut encryption_generator,
-    /// );
-    /// let lwe_secret_key = glwe_secret_key.into_lwe_secret_key();
-    ///
-    /// // Check for the first
-    /// for i in 0..4 {
-    ///     // We sample extract
-    ///     lwe_ct.fill_with_glwe_sample_extraction(&glwe_ct, MonomialDegree(i));
-    ///     // We decrypt
-    ///     let mut output = Plaintext(0u32);
-    ///     lwe_secret_key.decrypt_lwe(&mut output, &lwe_ct);
-    ///     // We check that the decryption is correct
-    ///     let plain = plaintext_list.as_tensor().get_element(i);
-    ///     let d0 = output.0.wrapping_sub(*plain);
-    ///     let d1 = plain.wrapping_sub(output.0);
-    ///     let dist = std::cmp::min(d0, d1);
-    ///     assert!(dist < 400);
-    /// }
-    /// ```
-    pub fn fill_with_glwe_sample_extraction<InputCont, Element>(
-        &mut self,
-        glwe: &GlweCiphertext<InputCont>,
-        n_th: MonomialDegree,
-    ) where
-        Self: AsMutTensor<Element = Element>,
-        GlweCiphertext<InputCont>: AsRefTensor<Element = Element>,
-        Element: UnsignedTorus,
-    {
-        glwe.fill_lwe_with_sample_extraction(self, n_th);
-    }
-
-    pub fn fill_with_trivial_encryption<Scalar>(&mut self, plaintext: &Plaintext<Scalar>)
-    where
-        Scalar: Numeric,
-        Self: AsMutTensor<Element = Scalar>,
-    {
+    pub fn fill_with_trivial_encryption(&mut self, plaintext: &Plaintext<Scalar>) {
         let (output_body, mut output_mask) = self.get_mut_body_and_mask();
 
         // generate a uniformly random mask
-        output_mask.as_mut_tensor().fill_with_element(Scalar::ZERO);
+        output_mask.tensor.fill_with_element(Scalar::ZERO);
 
         // No need to do the multisum between the secret key and the mask
         // as the mask only contains zeros
@@ -688,118 +196,93 @@ impl<Cont> LweCiphertext<Cont> {
     }
 }
 
-/// The mask of an LWE encrypted ciphertext.
-#[derive(Debug, PartialEq, Eq)]
-pub struct LweMask<Cont> {
-    tensor: Tensor<Cont>,
+impl<'a, Scalar: UnsignedTorus> LweCiphertextMutView<'a, Scalar> {
+    pub fn fill_with_glwe_sample_extraction<InputCont>(
+        &mut self,
+        glwe: &GlweCiphertext<InputCont>,
+        n_th: MonomialDegree,
+    ) where
+        GlweCiphertext<InputCont>: AsRefTensor<Element = Scalar>,
+    {
+        glwe.fill_lwe_with_sample_extraction(self, n_th);
+    }
 }
 
-tensor_traits!(LweMask);
+#[derive(Debug, PartialEq, Eq)]
+pub struct LweMask<Scalar: UnsignedInteger> {
+    tensor: Tensor<Vec<Scalar>>,
+}
 
-impl<Cont> LweMask<Cont> {
-    /// Creates a mask from a scalar container.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use concrete_commons::parameters::LweDimension;
-    /// use concrete_core::commons::crypto::lwe::*;
-    /// let masks = LweMask::from_container(vec![0 as u8; 10]);
-    /// assert_eq!(masks.mask_size(), LweDimension(10));
-    /// ```
-    pub fn from_container(cont: Cont) -> LweMask<Cont> {
+impl<Scalar: UnsignedInteger> LweMask<Scalar> {
+    pub fn from_vec(v: Vec<Scalar>) -> LweMask<Scalar> {
         LweMask {
-            tensor: Tensor::from_container(cont),
+            tensor: Tensor::from_container(v),
         }
     }
 
-    /// Returns an iterator over the mask elements.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use concrete_core::commons::crypto::lwe::*;
-    /// let mut ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
-    /// let masks = ciphertext.get_mask();
-    /// for mask in masks.mask_element_iter() {
-    ///     assert_eq!(mask, &0);
-    /// }
-    /// assert_eq!(masks.mask_element_iter().count(), 9);
-    /// ```
-    pub fn mask_element_iter(&self) -> impl Iterator<Item = &<Self as AsRefTensor>::Element>
-    where
-        Self: AsRefTensor,
-    {
-        self.as_tensor().iter()
+    pub fn as_ref(&self) -> LweMaskView<'_, Scalar> {
+        LweMaskView {
+            tensor: Tensor::from_container(self.tensor.as_container().as_slice()),
+        }
     }
 
-    /// Returns an iterator over mutable mask elements.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use concrete_core::commons::crypto::lwe::*;
-    /// let mut ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
-    /// let mut masks = ciphertext.get_mut_mask();
-    /// for mask in masks.mask_element_iter_mut() {
-    ///     *mask = 9;
-    /// }
-    /// for mask in masks.mask_element_iter() {
-    ///     assert_eq!(mask, &9);
-    /// }
-    /// assert_eq!(masks.mask_element_iter_mut().count(), 9);
-    /// ```
-    pub fn mask_element_iter_mut(
-        &mut self,
-    ) -> impl Iterator<Item = &mut <Self as AsMutTensor>::Element>
-    where
-        Self: AsMutTensor,
-    {
-        self.as_mut_tensor().iter_mut()
+    pub fn as_mut(&mut self) -> LweMaskMutView<'_, Scalar> {
+        LweMaskMutView {
+            tensor: Tensor::from_container(self.tensor.as_mut_container().as_mut_slice()),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct LweMaskView<'a, Scalar: UnsignedInteger> {
+    pub(crate) tensor: Tensor<&'a [Scalar]>,
+}
+
+impl<'a, Scalar: UnsignedInteger> LweMaskView<'a, Scalar> {
+    pub fn mask_element_iter(&self) -> impl Iterator<Item = &Scalar> {
+        self.tensor.iter()
     }
 
-    /// Returns the number of masks.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use concrete_commons::parameters::LweDimension;
-    /// use concrete_core::commons::crypto::lwe::*;
-    /// let mut ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
-    /// assert_eq!(ciphertext.get_mask().mask_size(), LweDimension(9));
-    /// ```
-    pub fn mask_size(&self) -> LweDimension
-    where
-        Self: AsRefTensor,
-    {
-        LweDimension(self.as_tensor().len())
+    pub fn mask_size(&self) -> LweDimension {
+        LweDimension(self.tensor.len())
     }
 
-    /// Computes sum of the mask elements weighted by the key elements.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use concrete_core::commons::crypto::lwe::LweCiphertext;
-    /// use concrete_core::commons::crypto::secret::LweSecretKey;
-    /// let ciphertext = LweCiphertext::from_container(vec![1u32, 2, 3, 4, 5]);
-    /// let mask = ciphertext.get_mask();
-    /// let key = LweSecretKey::binary_from_container(vec![1, 1, 0, 1]);
-    /// let multisum = mask.compute_multisum(&key);
-    /// assert_eq!(multisum, 7);
-    /// ```
-    pub fn compute_multisum<Kind, Scalar, Cont1>(&self, key: &LweSecretKey<Kind, Cont1>) -> Scalar
+    pub fn compute_multisum<Kind, Cont1>(&self, key: &LweSecretKey<Kind, Cont1>) -> Scalar
     where
-        Self: AsRefTensor<Element = Scalar>,
         LweSecretKey<Kind, Cont1>: AsRefTensor<Element = Scalar>,
         Kind: KeyKind,
-        Scalar: UnsignedTorus,
     {
-        self.as_tensor().fold_with_one(
+        self.tensor.fold_with_one(
             key.as_tensor(),
             <Scalar as Numeric>::ZERO,
             |ac, s_i, o_i| ac.wrapping_add(*s_i * *o_i),
         )
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct LweMaskMutView<'a, Scalar: UnsignedInteger> {
+    pub(crate) tensor: Tensor<&'a mut [Scalar]>,
+}
+
+impl<'a, Scalar: UnsignedInteger> LweMaskMutView<'a, Scalar> {
+    pub fn from_mut_slice(c: &'a mut [Scalar]) -> LweMaskMutView<'a, Scalar> {
+        LweMaskMutView {
+            tensor: Tensor::from_container(c),
+        }
+    }
+
+    pub fn as_ref(&'a self) -> LweMaskView<'a, Scalar> {
+        LweMaskView {
+            tensor: Tensor::from_container(self.tensor.as_container().as_slice()),
+        }
+    }
+
+    pub fn mask_size(&self) -> LweDimension {
+        LweDimension(self.tensor.len())
+    }
+    pub fn mask_element_iter_mut(&'a mut self) -> impl Iterator<Item = &'a mut Scalar> {
+        self.tensor.iter_mut()
     }
 }
 

--- a/concrete-core/src/commons/crypto/lwe/seeded_keyswitch.rs
+++ b/concrete-core/src/commons/crypto/lwe/seeded_keyswitch.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "__commons_serialization")]
 use serde::{Deserialize, Serialize};
 
-use concrete_commons::numeric::Numeric;
+use concrete_commons::numeric::{Numeric, UnsignedInteger};
 
 use concrete_commons::dispersion::DispersionParameter;
 use concrete_commons::key_kinds::BinaryKeyKind;
@@ -473,7 +473,7 @@ impl<Cont> LweSeededKeyswitchKey<Cont> {
     where
         LweKeyswitchKey<OutCont>: AsMutTensor<Element = Scalar>,
         Self: AsRefTensor<Element = Scalar>,
-        Scalar: Copy + RandomGenerable<Uniform> + Numeric,
+        Scalar: Copy + RandomGenerable<Uniform> + Numeric + UnsignedInteger,
         Gen: ByteRandomGenerator,
     {
         let mut generator = RandomGenerator::<Gen>::new(self.compression_seed.seed);

--- a/concrete-core/src/commons/crypto/lwe/seeded_list.rs
+++ b/concrete-core/src/commons/crypto/lwe/seeded_list.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "__commons_serialization")]
 use serde::{Deserialize, Serialize};
 
-use concrete_commons::numeric::Numeric;
+use concrete_commons::numeric::{Numeric, UnsignedInteger};
 use concrete_commons::parameters::{CiphertextCount, LweDimension, LweSize};
 
 use crate::commons::crypto::lwe::LweList;
@@ -247,14 +247,14 @@ impl<Cont> LweSeededList<Cont> {
     ) where
         LweList<OutCont>: AsMutTensor<Element = Scalar>,
         Self: AsRefTensor<Element = Scalar>,
-        Scalar: RandomGenerable<Uniform> + Numeric,
+        Scalar: RandomGenerable<Uniform> + Numeric + UnsignedInteger,
         Gen: ByteRandomGenerator,
     {
         for (mut lwe_out, body_in) in output.ciphertext_iter_mut().zip(self.body_iter()) {
             let (output_body, mut output_mask) = lwe_out.get_mut_body_and_mask();
 
             // generate a uniformly random mask
-            generator.fill_tensor_with_random_uniform(output_mask.as_mut_tensor());
+            generator.fill_tensor_with_random_uniform(&mut output_mask.tensor);
             output_body.0 = body_in.0;
         }
     }
@@ -282,7 +282,7 @@ impl<Cont> LweSeededList<Cont> {
     where
         LweList<OutCont>: AsMutTensor<Element = Scalar>,
         Self: AsRefTensor<Element = Scalar>,
-        Scalar: RandomGenerable<Uniform> + Numeric,
+        Scalar: RandomGenerable<Uniform> + Numeric + UnsignedInteger,
         Gen: ByteRandomGenerator,
     {
         let mut generator = RandomGenerator::<Gen>::new(self.compression_seed.seed);


### PR DESCRIPTION
### Resolves: 

closes zama-ai/concrete-core-internal#291

### Description

This PR is a example of how the api change proposed by @mayeul-zama on the `LweCiphertext` could be brought to the library,

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
