### PR TITLE
feat(concrete-fft): add concrete-fft backend

### DIFF
--- a/concrete-commons/src/numeric/mod.rs
+++ b/concrete-commons/src/numeric/mod.rs
@@ -21,7 +21,7 @@ mod signed;
 mod unsigned;
 
 /// A trait implemented by any generic numeric type suitable for computations.
-pub trait Numeric: Sized + Copy + PartialEq + PartialOrd {
+pub trait Numeric: Sized + Copy + PartialEq + PartialOrd + 'static {
     /// This size of the type in bits.
     const BITS: usize;
 

--- a/concrete-core-bench/Cargo.toml
+++ b/concrete-core-bench/Cargo.toml
@@ -17,6 +17,11 @@ backend_fftw = [
     "concrete-core/backend_fftw",
     "concrete-core-fixture/backend_fftw",
 ]
+backend_fft = [
+    "concrete-core/backend_fft",
+    "concrete-core-fixture/backend_fft",
+]
+# backend_fft_nightly_avx512 = ["concrete-core/backend_fft_nightly_avx512"]
 backend_default_parallel = [
     "concrete-core/backend_default_parallel",
     "concrete-core-fixture/backend_default_parallel"

--- a/concrete-core-bench/src/fft.rs
+++ b/concrete-core-bench/src/fft.rs
@@ -1,0 +1,41 @@
+use crate::benchmark::BenchmarkFixture;
+use concrete_core::prelude::*;
+use concrete_core_fixture::fixture::*;
+use concrete_core_fixture::generation::{BinaryKeyDistribution, Maker, Precision32, Precision64};
+use criterion::Criterion;
+
+use paste::paste;
+
+macro_rules! bench {
+    (($($key_dist:ident),*), $fixture: ident, $precision: ident, ($($types:ident),+), $maker: ident, $engine: ident, $criterion: ident) => {
+        paste!{
+            <$fixture as BenchmarkFixture<$precision,($($key_dist,)*), FftEngine, ($($types,)+),
+            >>::bench_all_parameters(
+                &mut $maker,
+                &mut $engine,
+                &mut $criterion,
+                None
+            );
+        }
+    };
+    ($((($($key_dist:ident),*), $fixture: ident, ($($types:ident),+))),+) => {
+        pub fn bench() {
+            let mut criterion = Criterion::default().configure_from_args();
+            let mut maker = Maker::default();
+            let mut engine = FftEngine::new(()).unwrap();
+            $(
+                paste!{
+                    bench!{($($key_dist),*), $fixture, Precision32, ($([< $types 32 >]),+), maker, engine, criterion}
+                    bench!{($($key_dist),*), $fixture, Precision64, ($([< $types 64 >]),+), maker, engine, criterion}
+                }
+            )+
+        }
+    };
+}
+
+bench! {
+    ((BinaryKeyDistribution, BinaryKeyDistribution), LweCiphertextDiscardingBootstrapFixture1, (FftFourierLweBootstrapKey, GlweCiphertext, LweCiphertext, LweCiphertext)),
+    ((BinaryKeyDistribution, BinaryKeyDistribution), LweCiphertextDiscardingBootstrapFixture2, (FftFourierLweBootstrapKey, GlweCiphertext, LweCiphertext, LweCiphertext)),
+    ((BinaryKeyDistribution), GlweCiphertextGgswCiphertextDiscardingExternalProductFixture, (GlweCiphertext, FftFourierGgswCiphertext, GlweCiphertext)),
+    ((BinaryKeyDistribution), GlweCiphertextsGgswCiphertextFusingCmuxFixture, (GlweCiphertext, GlweCiphertext, FftFourierGgswCiphertext))
+}

--- a/concrete-core-bench/src/main.rs
+++ b/concrete-core-bench/src/main.rs
@@ -13,6 +13,9 @@ mod default;
 #[cfg(feature = "backend_fftw")]
 mod fftw;
 
+#[cfg(feature = "backend_fft")]
+mod fft;
+
 #[cfg(all(feature = "backend_cuda", not(feature = "_ci_do_not_compile")))]
 mod cuda;
 
@@ -25,6 +28,8 @@ fn main() {
     default::bench_parallel();
     #[cfg(feature = "backend_fftw")]
     fftw::bench();
+    #[cfg(feature = "backend_fft")]
+    fft::bench();
     #[cfg(all(feature = "backend_cuda", not(feature = "_ci_do_not_compile")))]
     cuda::bench();
     #[cfg(all(feature = "backend_cuda", not(feature = "_ci_do_not_compile")))]

--- a/concrete-core-fixture/Cargo.toml
+++ b/concrete-core-fixture/Cargo.toml
@@ -16,8 +16,11 @@ paste = "1.0"
 [features]
 # No backend_default feature as it's required for all tests to work, so always enabled
 backend_fftw = ["concrete-core/backend_fftw"]
+backend_fft = ["concrete-core/backend_fft"]
+# backend_fft_nightly_avx512 = ["concrete-core/backend_fft_nightly_avx512"]
 backend_default_parallel = ["concrete-core/backend_default_parallel"]
 backend_cuda = ["concrete-core/backend_cuda", "concrete-cuda"]
+
 _ci_do_not_compile = []
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/concrete-core-fixture/src/generation/mod.rs
+++ b/concrete-core-fixture/src/generation/mod.rs
@@ -77,6 +77,8 @@ pub struct Maker {
     default_parallel_engine: DefaultParallelEngine,
     #[cfg(feature = "backend_fftw")]
     fftw_engine: concrete_core::backends::fftw::engines::FftwEngine,
+    #[cfg(feature = "backend_fft")]
+    fft_engine: concrete_core::backends::fft::engines::FftEngine,
     #[cfg(all(feature = "backend_cuda", not(feature = "_ci_do_not_compile")))]
     cuda_engine: concrete_core::backends::cuda::engines::CudaEngine,
 }
@@ -89,6 +91,8 @@ impl Default for Maker {
                 .unwrap(),
             #[cfg(feature = "backend_fftw")]
             fftw_engine: concrete_core::backends::fftw::engines::FftwEngine::new(()).unwrap(),
+            #[cfg(feature = "backend_fft")]
+            fft_engine: concrete_core::backends::fft::engines::FftEngine::new(()).unwrap(),
             #[cfg(all(feature = "backend_cuda", not(feature = "_ci_do_not_compile")))]
             cuda_engine: concrete_core::backends::cuda::engines::CudaEngine::new(()).unwrap(),
         }

--- a/concrete-core-fixture/src/generation/synthesizing/ggsw_ciphertext.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/ggsw_ciphertext.rs
@@ -116,3 +116,58 @@ mod backend_fftw {
         fn destroy_ggsw_ciphertext(&mut self, _entity: FftwFourierGgswCiphertext64) {}
     }
 }
+
+#[cfg(feature = "backend_fft")]
+mod backend_fft {
+    use crate::generation::synthesizing::SynthesizesGgswCiphertext;
+    use crate::generation::{BinaryKeyDistribution, Maker, Precision32, Precision64};
+    use concrete_core::prelude::{
+        FftFourierGgswCiphertext32, FftFourierGgswCiphertext64, GgswCiphertextConversionEngine,
+    };
+
+    impl SynthesizesGgswCiphertext<Precision32, BinaryKeyDistribution, FftFourierGgswCiphertext32>
+        for Maker
+    {
+        fn synthesize_ggsw_ciphertext(
+            &mut self,
+            prototype: &Self::GgswCiphertextProto,
+        ) -> FftFourierGgswCiphertext32 {
+            self.fft_engine
+                .convert_ggsw_ciphertext(&prototype.0)
+                .unwrap()
+        }
+
+        fn unsynthesize_ggsw_ciphertext(
+            &mut self,
+            _entity: FftFourierGgswCiphertext32,
+        ) -> Self::GgswCiphertextProto {
+            // FIXME:
+            unimplemented!("The backward fourier conversion was not yet implemented");
+        }
+
+        fn destroy_ggsw_ciphertext(&mut self, _entity: FftFourierGgswCiphertext32) {}
+    }
+
+    impl SynthesizesGgswCiphertext<Precision64, BinaryKeyDistribution, FftFourierGgswCiphertext64>
+        for Maker
+    {
+        fn synthesize_ggsw_ciphertext(
+            &mut self,
+            prototype: &Self::GgswCiphertextProto,
+        ) -> FftFourierGgswCiphertext64 {
+            self.fft_engine
+                .convert_ggsw_ciphertext(&prototype.0)
+                .unwrap()
+        }
+
+        fn unsynthesize_ggsw_ciphertext(
+            &mut self,
+            _entity: FftFourierGgswCiphertext64,
+        ) -> Self::GgswCiphertextProto {
+            // FIXME:
+            unimplemented!("The backward fourier conversion was not yet implemented");
+        }
+
+        fn destroy_ggsw_ciphertext(&mut self, _entity: FftFourierGgswCiphertext64) {}
+    }
+}

--- a/concrete-core-fixture/src/generation/synthesizing/lwe_bootstrap_key.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/lwe_bootstrap_key.rs
@@ -448,6 +448,69 @@ mod backend_fftw {
     }
 }
 
+#[cfg(feature = "backend_fft")]
+mod backend_fft {
+    use crate::generation::synthesizing::SynthesizesLweBootstrapKey;
+    use crate::generation::{BinaryKeyDistribution, Maker, Precision32, Precision64};
+    use concrete_core::prelude::{
+        FftFourierLweBootstrapKey32, FftFourierLweBootstrapKey64, LweBootstrapKeyConversionEngine,
+    };
+
+    impl
+        SynthesizesLweBootstrapKey<
+            Precision32,
+            BinaryKeyDistribution,
+            BinaryKeyDistribution,
+            FftFourierLweBootstrapKey32,
+        > for Maker
+    {
+        fn synthesize_lwe_bootstrap_key(
+            &mut self,
+            prototype: &Self::LweBootstrapKeyProto,
+        ) -> FftFourierLweBootstrapKey32 {
+            self.fft_engine
+                .convert_lwe_bootstrap_key(&prototype.0)
+                .unwrap()
+        }
+
+        fn unsynthesize_lwe_bootstrap_key(
+            &mut self,
+            _entity: FftFourierLweBootstrapKey32,
+        ) -> Self::LweBootstrapKeyProto {
+            todo!()
+        }
+
+        fn destroy_lwe_bootstrap_key(&mut self, _entity: FftFourierLweBootstrapKey32) {}
+    }
+
+    impl
+        SynthesizesLweBootstrapKey<
+            Precision64,
+            BinaryKeyDistribution,
+            BinaryKeyDistribution,
+            FftFourierLweBootstrapKey64,
+        > for Maker
+    {
+        fn synthesize_lwe_bootstrap_key(
+            &mut self,
+            prototype: &Self::LweBootstrapKeyProto,
+        ) -> FftFourierLweBootstrapKey64 {
+            self.fft_engine
+                .convert_lwe_bootstrap_key(&prototype.0)
+                .unwrap()
+        }
+
+        fn unsynthesize_lwe_bootstrap_key(
+            &mut self,
+            _entity: FftFourierLweBootstrapKey64,
+        ) -> Self::LweBootstrapKeyProto {
+            todo!()
+        }
+
+        fn destroy_lwe_bootstrap_key(&mut self, _entity: FftFourierLweBootstrapKey64) {}
+    }
+}
+
 #[cfg(all(feature = "backend_cuda", not(feature = "_ci_do_not_compile")))]
 mod backend_cuda {
     use crate::generation::synthesizing::SynthesizesLweBootstrapKey;

--- a/concrete-core-test/Cargo.toml
+++ b/concrete-core-test/Cargo.toml
@@ -16,8 +16,13 @@ backend_fftw = [
     "concrete-core/backend_fftw",
     "concrete-core-fixture/backend_fftw",
 ]
+backend_fft = [
+    "concrete-core/backend_fft",
+    "concrete-core-fixture/backend_fft",
+]
+# backend_fft_nightly_avx512 = ["concrete-core/backend_fft_nightly_avx512"]
 backend_cuda = [
-    "concrete-core/backend_cuda", 
+    "concrete-core/backend_cuda",
     "concrete-core-fixture/backend_cuda",
 ]
 _ci_do_not_compile = ["concrete-core/_ci_do_not_compile", "concrete-core-fixture/_ci_do_not_compile"]

--- a/concrete-core-test/src/fft.rs
+++ b/concrete-core-test/src/fft.rs
@@ -1,0 +1,40 @@
+use crate::{REPETITIONS, SAMPLE_SIZE};
+use concrete_core::prelude::*;
+use concrete_core_fixture::fixture::*;
+use concrete_core_fixture::generation::{BinaryKeyDistribution, Maker, Precision32, Precision64};
+use paste::paste;
+
+macro_rules! test {
+    (($($key_dist:ident),*), $fixture: ident, $precision: ident, ($($types:ident),+)) => {
+        paste!{
+            #[test]
+            fn [< test_ $fixture:snake _ $precision:snake _ $($types:snake)_+ >]() {
+                let mut maker = Maker::default();
+                let mut engine = FftEngine::new(()).unwrap();
+                let test_result =
+                    <$fixture as Fixture<
+                        $precision,
+                        ($($key_dist,)*),
+                        FftEngine,
+                        ($($types,)+),
+                    >>::stress_all_parameters(&mut maker, &mut engine, REPETITIONS, SAMPLE_SIZE);
+                assert!(test_result);
+            }
+        }
+    };
+    ($((($($key_dist:ident),*), $fixture: ident, ($($types:ident),+))),+) => {
+        $(
+            paste!{
+                test!{($($key_dist),*), $fixture, Precision32, ($([< $types 32 >]),+)}
+                test!{($($key_dist),*), $fixture, Precision64, ($([< $types 64 >]),+)}
+            }
+        )+
+    };
+}
+
+test! {
+    ((BinaryKeyDistribution, BinaryKeyDistribution), LweCiphertextDiscardingBootstrapFixture1, (FftFourierLweBootstrapKey, GlweCiphertext, LweCiphertext, LweCiphertext)),
+    ((BinaryKeyDistribution, BinaryKeyDistribution), LweCiphertextDiscardingBootstrapFixture2, (FftFourierLweBootstrapKey, GlweCiphertext, LweCiphertext, LweCiphertext)),
+    ((BinaryKeyDistribution), GlweCiphertextGgswCiphertextDiscardingExternalProductFixture, (GlweCiphertext, FftFourierGgswCiphertext, GlweCiphertext)),
+    ((BinaryKeyDistribution), GlweCiphertextsGgswCiphertextFusingCmuxFixture, (GlweCiphertext, GlweCiphertext, FftFourierGgswCiphertext))
+}

--- a/concrete-core-test/src/lib.rs
+++ b/concrete-core-test/src/lib.rs
@@ -16,5 +16,7 @@ pub const SAMPLE_SIZE: SampleSize = SampleSize(100);
 pub mod cuda;
 #[cfg(all(test, feature = "backend_default"))]
 pub mod default;
+#[cfg(all(test, feature = "backend_fft"))]
+pub mod fft;
 #[cfg(all(test, feature = "backend_fftw"))]
 pub mod fftw;

--- a/concrete-core/Cargo.toml
+++ b/concrete-core/Cargo.toml
@@ -25,6 +25,10 @@ serde = { version = "1.0", optional = true }
 lazy_static = "1.4.0"
 rayon = { version = "1.5.0", optional = true }
 bincode = { version = "1.3.3", optional = true }
+concrete-fft = { version = "0.1", optional = true }
+aligned-vec = "0.5"
+dyn-stack = "0.8"
+once_cell = "1.13"
 
 [lib]
 name = "concrete_core"
@@ -36,6 +40,16 @@ doc = []
 
 # A pure-rust backend. Included by default in the build.
 backend_default = ["concrete-csprng/generator_soft"]
+
+# An accelerated backend, using the `concrete-fft` library.
+backend_fft = ["concrete-fft"]
+backend_fft_serialization = [
+    "bincode",
+    "concrete-fft/serde",
+    "aligned-vec/serde",
+    "__commons_serialization",
+]
+# backend_fft_nightly_avx512 = ["concrete-fft/nightly"]
 
 # Enables the parallel engine in default backend.
 backend_default_parallel = ["__commons_parallel"]
@@ -63,6 +77,7 @@ backend_fftw_serialization = [
 backend_cuda = ["concrete-cuda"]
 
 # Private features
+__private_docs = []
 __commons_parallel = ["rayon", "concrete-csprng/parallel"]
 __commons_serialization = [
     "serde",

--- a/concrete-core/src/backends/fft/implementation/engines/computation_engine.rs
+++ b/concrete-core/src/backends/fft/implementation/engines/computation_engine.rs
@@ -1,0 +1,59 @@
+use concrete_commons::parameters::PolynomialSize;
+use dyn_stack::DynStack;
+
+use crate::specification::engines::sealed::AbstractEngineSeal;
+use crate::specification::engines::AbstractEngine;
+use core::mem::MaybeUninit;
+
+/// Error that can occur in the execution of FHE operations by the [`FftEngine`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum FftError {
+    UnsupportedPolynomialSize,
+}
+
+impl core::fmt::Display for FftError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FftError::UnsupportedPolynomialSize => f.write_str(
+                "The Concrete-FFT backend only supports polynomials of sizes that are powers of two \
+                    and greater than or equal to 32.",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FftError {}
+
+/// The main engine exposed by the Concrete-FFT backend.
+pub struct FftEngine {
+    memory: Vec<MaybeUninit<u8>>,
+}
+
+impl FftEngine {
+    pub(crate) fn resize(&mut self, capacity: usize) {
+        self.memory.resize_with(capacity, MaybeUninit::uninit);
+    }
+
+    pub(crate) fn stack(&mut self) -> DynStack<'_> {
+        DynStack::new(&mut self.memory)
+    }
+
+    pub fn check_supported_size(polynomial_size: PolynomialSize) -> Result<(), FftError> {
+        if polynomial_size.0.is_power_of_two() && polynomial_size.0 >= 32 {
+            Ok(())
+        } else {
+            Err(FftError::UnsupportedPolynomialSize)
+        }
+    }
+}
+
+impl AbstractEngineSeal for FftEngine {}
+impl AbstractEngine for FftEngine {
+    type EngineError = FftError;
+    type Parameters = ();
+
+    fn new(_parameter: Self::Parameters) -> Result<Self, Self::EngineError> {
+        Ok(FftEngine { memory: Vec::new() })
+    }
+}

--- a/concrete-core/src/backends/fft/implementation/engines/deserialization.rs
+++ b/concrete-core/src/backends/fft/implementation/engines/deserialization.rs
@@ -1,0 +1,308 @@
+use super::super::super::private::crypto::bootstrap::FourierLweBootstrapKey;
+use super::super::super::private::crypto::ggsw::FourierGgswCiphertext;
+use super::super::super::private::math::fft::Fft;
+use super::{FftSerializationEngine, FftSerializationError};
+use crate::prelude::{
+    EntityDeserializationEngine, EntityDeserializationError, FftFourierGgswCiphertext32,
+    FftFourierGgswCiphertext32Version, FftFourierGgswCiphertext64,
+    FftFourierGgswCiphertext64Version, FftFourierLweBootstrapKey32,
+    FftFourierLweBootstrapKey32Version, FftFourierLweBootstrapKey64,
+    FftFourierLweBootstrapKey64Version,
+};
+use aligned_vec::avec;
+use concrete_fft::c64;
+use concrete_commons::parameters::{
+    DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+};
+use serde::Deserialize;
+
+impl EntityDeserializationEngine<&[u8], FftFourierGgswCiphertext32> for FftSerializationEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u32 << 20;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let key: GlweSecretKey32 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    ///
+    /// // We encrypt a GGSW ciphertext in the standard domain
+    /// let ciphertext =
+    ///     default_engine.encrypt_scalar_ggsw_ciphertext(&key, &plaintext, noise, level, base_log)?;
+    ///
+    /// // Then we convert it to the Fourier domain.
+    /// let fourier_ciphertext: FftFourierGgswCiphertext32 =
+    ///     fft_engine.convert_ggsw_ciphertext(&ciphertext)?;
+    ///
+    /// let mut serialization_engine = FftSerializationEngine::new(())?;
+    /// let serialized = serialization_engine.serialize(&fourier_ciphertext)?;
+    /// let recovered = serialization_engine.deserialize(serialized.as_slice())?;
+    /// assert_eq!(fourier_ciphertext, recovered);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn deserialize(
+        &mut self,
+        serialized: &[u8],
+    ) -> Result<FftFourierGgswCiphertext32, EntityDeserializationError<Self::EngineError>> {
+        #[derive(Deserialize)]
+        struct SerializableFftFourierGgswCiphertext32 {
+            version: FftFourierGgswCiphertext32Version,
+            inner: FourierGgswCiphertext,
+        }
+        let deserialized: SerializableFftFourierGgswCiphertext32 = bincode::deserialize(serialized)
+            .map_err(FftSerializationError::Deserialization)
+            .map_err(EntityDeserializationError::Engine)?;
+        match deserialized {
+            SerializableFftFourierGgswCiphertext32 {
+                version: FftFourierGgswCiphertext32Version::Unsupported,
+                ..
+            } => Err(EntityDeserializationError::Engine(
+                FftSerializationError::UnsupportedVersion,
+            )),
+            SerializableFftFourierGgswCiphertext32 {
+                version: FftFourierGgswCiphertext32Version::V0,
+                inner,
+            } => Ok(FftFourierGgswCiphertext32(inner)),
+        }
+    }
+
+    unsafe fn deserialize_unchecked(&mut self, serialized: &[u8]) -> FftFourierGgswCiphertext32 {
+        self.deserialize(serialized).unwrap()
+    }
+}
+
+impl EntityDeserializationEngine<&[u8], FftFourierGgswCiphertext64> for FftSerializationEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = 3_u64 << 50;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let key: GlweSecretKey64 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    ///
+    /// // We encrypt a GGSW ciphertext in the standard domain
+    /// let ciphertext =
+    ///     default_engine.encrypt_scalar_ggsw_ciphertext(&key, &plaintext, noise, level, base_log)?;
+    ///
+    /// // Then we convert it to the Fourier domain.
+    /// let fourier_ciphertext: FftFourierGgswCiphertext64 =
+    ///     fft_engine.convert_ggsw_ciphertext(&ciphertext)?;
+    ///
+    /// let mut serialization_engine = FftSerializationEngine::new(())?;
+    /// let serialized = serialization_engine.serialize(&fourier_ciphertext)?;
+    /// let recovered = serialization_engine.deserialize(serialized.as_slice())?;
+    /// assert_eq!(fourier_ciphertext, recovered);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn deserialize(
+        &mut self,
+        serialized: &[u8],
+    ) -> Result<FftFourierGgswCiphertext64, EntityDeserializationError<Self::EngineError>> {
+        #[derive(Deserialize)]
+        struct SerializableFftFourierGgswCiphertext64 {
+            version: FftFourierGgswCiphertext64Version,
+            inner: FourierGgswCiphertext,
+        }
+        let deserialized: SerializableFftFourierGgswCiphertext64 = bincode::deserialize(serialized)
+            .map_err(FftSerializationError::Deserialization)
+            .map_err(EntityDeserializationError::Engine)?;
+        match deserialized {
+            SerializableFftFourierGgswCiphertext64 {
+                version: FftFourierGgswCiphertext64Version::Unsupported,
+                ..
+            } => Err(EntityDeserializationError::Engine(
+                FftSerializationError::UnsupportedVersion,
+            )),
+            SerializableFftFourierGgswCiphertext64 {
+                version: FftFourierGgswCiphertext64Version::V0,
+                inner,
+            } => Ok(FftFourierGgswCiphertext64(inner)),
+        }
+    }
+
+    unsafe fn deserialize_unchecked(&mut self, serialized: &[u8]) -> FftFourierGgswCiphertext64 {
+        self.deserialize(serialized).unwrap()
+    }
+}
+
+impl EntityDeserializationEngine<&[u8], FftFourierLweBootstrapKey32> for FftSerializationEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let (lwe_dim, glwe_dim, poly_size) = (LweDimension(4), GlweDimension(6), PolynomialSize(256));
+    /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let lwe_sk: LweSecretKey32 = default_engine.create_lwe_secret_key(lwe_dim)?;
+    /// let glwe_sk: GlweSecretKey32 = default_engine.create_glwe_secret_key(glwe_dim, poly_size)?;
+    /// let bsk: LweBootstrapKey32 =
+    ///     default_engine.create_lwe_bootstrap_key(&lwe_sk, &glwe_sk, dec_bl, dec_lc, noise)?;
+    ///
+    /// let fourier_bsk: FftFourierLweBootstrapKey32 = fft_engine.convert_lwe_bootstrap_key(&bsk)?;
+    ///
+    /// let mut serialization_engine = FftSerializationEngine::new(())?;
+    /// let serialized = serialization_engine.serialize(&fourier_bsk)?;
+    /// let recovered = serialization_engine.deserialize(serialized.as_slice())?;
+    /// assert_eq!(fourier_bsk, recovered);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn deserialize(
+        &mut self,
+        serialized: &[u8],
+    ) -> Result<FftFourierLweBootstrapKey32, EntityDeserializationError<Self::EngineError>> {
+        #[derive(Deserialize)]
+        struct SerializableFftFourierLweBootstrapKey32 {
+            version: FftFourierLweBootstrapKey32Version,
+            inner: FourierLweBootstrapKey,
+        }
+        let deserialized: SerializableFftFourierLweBootstrapKey32 =
+            bincode::deserialize(serialized)
+                .map_err(FftSerializationError::Deserialization)
+                .map_err(EntityDeserializationError::Engine)?;
+        match deserialized {
+            SerializableFftFourierLweBootstrapKey32 {
+                version: FftFourierLweBootstrapKey32Version::Unsupported,
+                ..
+            } => Err(EntityDeserializationError::Engine(
+                FftSerializationError::UnsupportedVersion,
+            )),
+            SerializableFftFourierLweBootstrapKey32 {
+                version: FftFourierLweBootstrapKey32Version::V0,
+                inner,
+            } => Ok(FftFourierLweBootstrapKey32(inner)),
+        }
+    }
+
+    unsafe fn deserialize_unchecked(&mut self, serialized: &[u8]) -> FftFourierLweBootstrapKey32 {
+        self.deserialize(serialized).unwrap()
+    }
+}
+
+impl EntityDeserializationEngine<&[u8], FftFourierLweBootstrapKey64> for FftSerializationEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let (lwe_dim, glwe_dim, poly_size) = (LweDimension(4), GlweDimension(6), PolynomialSize(256));
+    /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let lwe_sk: LweSecretKey64 = default_engine.create_lwe_secret_key(lwe_dim)?;
+    /// let glwe_sk: GlweSecretKey64 = default_engine.create_glwe_secret_key(glwe_dim, poly_size)?;
+    /// let bsk: LweBootstrapKey64 =
+    ///     default_engine.create_lwe_bootstrap_key(&lwe_sk, &glwe_sk, dec_bl, dec_lc, noise)?;
+    ///
+    /// let fourier_bsk: FftFourierLweBootstrapKey64 = fft_engine.convert_lwe_bootstrap_key(&bsk)?;
+    ///
+    /// let mut serialization_engine = FftSerializationEngine::new(())?;
+    /// let serialized = serialization_engine.serialize(&fourier_bsk)?;
+    /// let recovered = serialization_engine.deserialize(serialized.as_slice())?;
+    /// assert_eq!(fourier_bsk, recovered);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn deserialize(
+        &mut self,
+        serialized: &[u8],
+    ) -> Result<FftFourierLweBootstrapKey64, EntityDeserializationError<Self::EngineError>> {
+        #[derive(Deserialize)]
+        struct SerializableFftFourierLweBootstrapKey64 {
+            version: FftFourierLweBootstrapKey64Version,
+            inner: FourierLweBootstrapKey,
+        }
+        let deserialized: SerializableFftFourierLweBootstrapKey64 =
+            bincode::deserialize(serialized)
+                .map_err(FftSerializationError::Deserialization)
+                .map_err(EntityDeserializationError::Engine)?;
+        match deserialized {
+            SerializableFftFourierLweBootstrapKey64 {
+                version: FftFourierLweBootstrapKey64Version::Unsupported,
+                ..
+            } => Err(EntityDeserializationError::Engine(
+                FftSerializationError::UnsupportedVersion,
+            )),
+            SerializableFftFourierLweBootstrapKey64 {
+                version: FftFourierLweBootstrapKey64Version::V0,
+                inner,
+            } => Ok(FftFourierLweBootstrapKey64(inner)),
+        }
+    }
+
+    unsafe fn deserialize_unchecked(&mut self, serialized: &[u8]) -> FftFourierLweBootstrapKey64 {
+        self.deserialize(serialized).unwrap()
+    }
+}

--- a/concrete-core/src/backends/fft/implementation/engines/ggsw_ciphertext_conversion.rs
+++ b/concrete-core/src/backends/fft/implementation/engines/ggsw_ciphertext_conversion.rs
@@ -1,0 +1,399 @@
+use super::super::super::private::crypto::ggsw::{
+    fill_with_forward_fourier_scratch, FourierGgswCiphertext, StandardGgswCiphertextView,
+};
+use super::super::super::private::math::fft::Fft;
+use super::super::entities::{FftFourierGgswCiphertext32, FftFourierGgswCiphertext64};
+use super::{FftEngine, FftError};
+use crate::commons::math::tensor::AsRefSlice;
+use crate::prelude::{
+    GgswCiphertext32, GgswCiphertext64, GgswCiphertextConversionError,
+    GgswCiphertextDiscardingConversionEngine, GgswCiphertextDiscardingConversionError,
+};
+use crate::specification::engines::GgswCiphertextConversionEngine;
+use crate::specification::entities::GgswCiphertextEntity;
+use aligned_vec::avec;
+use concrete_fft::c64;
+
+impl From<FftError> for GgswCiphertextDiscardingConversionError<FftError> {
+    fn from(err: FftError) -> Self {
+        Self::Engine(err)
+    }
+}
+impl From<FftError> for GgswCiphertextConversionError<FftError> {
+    fn from(err: FftError) -> Self {
+        Self::Engine(err)
+    }
+}
+
+/// # Description
+///
+/// Implementation of [`GgswCiphertextDiscardingConversionEngine`] for [`FftEngine`] that
+/// operates on 32 bit integers. It converts a GGSW ciphertext from the standard to the Fourier
+/// domain.
+impl GgswCiphertextDiscardingConversionEngine<GgswCiphertext32, FftFourierGgswCiphertext32>
+    for FftEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u32 << 20;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let key_1: GlweSecretKey32 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    ///
+    /// let mut ciphertext = default_engine
+    ///     .encrypt_scalar_ggsw_ciphertext(&key_1, &plaintext, noise, level, base_log)?;
+    ///
+    /// let mut fourier_ciphertext: FftFourierGgswCiphertext32 =
+    ///     fft_engine.convert_ggsw_ciphertext(&ciphertext)?;
+    ///
+    /// // We're going to re-encrypt and re-convert the input with another secret key
+    /// // For this, it is required that the second secret key uses the same GLWE dimension
+    /// // and polynomial size as the first one.
+    /// let key_2: GlweSecretKey32 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    ///
+    /// default_engine.discard_encrypt_scalar_ggsw_ciphertext(
+    ///     &key_2,
+    ///     &mut ciphertext,
+    ///     &plaintext,
+    ///     noise,
+    /// )?;
+    /// fft_engine.discard_convert_ggsw_ciphertext(&mut fourier_ciphertext, &ciphertext)?;
+    ///
+    /// assert_eq!(fourier_ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(fourier_ciphertext.polynomial_size(), polynomial_size);
+    /// assert_eq!(fourier_ciphertext.decomposition_base_log(), base_log);
+    /// assert_eq!(fourier_ciphertext.decomposition_level_count(), level);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_convert_ggsw_ciphertext(
+        &mut self,
+        output: &mut FftFourierGgswCiphertext32,
+        input: &GgswCiphertext32,
+    ) -> Result<(), GgswCiphertextDiscardingConversionError<Self::EngineError>> {
+        FftEngine::check_supported_size(input.0.polynomial_size())?;
+        GgswCiphertextDiscardingConversionError::perform_generic_checks(output, input)?;
+        unsafe { self.discard_convert_ggsw_ciphertext_unchecked(output, input) };
+        Ok(())
+    }
+
+    unsafe fn discard_convert_ggsw_ciphertext_unchecked(
+        &mut self,
+        output: &mut FftFourierGgswCiphertext32,
+        input: &GgswCiphertext32,
+    ) {
+        let fft = Fft::new(input.polynomial_size());
+        let fft = fft.as_view();
+        self.resize(
+            fill_with_forward_fourier_scratch(fft)
+                .unwrap()
+                .unaligned_bytes_required(),
+        );
+        output.0.as_mut_view().fill_with_forward_fourier(
+            StandardGgswCiphertextView::new(
+                input.0.tensor.as_slice(),
+                input.polynomial_size(),
+                input.glwe_dimension().to_glwe_size(),
+                input.decomposition_base_log(),
+                input.decomposition_level_count(),
+            ),
+            fft,
+            self.stack(),
+        );
+    }
+}
+
+/// # Description
+///
+/// Implementation of [`GgswCiphertextDiscardingConversionEngine`] for [`FftEngine`] that
+/// operates on 64 bit integers. It converts a GGSW ciphertext from the standard to the Fourier
+/// domain.
+impl GgswCiphertextDiscardingConversionEngine<GgswCiphertext64, FftFourierGgswCiphertext64>
+    for FftEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = 3_u64 << 50;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let key_1: GlweSecretKey64 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    ///
+    /// let mut ciphertext = default_engine
+    ///     .encrypt_scalar_ggsw_ciphertext(&key_1, &plaintext, noise, level, base_log)?;
+    ///
+    /// let mut fourier_ciphertext: FftFourierGgswCiphertext64 =
+    ///     fft_engine.convert_ggsw_ciphertext(&ciphertext)?;
+    ///
+    /// // We're going to re-encrypt and re-convert the input with another secret key
+    /// // For this, it is required that the second secret key uses the same GLWE dimension
+    /// // and polynomial size as the first one.
+    /// let key_2: GlweSecretKey64 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    ///
+    /// default_engine.discard_encrypt_scalar_ggsw_ciphertext(
+    ///     &key_2,
+    ///     &mut ciphertext,
+    ///     &plaintext,
+    ///     noise,
+    /// )?;
+    /// fft_engine.discard_convert_ggsw_ciphertext(&mut fourier_ciphertext, &ciphertext)?;
+    ///
+    /// #
+    /// assert_eq!(fourier_ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(fourier_ciphertext.polynomial_size(), polynomial_size);
+    /// assert_eq!(fourier_ciphertext.decomposition_base_log(), base_log);
+    /// assert_eq!(fourier_ciphertext.decomposition_level_count(), level);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_convert_ggsw_ciphertext(
+        &mut self,
+        output: &mut FftFourierGgswCiphertext64,
+        input: &GgswCiphertext64,
+    ) -> Result<(), GgswCiphertextDiscardingConversionError<Self::EngineError>> {
+        FftEngine::check_supported_size(input.0.polynomial_size())?;
+        GgswCiphertextDiscardingConversionError::perform_generic_checks(output, input)?;
+        unsafe { self.discard_convert_ggsw_ciphertext_unchecked(output, input) };
+        Ok(())
+    }
+
+    unsafe fn discard_convert_ggsw_ciphertext_unchecked(
+        &mut self,
+        output: &mut FftFourierGgswCiphertext64,
+        input: &GgswCiphertext64,
+    ) {
+        let fft = Fft::new(input.polynomial_size());
+        let fft = fft.as_view();
+        self.resize(
+            fill_with_forward_fourier_scratch(fft)
+                .unwrap()
+                .unaligned_bytes_required(),
+        );
+        output.0.as_mut_view().fill_with_forward_fourier(
+            StandardGgswCiphertextView::new(
+                input.0.tensor.as_slice(),
+                input.polynomial_size(),
+                input.glwe_dimension().to_glwe_size(),
+                input.decomposition_base_log(),
+                input.decomposition_level_count(),
+            ),
+            fft,
+            self.stack(),
+        );
+    }
+}
+
+/// # Description
+///
+/// Implementation of [`GgswCiphertextConversionEngine`] for [`FftEngine`] that operates on 32
+/// bit integers. It converts a GGSW ciphertext from the standard to the Fourier domain.
+impl GgswCiphertextConversionEngine<GgswCiphertext32, FftFourierGgswCiphertext32> for FftEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u32 << 20;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let key: GlweSecretKey32 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    ///
+    /// // We encrypt a GGSW ciphertext in the standard domain
+    /// let ciphertext =
+    ///     default_engine.encrypt_scalar_ggsw_ciphertext(&key, &plaintext, noise, level, base_log)?;
+    ///
+    /// // Then we convert it to the Fourier domain.
+    /// let fourier_ciphertext: FftFourierGgswCiphertext32 =
+    ///     fft_engine.convert_ggsw_ciphertext(&ciphertext)?;
+    ///
+    /// assert_eq!(fourier_ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(fourier_ciphertext.polynomial_size(), polynomial_size);
+    /// assert_eq!(fourier_ciphertext.decomposition_base_log(), base_log);
+    /// assert_eq!(fourier_ciphertext.decomposition_level_count(), level);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn convert_ggsw_ciphertext(
+        &mut self,
+        input: &GgswCiphertext32,
+    ) -> Result<FftFourierGgswCiphertext32, GgswCiphertextConversionError<Self::EngineError>> {
+        FftEngine::check_supported_size(input.0.polynomial_size())?;
+        Ok(unsafe { self.convert_ggsw_ciphertext_unchecked(input) })
+    }
+
+    unsafe fn convert_ggsw_ciphertext_unchecked(
+        &mut self,
+        input: &GgswCiphertext32,
+    ) -> FftFourierGgswCiphertext32 {
+        let glwe_size = input.glwe_dimension().to_glwe_size();
+        let mut output = FftFourierGgswCiphertext32(FourierGgswCiphertext::new(
+            avec![
+                c64::default();
+                (input.polynomial_size().0
+                    * glwe_size.0
+                    * glwe_size.0
+                    * input.decomposition_level_count().0)
+                    / 2
+            ]
+            .into_boxed_slice(),
+            input.polynomial_size(),
+            glwe_size,
+            input.decomposition_base_log(),
+            input.decomposition_level_count(),
+        ));
+
+        self.discard_convert_ggsw_ciphertext_unchecked(&mut output, input);
+        output
+    }
+}
+
+/// # Description
+///
+/// Implementation of [`GgswCiphertextConversionEngine`] for [`FftEngine`] that operates on 64
+/// bit integers. It converts a GGSW ciphertext from the standard to the Fourier domain.
+impl GgswCiphertextConversionEngine<GgswCiphertext64, FftFourierGgswCiphertext64> for FftEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = 3_u64 << 50;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let key: GlweSecretKey64 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    ///
+    /// // We encrypt a GGSW ciphertext in the standard domain
+    /// let ciphertext =
+    ///     default_engine.encrypt_scalar_ggsw_ciphertext(&key, &plaintext, noise, level, base_log)?;
+    ///
+    /// // Then we convert it to the Fourier domain.
+    /// let fourier_ciphertext: FftFourierGgswCiphertext64 =
+    ///     fft_engine.convert_ggsw_ciphertext(&ciphertext)?;
+    ///
+    /// assert_eq!(fourier_ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(fourier_ciphertext.polynomial_size(), polynomial_size);
+    /// assert_eq!(fourier_ciphertext.decomposition_base_log(), base_log);
+    /// assert_eq!(fourier_ciphertext.decomposition_level_count(), level);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn convert_ggsw_ciphertext(
+        &mut self,
+        input: &GgswCiphertext64,
+    ) -> Result<FftFourierGgswCiphertext64, GgswCiphertextConversionError<Self::EngineError>> {
+        FftEngine::check_supported_size(input.0.polynomial_size())?;
+        Ok(unsafe { self.convert_ggsw_ciphertext_unchecked(input) })
+    }
+
+    unsafe fn convert_ggsw_ciphertext_unchecked(
+        &mut self,
+        input: &GgswCiphertext64,
+    ) -> FftFourierGgswCiphertext64 {
+        let glwe_size = input.glwe_dimension().to_glwe_size();
+        let mut output = FftFourierGgswCiphertext64(FourierGgswCiphertext::new(
+            avec![
+                c64::default();
+                (input.polynomial_size().0
+                    * glwe_size.0
+                    * glwe_size.0
+                    * input.decomposition_level_count().0)
+                    / 2
+            ]
+            .into_boxed_slice(),
+            input.polynomial_size(),
+            glwe_size,
+            input.decomposition_base_log(),
+            input.decomposition_level_count(),
+        ));
+
+        self.discard_convert_ggsw_ciphertext_unchecked(&mut output, input);
+        output
+    }
+}

--- a/concrete-core/src/backends/fft/implementation/engines/glwe_ciphertext_ggsw_ciphertext_discarding_external_product.rs
+++ b/concrete-core/src/backends/fft/implementation/engines/glwe_ciphertext_ggsw_ciphertext_discarding_external_product.rs
@@ -1,0 +1,243 @@
+use super::super::super::entities::{FftFourierGgswCiphertext32, FftFourierGgswCiphertext64};
+use super::super::super::private::crypto::ggsw::{external_product, external_product_scratch};
+use super::super::super::private::crypto::glwe::{GlweCiphertextMutView, GlweCiphertextView};
+use super::super::super::private::math::fft::Fft;
+use super::{FftEngine, FftError};
+use crate::commons::math::tensor::{AsMutSlice, AsRefSlice};
+use crate::prelude::{
+    GlweCiphertext32, GlweCiphertext64,
+    GlweCiphertextGgswCiphertextDiscardingExternalProductEngine,
+    GlweCiphertextGgswCiphertextDiscardingExternalProductError,
+};
+
+impl From<FftError> for GlweCiphertextGgswCiphertextDiscardingExternalProductError<FftError> {
+    fn from(err: FftError) -> Self {
+        Self::Engine(err)
+    }
+}
+
+/// # Description
+///
+/// Implementation of [`GlweCiphertextGgswCiphertextDiscardingExternalProductEngine`] for
+/// [`FftEngine`] that operates on 32 bit integers.
+impl
+    GlweCiphertextGgswCiphertextDiscardingExternalProductEngine<
+        GlweCiphertext32,
+        FftFourierGgswCiphertext32,
+        GlweCiphertext32,
+    > for FftEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input_ggsw = 3_u32 << 20;
+    /// let input_glwe = vec![3_u32 << 20; polynomial_size.0];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let key: GlweSecretKey32 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext_ggsw = default_engine.create_plaintext(&input_ggsw)?;
+    /// let plaintext_glwe = default_engine.create_plaintext_vector(&input_glwe)?;
+    ///
+    /// let ggsw = default_engine.encrypt_scalar_ggsw_ciphertext(
+    ///     &key,
+    ///     &plaintext_ggsw,
+    ///     noise,
+    ///     level,
+    ///     base_log,
+    /// )?;
+    /// let complex_ggsw: FftFourierGgswCiphertext32 = fft_engine.convert_ggsw_ciphertext(&ggsw)?;
+    /// let glwe = default_engine.encrypt_glwe_ciphertext(&key, &plaintext_glwe, noise)?;
+    ///
+    /// // We allocate an output ciphertext simply by cloning the input.
+    /// // The content of this output ciphertext will by wiped by the external product.
+    /// let mut product = glwe.clone();
+    /// fft_engine.discard_compute_external_product_glwe_ciphertext_ggsw_ciphertext(
+    ///     &glwe,
+    ///     &complex_ggsw,
+    ///     &mut product,
+    /// )?;
+    /// #
+    /// # assert_eq!(
+    /// #     product.polynomial_size(),
+    /// #     glwe.polynomial_size(),
+    /// # );
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_compute_external_product_glwe_ciphertext_ggsw_ciphertext(
+        &mut self,
+        glwe_input: &GlweCiphertext32,
+        ggsw_input: &FftFourierGgswCiphertext32,
+        output: &mut GlweCiphertext32,
+    ) -> Result<(), GlweCiphertextGgswCiphertextDiscardingExternalProductError<Self::EngineError>>
+    {
+        FftEngine::check_supported_size(glwe_input.0.polynomial_size())?;
+        GlweCiphertextGgswCiphertextDiscardingExternalProductError::perform_generic_checks(
+            glwe_input, ggsw_input, output,
+        )?;
+        unsafe {
+            self.discard_compute_external_product_glwe_ciphertext_ggsw_ciphertext_unchecked(
+                glwe_input, ggsw_input, output,
+            )
+        };
+        Ok(())
+    }
+
+    unsafe fn discard_compute_external_product_glwe_ciphertext_ggsw_ciphertext_unchecked(
+        &mut self,
+        glwe_input: &GlweCiphertext32,
+        ggsw_input: &FftFourierGgswCiphertext32,
+        output: &mut GlweCiphertext32,
+    ) {
+        let glwe_size = glwe_input.0.size();
+        let polynomial_size = glwe_input.0.polynomial_size();
+        let fft = Fft::new(polynomial_size);
+        let fft = fft.as_view();
+        self.resize(
+            external_product_scratch::<u32>(glwe_size, polynomial_size, fft)
+                .unwrap()
+                .unaligned_bytes_required(),
+        );
+        let stack = self.stack();
+        let out =
+            GlweCiphertextMutView::new(output.0.tensor.as_mut_slice(), polynomial_size, glwe_size);
+        let ggsw = ggsw_input.0.as_view();
+        let glwe =
+            GlweCiphertextView::new(glwe_input.0.tensor.as_slice(), polynomial_size, glwe_size);
+        external_product(out, ggsw, glwe, fft, stack)
+    }
+}
+
+/// # Description
+///
+/// Implementation of [`GlweCiphertextGgswCiphertextDiscardingExternalProductEngine`] for
+/// [`FftEngine`] that operates on 64 bit integers.
+impl
+    GlweCiphertextGgswCiphertextDiscardingExternalProductEngine<
+        GlweCiphertext64,
+        FftFourierGgswCiphertext64,
+        GlweCiphertext64,
+    > for FftEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input_ggsw = 3_u64 << 50;
+    /// let input_glwe = vec![3_u64 << 50; polynomial_size.0];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let key: GlweSecretKey64 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext_ggsw = default_engine.create_plaintext(&input_ggsw)?;
+    /// let plaintext_glwe = default_engine.create_plaintext_vector(&input_glwe)?;
+    ///
+    /// let ggsw = default_engine.encrypt_scalar_ggsw_ciphertext(
+    ///     &key,
+    ///     &plaintext_ggsw,
+    ///     noise,
+    ///     level,
+    ///     base_log,
+    /// )?;
+    /// let complex_ggsw: FftFourierGgswCiphertext64 = fft_engine.convert_ggsw_ciphertext(&ggsw)?;
+    /// let glwe = default_engine.encrypt_glwe_ciphertext(&key, &plaintext_glwe, noise)?;
+    ///
+    /// // We allocate an output ciphertext simply by cloning the input.
+    /// // The content of this output ciphertext will by wiped by the external product.
+    /// let mut product = glwe.clone();
+    /// fft_engine.discard_compute_external_product_glwe_ciphertext_ggsw_ciphertext(
+    ///     &glwe,
+    ///     &complex_ggsw,
+    ///     &mut product,
+    /// )?;
+    /// #
+    /// # assert_eq!(
+    /// #     product.polynomial_size(),
+    /// #     glwe.polynomial_size(),
+    /// # );
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_compute_external_product_glwe_ciphertext_ggsw_ciphertext(
+        &mut self,
+        glwe_input: &GlweCiphertext64,
+        ggsw_input: &FftFourierGgswCiphertext64,
+        output: &mut GlweCiphertext64,
+    ) -> Result<(), GlweCiphertextGgswCiphertextDiscardingExternalProductError<Self::EngineError>>
+    {
+        FftEngine::check_supported_size(glwe_input.0.polynomial_size())?;
+        GlweCiphertextGgswCiphertextDiscardingExternalProductError::perform_generic_checks(
+            glwe_input, ggsw_input, output,
+        )?;
+        unsafe {
+            self.discard_compute_external_product_glwe_ciphertext_ggsw_ciphertext_unchecked(
+                glwe_input, ggsw_input, output,
+            )
+        };
+        Ok(())
+    }
+
+    unsafe fn discard_compute_external_product_glwe_ciphertext_ggsw_ciphertext_unchecked(
+        &mut self,
+        glwe_input: &GlweCiphertext64,
+        ggsw_input: &FftFourierGgswCiphertext64,
+        output: &mut GlweCiphertext64,
+    ) {
+        let glwe_size = glwe_input.0.size();
+        let polynomial_size = glwe_input.0.polynomial_size();
+        let fft = Fft::new(polynomial_size);
+        let fft = fft.as_view();
+        self.resize(
+            external_product_scratch::<u64>(glwe_size, polynomial_size, fft)
+                .unwrap()
+                .unaligned_bytes_required(),
+        );
+        let stack = self.stack();
+        let out =
+            GlweCiphertextMutView::new(output.0.tensor.as_mut_slice(), polynomial_size, glwe_size);
+        let ggsw = ggsw_input.0.as_view();
+        let glwe =
+            GlweCiphertextView::new(glwe_input.0.tensor.as_slice(), polynomial_size, glwe_size);
+        external_product(out, ggsw, glwe, fft, stack)
+    }
+}

--- a/concrete-core/src/backends/fft/implementation/engines/glwe_ciphertexts_ggsw_ciphertext_fusing_cmux.rs
+++ b/concrete-core/src/backends/fft/implementation/engines/glwe_ciphertexts_ggsw_ciphertext_fusing_cmux.rs
@@ -1,0 +1,259 @@
+use super::super::super::private::crypto::ggsw::{cmux, cmux_scratch};
+use super::super::super::private::crypto::glwe::GlweCiphertextMutView;
+use super::super::super::private::math::fft::Fft;
+use super::{FftEngine, FftError};
+use crate::commons::math::tensor::AsMutSlice;
+use crate::prelude::{
+    FftFourierGgswCiphertext32, FftFourierGgswCiphertext64, GlweCiphertext32, GlweCiphertext64,
+    GlweCiphertextsGgswCiphertextFusingCmuxEngine, GlweCiphertextsGgswCiphertextFusingCmuxError,
+};
+
+impl From<FftError> for GlweCiphertextsGgswCiphertextFusingCmuxError<FftError> {
+    fn from(err: FftError) -> Self {
+        Self::Engine(err)
+    }
+}
+
+/// # Description
+///
+/// Implementation of [`GlweCiphertextsGgswCiphertextFusingCmuxEngine`] for [`FftEngine`] that
+/// operates on 32 bit integers.
+impl
+    GlweCiphertextsGgswCiphertextFusingCmuxEngine<
+        GlweCiphertext32,
+        GlweCiphertext32,
+        FftFourierGgswCiphertext32,
+    > for FftEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purposes, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 20 buts)
+    /// let input_ggsw = 1_u32 << 20;
+    /// let output_glwe = vec![1_u32 << 20; polynomial_size.0];
+    /// let input_glwe = vec![3_u32 << 20; polynomial_size.0];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let key: GlweSecretKey32 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext_ggsw = default_engine.create_plaintext(&input_ggsw)?;
+    /// let plaintext_output_glwe = default_engine.create_plaintext_vector(&output_glwe)?;
+    /// let plaintext_input_glwe = default_engine.create_plaintext_vector(&input_glwe)?;
+    ///
+    /// let ggsw = default_engine.encrypt_scalar_ggsw_ciphertext(
+    ///     &key,
+    ///     &plaintext_ggsw,
+    ///     noise,
+    ///     level,
+    ///     base_log,
+    /// )?;
+    /// let complex_ggsw: FftFourierGgswCiphertext32 = fft_engine.convert_ggsw_ciphertext(&ggsw)?;
+    /// let mut glwe_output =
+    ///     default_engine.encrypt_glwe_ciphertext(&key, &plaintext_output_glwe, noise)?;
+    /// let mut glwe_input =
+    ///     default_engine.encrypt_glwe_ciphertext(&key, &plaintext_input_glwe, noise)?;
+    ///
+    /// // Compute the cmux.
+    /// fft_engine.fuse_cmux_glwe_ciphertexts_ggsw_ciphertext(
+    ///     &mut glwe_output,
+    ///     &mut glwe_input,
+    ///     &complex_ggsw,
+    /// )?;
+    /// #
+    /// assert_eq!(glwe_output.polynomial_size(), glwe_input.polynomial_size(),);
+    /// assert_eq!(glwe_output.glwe_dimension(), glwe_input.glwe_dimension(),);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn fuse_cmux_glwe_ciphertexts_ggsw_ciphertext(
+        &mut self,
+        glwe_output: &mut GlweCiphertext32,
+        glwe_input: &mut GlweCiphertext32,
+        ggsw_input: &FftFourierGgswCiphertext32,
+    ) -> Result<(), GlweCiphertextsGgswCiphertextFusingCmuxError<Self::EngineError>> {
+        FftEngine::check_supported_size(glwe_output.0.polynomial_size())?;
+        GlweCiphertextsGgswCiphertextFusingCmuxError::perform_generic_checks(
+            glwe_output,
+            glwe_input,
+            ggsw_input,
+        )?;
+        unsafe {
+            self.fuse_cmux_glwe_ciphertexts_ggsw_ciphertext_unchecked(
+                glwe_output,
+                glwe_input,
+                ggsw_input,
+            )
+        };
+        Ok(())
+    }
+
+    unsafe fn fuse_cmux_glwe_ciphertexts_ggsw_ciphertext_unchecked(
+        &mut self,
+        glwe_output: &mut GlweCiphertext32,
+        glwe_input: &mut GlweCiphertext32,
+        ggsw_input: &FftFourierGgswCiphertext32,
+    ) {
+        let glwe_size = glwe_input.0.size();
+        let polynomial_size = glwe_input.0.polynomial_size();
+        let fft = Fft::new(polynomial_size);
+        let fft = fft.as_view();
+        self.resize(
+            cmux_scratch::<u32>(glwe_size, polynomial_size, fft)
+                .unwrap()
+                .unaligned_bytes_required(),
+        );
+        let stack = self.stack();
+        let glwe_output = GlweCiphertextMutView::new(
+            glwe_output.0.tensor.as_mut_slice(),
+            polynomial_size,
+            glwe_size,
+        );
+        let glwe_input = GlweCiphertextMutView::new(
+            glwe_input.0.tensor.as_mut_slice(),
+            polynomial_size,
+            glwe_size,
+        );
+        cmux(glwe_output, glwe_input, ggsw_input.0.as_view(), fft, stack);
+    }
+}
+
+/// # Description
+///
+/// Implementation of [`GlweCiphertextsGgswCiphertextFusingCmuxEngine`] for [`FftEngine`] that
+/// operates on 64 bit integers.
+impl
+    GlweCiphertextsGgswCiphertextFusingCmuxEngine<
+        GlweCiphertext64,
+        GlweCiphertext64,
+        FftFourierGgswCiphertext64,
+    > for FftEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purposes, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 50 buts)
+    /// let input_ggsw = 1_u64 << 50;
+    /// let output_glwe = vec![1_u64 << 50; polynomial_size.0];
+    /// let input_glwe = vec![3_u64 << 50; polynomial_size.0];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let key: GlweSecretKey64 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext_ggsw = default_engine.create_plaintext(&input_ggsw)?;
+    /// let plaintext_output_glwe = default_engine.create_plaintext_vector(&output_glwe)?;
+    /// let plaintext_input_glwe = default_engine.create_plaintext_vector(&input_glwe)?;
+    ///
+    /// let ggsw = default_engine.encrypt_scalar_ggsw_ciphertext(
+    ///     &key,
+    ///     &plaintext_ggsw,
+    ///     noise,
+    ///     level,
+    ///     base_log,
+    /// )?;
+    /// let complex_ggsw: FftFourierGgswCiphertext64 = fft_engine.convert_ggsw_ciphertext(&ggsw)?;
+    /// let mut glwe_output =
+    ///     default_engine.encrypt_glwe_ciphertext(&key, &plaintext_output_glwe, noise)?;
+    /// let mut glwe_input =
+    ///     default_engine.encrypt_glwe_ciphertext(&key, &plaintext_input_glwe, noise)?;
+    ///
+    /// // Compute the cmux.
+    /// fft_engine.fuse_cmux_glwe_ciphertexts_ggsw_ciphertext(
+    ///     &mut glwe_output,
+    ///     &mut glwe_input,
+    ///     &complex_ggsw,
+    /// )?;
+    /// #
+    /// assert_eq!(glwe_output.polynomial_size(), glwe_input.polynomial_size(),);
+    /// assert_eq!(glwe_output.glwe_dimension(), glwe_input.glwe_dimension(),);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn fuse_cmux_glwe_ciphertexts_ggsw_ciphertext(
+        &mut self,
+        glwe_output: &mut GlweCiphertext64,
+        glwe_input: &mut GlweCiphertext64,
+        ggsw_input: &FftFourierGgswCiphertext64,
+    ) -> Result<(), GlweCiphertextsGgswCiphertextFusingCmuxError<Self::EngineError>> {
+        FftEngine::check_supported_size(glwe_output.0.polynomial_size())?;
+        GlweCiphertextsGgswCiphertextFusingCmuxError::perform_generic_checks(
+            glwe_output,
+            glwe_input,
+            ggsw_input,
+        )?;
+        unsafe {
+            self.fuse_cmux_glwe_ciphertexts_ggsw_ciphertext_unchecked(
+                glwe_output,
+                glwe_input,
+                ggsw_input,
+            )
+        };
+        Ok(())
+    }
+
+    unsafe fn fuse_cmux_glwe_ciphertexts_ggsw_ciphertext_unchecked(
+        &mut self,
+        glwe_output: &mut GlweCiphertext64,
+        glwe_input: &mut GlweCiphertext64,
+        ggsw_input: &FftFourierGgswCiphertext64,
+    ) {
+        let glwe_size = glwe_input.0.size();
+        let polynomial_size = glwe_input.0.polynomial_size();
+        let fft = Fft::new(polynomial_size);
+        let fft = fft.as_view();
+        self.resize(
+            cmux_scratch::<u64>(glwe_size, polynomial_size, fft)
+                .unwrap()
+                .unaligned_bytes_required(),
+        );
+        let stack = self.stack();
+        let glwe_output = GlweCiphertextMutView::new(
+            glwe_output.0.tensor.as_mut_slice(),
+            polynomial_size,
+            glwe_size,
+        );
+        let glwe_input = GlweCiphertextMutView::new(
+            glwe_input.0.tensor.as_mut_slice(),
+            polynomial_size,
+            glwe_size,
+        );
+        cmux(glwe_output, glwe_input, ggsw_input.0.as_view(), fft, stack);
+    }
+}

--- a/concrete-core/src/backends/fft/implementation/engines/lwe_bootstrap_key_conversion.rs
+++ b/concrete-core/src/backends/fft/implementation/engines/lwe_bootstrap_key_conversion.rs
@@ -1,0 +1,233 @@
+use super::super::super::private::crypto::bootstrap::{
+    fill_with_forward_fourier_scratch, FourierLweBootstrapKey, StandardLweBootstrapKeyView,
+};
+use super::super::super::private::math::fft::Fft;
+use super::{FftEngine, FftError};
+use crate::commons::math::tensor::AsRefSlice;
+use crate::prelude::{
+    FftFourierLweBootstrapKey32, FftFourierLweBootstrapKey64, LweBootstrapKey32, LweBootstrapKey64,
+    LweBootstrapKeyConversionEngine, LweBootstrapKeyConversionError, LweBootstrapKeyEntity,
+};
+use aligned_vec::avec;
+use concrete_fft::c64;
+
+impl From<FftError> for LweBootstrapKeyConversionError<FftError> {
+    fn from(err: FftError) -> Self {
+        Self::Engine(err)
+    }
+}
+
+/// # Description
+///
+/// Implementation of [`LweBootstrapKeyConversionEngine`] for [`FftEngine`] that operates on
+/// 32 bit integers. It converts a bootstrap key from the standard to the Fourier domain.
+impl LweBootstrapKeyConversionEngine<LweBootstrapKey32, FftFourierLweBootstrapKey32> for FftEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let (lwe_dim, glwe_dim, poly_size) = (LweDimension(4), GlweDimension(6), PolynomialSize(256));
+    /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let lwe_sk: LweSecretKey32 = default_engine.create_lwe_secret_key(lwe_dim)?;
+    /// let glwe_sk: GlweSecretKey32 = default_engine.create_glwe_secret_key(glwe_dim, poly_size)?;
+    /// let bsk: LweBootstrapKey32 =
+    ///     default_engine.create_lwe_bootstrap_key(&lwe_sk, &glwe_sk, dec_bl, dec_lc, noise)?;
+    ///
+    /// let fourier_bsk: FftFourierLweBootstrapKey32 = fft_engine.convert_lwe_bootstrap_key(&bsk)?;
+    /// #
+    /// assert_eq!(fourier_bsk.glwe_dimension(), glwe_dim);
+    /// assert_eq!(fourier_bsk.polynomial_size(), poly_size);
+    /// assert_eq!(fourier_bsk.input_lwe_dimension(), lwe_dim);
+    /// assert_eq!(fourier_bsk.decomposition_base_log(), dec_bl);
+    /// assert_eq!(fourier_bsk.decomposition_level_count(), dec_lc);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn convert_lwe_bootstrap_key(
+        &mut self,
+        input: &LweBootstrapKey32,
+    ) -> Result<FftFourierLweBootstrapKey32, LweBootstrapKeyConversionError<Self::EngineError>>
+    {
+        FftEngine::check_supported_size(input.0.polynomial_size())?;
+        Ok(unsafe { self.convert_lwe_bootstrap_key_unchecked(input) })
+    }
+
+    unsafe fn convert_lwe_bootstrap_key_unchecked(
+        &mut self,
+        input: &LweBootstrapKey32,
+    ) -> FftFourierLweBootstrapKey32 {
+        let glwe_size = input.0.glwe_size();
+
+        let boxed = avec![
+            c64::default();
+            input.0.polynomial_size().0
+                * input.0.key_size().0
+                * input.0.level_count().0
+                * glwe_size.0
+                * glwe_size.0
+                / 2
+        ]
+        .into_boxed_slice();
+        let fft = Fft::new(input.0.polynomial_size());
+        let fft = fft.as_view();
+        self.resize(
+            fill_with_forward_fourier_scratch(fft)
+                .unwrap()
+                .unaligned_bytes_required(),
+        );
+        let stack = self.stack();
+
+        let mut output = FourierLweBootstrapKey::new(
+            boxed,
+            input.0.key_size(),
+            input.0.polynomial_size(),
+            input.0.glwe_size(),
+            input.0.base_log(),
+            input.0.level_count(),
+        );
+        let input = StandardLweBootstrapKeyView::new(
+            input.0.tensor.as_slice(),
+            input.0.key_size(),
+            input.0.polynomial_size(),
+            input.0.glwe_size(),
+            input.0.base_log(),
+            input.0.level_count(),
+        );
+        output
+            .as_mut_view()
+            .fill_with_forward_fourier(input, fft, stack);
+        FftFourierLweBootstrapKey32(output)
+    }
+}
+
+/// # Description
+///
+/// Implementation of [`LweBootstrapKeyConversionEngine`] for [`FftEngine`] that operates on
+/// 64 bit integers. It converts a bootstrap key from the standard to the Fourier domain.
+impl LweBootstrapKeyConversionEngine<LweBootstrapKey64, FftFourierLweBootstrapKey64> for FftEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let (lwe_dim, glwe_dim, poly_size) = (LweDimension(4), GlweDimension(6), PolynomialSize(256));
+    /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let lwe_sk: LweSecretKey64 = default_engine.create_lwe_secret_key(lwe_dim)?;
+    /// let glwe_sk: GlweSecretKey64 = default_engine.create_glwe_secret_key(glwe_dim, poly_size)?;
+    /// let bsk: LweBootstrapKey64 =
+    ///     default_engine.create_lwe_bootstrap_key(&lwe_sk, &glwe_sk, dec_bl, dec_lc, noise)?;
+    ///
+    /// let fourier_bsk: FftFourierLweBootstrapKey64 = fft_engine.convert_lwe_bootstrap_key(&bsk)?;
+    /// #
+    /// assert_eq!(fourier_bsk.glwe_dimension(), glwe_dim);
+    /// assert_eq!(fourier_bsk.polynomial_size(), poly_size);
+    /// assert_eq!(fourier_bsk.input_lwe_dimension(), lwe_dim);
+    /// assert_eq!(fourier_bsk.decomposition_base_log(), dec_bl);
+    /// assert_eq!(fourier_bsk.decomposition_level_count(), dec_lc);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn convert_lwe_bootstrap_key(
+        &mut self,
+        input: &LweBootstrapKey64,
+    ) -> Result<FftFourierLweBootstrapKey64, LweBootstrapKeyConversionError<Self::EngineError>>
+    {
+        FftEngine::check_supported_size(input.0.polynomial_size())?;
+        Ok(unsafe { self.convert_lwe_bootstrap_key_unchecked(input) })
+    }
+
+    unsafe fn convert_lwe_bootstrap_key_unchecked(
+        &mut self,
+        input: &LweBootstrapKey64,
+    ) -> FftFourierLweBootstrapKey64 {
+        let glwe_size = input.0.glwe_size();
+
+        let boxed = avec![
+            c64::default();
+            input.0.polynomial_size().0
+                * input.0.key_size().0
+                * input.0.level_count().0
+                * glwe_size.0
+                * glwe_size.0
+                / 2
+        ]
+        .into_boxed_slice();
+
+        let fft = Fft::new(input.0.polynomial_size());
+        let fft = fft.as_view();
+        self.resize(
+            fill_with_forward_fourier_scratch(fft)
+                .unwrap()
+                .unaligned_bytes_required(),
+        );
+        let stack = self.stack();
+
+        let mut output = FourierLweBootstrapKey::new(
+            boxed,
+            input.0.key_size(),
+            input.0.polynomial_size(),
+            input.0.glwe_size(),
+            input.0.base_log(),
+            input.0.level_count(),
+        );
+        let input = StandardLweBootstrapKeyView::new(
+            input.0.tensor.as_slice(),
+            input.0.key_size(),
+            input.0.polynomial_size(),
+            input.0.glwe_size(),
+            input.0.base_log(),
+            input.0.level_count(),
+        );
+        output
+            .as_mut_view()
+            .fill_with_forward_fourier(input, fft, stack);
+        FftFourierLweBootstrapKey64(output)
+    }
+}
+
+impl<Key> LweBootstrapKeyConversionEngine<Key, Key> for FftEngine
+where
+    Key: LweBootstrapKeyEntity + Clone,
+{
+    fn convert_lwe_bootstrap_key(
+        &mut self,
+        input: &Key,
+    ) -> Result<Key, LweBootstrapKeyConversionError<Self::EngineError>> {
+        Ok(unsafe { self.convert_lwe_bootstrap_key_unchecked(input) })
+    }
+
+    unsafe fn convert_lwe_bootstrap_key_unchecked(&mut self, input: &Key) -> Key {
+        (*input).clone()
+    }
+}

--- a/concrete-core/src/backends/fft/implementation/engines/lwe_ciphertext_discarding_bootstrap.rs
+++ b/concrete-core/src/backends/fft/implementation/engines/lwe_ciphertext_discarding_bootstrap.rs
@@ -1,0 +1,483 @@
+use super::super::super::private::crypto::bootstrap::bootstrap_scratch;
+use super::super::super::private::crypto::glwe::GlweCiphertextView;
+use super::super::super::private::math::fft::Fft;
+use super::{FftEngine, FftError};
+use crate::commons::math::tensor::{AsMutSlice, AsRefSlice};
+use crate::prelude::{
+    FftFourierLweBootstrapKey32, FftFourierLweBootstrapKey64, GlweCiphertext32, GlweCiphertext64,
+    GlweCiphertextView32, GlweCiphertextView64, LweCiphertext32, LweCiphertext64,
+    LweCiphertextDiscardingBootstrapEngine, LweCiphertextDiscardingBootstrapError,
+    LweCiphertextMutView32, LweCiphertextMutView64, LweCiphertextView32, LweCiphertextView64,
+};
+
+impl From<FftError> for LweCiphertextDiscardingBootstrapError<FftError> {
+    fn from(err: FftError) -> Self {
+        Self::Engine(err)
+    }
+}
+
+/// # Description
+///
+/// Implementation of [`LweCiphertextDiscardingBootstrapEngine`] for [`FftEngine`] that operates
+/// on 32 bit integers.
+impl
+    LweCiphertextDiscardingBootstrapEngine<
+        FftFourierLweBootstrapKey32,
+        GlweCiphertext32,
+        LweCiphertext32,
+        LweCiphertext32,
+    > for FftEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u32 << 20;
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let (lwe_dim, lwe_dim_output, glwe_dim, poly_size) = (
+    ///     LweDimension(4),
+    ///     LweDimension(1024),
+    ///     GlweDimension(1),
+    ///     PolynomialSize(1024),
+    /// );
+    /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
+    /// // A constant function is applied during the bootstrap
+    /// let lut = vec![8_u32 << 20; poly_size.0];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let lwe_sk: LweSecretKey32 = default_engine.create_lwe_secret_key(lwe_dim)?;
+    /// let glwe_sk: GlweSecretKey32 = default_engine.create_glwe_secret_key(glwe_dim, poly_size)?;
+    /// let bsk: LweBootstrapKey32 =
+    ///     default_engine.create_lwe_bootstrap_key(&lwe_sk, &glwe_sk, dec_bl, dec_lc, noise)?;
+    /// let bsk: FftFourierLweBootstrapKey32 = fft_engine.convert_lwe_bootstrap_key(&bsk)?;
+    /// let lwe_sk_output: LweSecretKey32 = default_engine.create_lwe_secret_key(lwe_dim_output)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    /// let plaintext_vector = default_engine.create_plaintext_vector(&lut)?;
+    /// let acc = default_engine
+    ///     .trivially_encrypt_glwe_ciphertext(glwe_dim.to_glwe_size(), &plaintext_vector)?;
+    /// let input = default_engine.encrypt_lwe_ciphertext(&lwe_sk, &plaintext, noise)?;
+    /// let mut output = default_engine.zero_encrypt_lwe_ciphertext(&lwe_sk_output, noise)?;
+    ///
+    /// fft_engine.discard_bootstrap_lwe_ciphertext(&mut output, &input, &acc, &bsk)?;
+    /// #
+    /// assert_eq!(output.lwe_dimension(), lwe_dim_output);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_bootstrap_lwe_ciphertext(
+        &mut self,
+        output: &mut LweCiphertext32,
+        input: &LweCiphertext32,
+        acc: &GlweCiphertext32,
+        bsk: &FftFourierLweBootstrapKey32,
+    ) -> Result<(), LweCiphertextDiscardingBootstrapError<Self::EngineError>> {
+        if !(acc.0.polynomial_size().0.is_power_of_two() && acc.0.polynomial_size().0 >= 32) {
+            return Err(LweCiphertextDiscardingBootstrapError::from(
+                FftError::UnsupportedPolynomialSize,
+            ));
+        }
+        LweCiphertextDiscardingBootstrapError::perform_generic_checks(output, input, acc, bsk)?;
+        unsafe { self.discard_bootstrap_lwe_ciphertext_unchecked(output, input, acc, bsk) };
+        Ok(())
+    }
+
+    unsafe fn discard_bootstrap_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut LweCiphertext32,
+        input: &LweCiphertext32,
+        acc: &GlweCiphertext32,
+        bsk: &FftFourierLweBootstrapKey32,
+    ) {
+        let fft = Fft::new(acc.0.polynomial_size());
+        let fft = fft.as_view();
+        self.resize(
+            bootstrap_scratch::<u32>(acc.0.size(), acc.0.polynomial_size(), fft)
+                .unwrap()
+                .unaligned_bytes_required(),
+        );
+        let acc = GlweCiphertextView::new(
+            acc.0.tensor.as_slice(),
+            acc.0.polynomial_size(),
+            acc.0.size(),
+        );
+        bsk.0.as_view().bootstrap(
+            output.0.tensor.as_mut_slice(),
+            input.0.tensor.as_slice(),
+            acc,
+            fft,
+            self.stack(),
+        );
+    }
+}
+
+/// # Description
+///
+/// Implementation of [`LweCiphertextDiscardingBootstrapEngine`] for [`FftEngine`] that operates
+/// on 64 bit integers.
+impl
+    LweCiphertextDiscardingBootstrapEngine<
+        FftFourierLweBootstrapKey64,
+        GlweCiphertext64,
+        LweCiphertext64,
+        LweCiphertext64,
+    > for FftEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = 3_u64 << 50;
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let (lwe_dim, lwe_dim_output, glwe_dim, poly_size) = (
+    ///     LweDimension(4),
+    ///     LweDimension(1024),
+    ///     GlweDimension(1),
+    ///     PolynomialSize(1024),
+    /// );
+    /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
+    /// // A constant function is applied during the bootstrap
+    /// let lut = vec![8_u64 << 50; poly_size.0];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let lwe_sk: LweSecretKey64 = default_engine.create_lwe_secret_key(lwe_dim)?;
+    /// let glwe_sk: GlweSecretKey64 = default_engine.create_glwe_secret_key(glwe_dim, poly_size)?;
+    /// let bsk: LweBootstrapKey64 =
+    ///     default_engine.create_lwe_bootstrap_key(&lwe_sk, &glwe_sk, dec_bl, dec_lc, noise)?;
+    /// let bsk: FftFourierLweBootstrapKey64 = fft_engine.convert_lwe_bootstrap_key(&bsk)?;
+    /// let lwe_sk_output: LweSecretKey64 = default_engine.create_lwe_secret_key(lwe_dim_output)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    /// let plaintext_vector = default_engine.create_plaintext_vector(&lut)?;
+    /// let acc = default_engine
+    ///     .trivially_encrypt_glwe_ciphertext(glwe_dim.to_glwe_size(), &plaintext_vector)?;
+    /// let input = default_engine.encrypt_lwe_ciphertext(&lwe_sk, &plaintext, noise)?;
+    /// let mut output = default_engine.zero_encrypt_lwe_ciphertext(&lwe_sk_output, noise)?;
+    ///
+    /// fft_engine.discard_bootstrap_lwe_ciphertext(&mut output, &input, &acc, &bsk)?;
+    /// #
+    /// assert_eq!(output.lwe_dimension(), lwe_dim_output);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_bootstrap_lwe_ciphertext(
+        &mut self,
+        output: &mut LweCiphertext64,
+        input: &LweCiphertext64,
+        acc: &GlweCiphertext64,
+        bsk: &FftFourierLweBootstrapKey64,
+    ) -> Result<(), LweCiphertextDiscardingBootstrapError<Self::EngineError>> {
+        if !(acc.0.polynomial_size().0.is_power_of_two() && acc.0.polynomial_size().0 >= 32) {
+            return Err(LweCiphertextDiscardingBootstrapError::from(
+                FftError::UnsupportedPolynomialSize,
+            ));
+        }
+        LweCiphertextDiscardingBootstrapError::perform_generic_checks(output, input, acc, bsk)?;
+        unsafe { self.discard_bootstrap_lwe_ciphertext_unchecked(output, input, acc, bsk) };
+        Ok(())
+    }
+
+    unsafe fn discard_bootstrap_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut LweCiphertext64,
+        input: &LweCiphertext64,
+        acc: &GlweCiphertext64,
+        bsk: &FftFourierLweBootstrapKey64,
+    ) {
+        let fft = Fft::new(acc.0.polynomial_size());
+        let fft = fft.as_view();
+        self.resize(
+            bootstrap_scratch::<u64>(acc.0.size(), acc.0.polynomial_size(), fft)
+                .unwrap()
+                .unaligned_bytes_required(),
+        );
+        let acc = GlweCiphertextView::new(
+            acc.0.tensor.as_slice(),
+            acc.0.polynomial_size(),
+            acc.0.size(),
+        );
+        bsk.0.as_view().bootstrap(
+            output.0.tensor.as_mut_slice(),
+            input.0.tensor.as_slice(),
+            acc,
+            fft,
+            self.stack(),
+        );
+    }
+}
+
+/// # Description
+///
+/// Implementation of [`LweCiphertextDiscardingBootstrapEngine`] for [`FftEngine`] that operates
+/// on 32 bit integers.
+impl
+    LweCiphertextDiscardingBootstrapEngine<
+        FftFourierLweBootstrapKey32,
+        GlweCiphertextView32<'_>,
+        LweCiphertextView32<'_>,
+        LweCiphertextMutView32<'_>,
+    > for FftEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// use concrete_core::backends::fft::engines::FftEngine;
+    /// use concrete_core::backends::fft::entities::FftFourierLweBootstrapKey32;
+    /// let input = 3_u32 << 20;
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let (lwe_dim, lwe_dim_output, glwe_dim, poly_size) = (
+    ///     LweDimension(4),
+    ///     LweDimension(1024),
+    ///     GlweDimension(1),
+    ///     PolynomialSize(1024),
+    /// );
+    /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
+    /// // A constant function is applied during the bootstrap
+    /// let lut = vec![8_u32 << 20; poly_size.0];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let lwe_sk: LweSecretKey32 = default_engine.create_lwe_secret_key(lwe_dim)?;
+    /// let glwe_sk: GlweSecretKey32 = default_engine.create_glwe_secret_key(glwe_dim, poly_size)?;
+    /// let bsk: LweBootstrapKey32 =
+    ///     default_engine.create_lwe_bootstrap_key(&lwe_sk, &glwe_sk, dec_bl, dec_lc, noise)?;
+    /// let bsk: FftFourierLweBootstrapKey32 = fft_engine.convert_lwe_bootstrap_key(&bsk)?;
+    /// let lwe_sk_output: LweSecretKey32 = default_engine.create_lwe_secret_key(lwe_dim_output)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    /// let plaintext_vector = default_engine.create_plaintext_vector(&lut)?;
+    /// let acc = default_engine
+    ///     .trivially_encrypt_glwe_ciphertext(glwe_dim.to_glwe_size(), &plaintext_vector)?;
+    ///
+    /// // Get the GlweCiphertext as a View
+    /// let raw_glwe = default_engine.consume_retrieve_glwe_ciphertext(acc)?;
+    /// let acc: GlweCiphertextView32 =
+    ///     default_engine.create_glwe_ciphertext(&raw_glwe[..], poly_size)?;
+    ///
+    /// let mut raw_input_container = vec![0_u32; lwe_sk.lwe_dimension().to_lwe_size().0];
+    /// let input: LweCiphertextMutView32 =
+    ///     default_engine.create_lwe_ciphertext(&mut raw_input_container[..])?;
+    /// let input = default_engine.encrypt_lwe_ciphertext(&lwe_sk, &plaintext, noise)?;
+    ///
+    /// // Convert MutView to View
+    /// let raw_input = default_engine.consume_retrieve_lwe_ciphertext(input)?;
+    /// let input = default_engine.create_lwe_ciphertext(&raw_input[..])?;
+    ///
+    /// let mut raw_output_container = vec![0_u32; lwe_sk_output.lwe_dimension().to_lwe_size().0];
+    /// let mut output = default_engine.create_lwe_ciphertext(&mut raw_output_container[..])?;
+    ///
+    /// fft_engine.discard_bootstrap_lwe_ciphertext(&mut output, &input, &acc, &bsk)?;
+    /// #
+    /// assert_eq!(output.lwe_dimension(), lwe_dim_output);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_bootstrap_lwe_ciphertext(
+        &mut self,
+        output: &mut LweCiphertextMutView32,
+        input: &LweCiphertextView32,
+        acc: &GlweCiphertextView32,
+        bsk: &FftFourierLweBootstrapKey32,
+    ) -> Result<(), LweCiphertextDiscardingBootstrapError<Self::EngineError>> {
+        if !(acc.0.polynomial_size().0.is_power_of_two() && acc.0.polynomial_size().0 >= 32) {
+            return Err(LweCiphertextDiscardingBootstrapError::from(
+                FftError::UnsupportedPolynomialSize,
+            ));
+        }
+        LweCiphertextDiscardingBootstrapError::perform_generic_checks(output, input, acc, bsk)?;
+        unsafe { self.discard_bootstrap_lwe_ciphertext_unchecked(output, input, acc, bsk) };
+        Ok(())
+    }
+
+    unsafe fn discard_bootstrap_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut LweCiphertextMutView32,
+        input: &LweCiphertextView32,
+        acc: &GlweCiphertextView32,
+        bsk: &FftFourierLweBootstrapKey32,
+    ) {
+        let fft = Fft::new(acc.0.polynomial_size());
+        let fft = fft.as_view();
+        self.resize(
+            bootstrap_scratch::<u32>(acc.0.size(), acc.0.polynomial_size(), fft)
+                .unwrap()
+                .unaligned_bytes_required(),
+        );
+        let acc = GlweCiphertextView::new(
+            acc.0.tensor.as_slice(),
+            acc.0.polynomial_size(),
+            acc.0.size(),
+        );
+        bsk.0.as_view().bootstrap(
+            output.0.tensor.as_mut_slice(),
+            input.0.tensor.as_slice(),
+            acc,
+            fft,
+            self.stack(),
+        );
+    }
+}
+
+/// # Description
+///
+/// Implementation of [`LweCiphertextDiscardingBootstrapEngine`] for [`FftEngine`] that operates
+/// on 64 bit integers.
+impl
+    LweCiphertextDiscardingBootstrapEngine<
+        FftFourierLweBootstrapKey64,
+        GlweCiphertextView64<'_>,
+        LweCiphertextView64<'_>,
+        LweCiphertextMutView64<'_>,
+    > for FftEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// use concrete_core::backends::fft::engines::FftEngine;
+    /// use concrete_core::backends::fft::entities::FftFourierLweBootstrapKey32;
+    /// let input = 3_u64 << 20;
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let (lwe_dim, lwe_dim_output, glwe_dim, poly_size) = (
+    ///     LweDimension(4),
+    ///     LweDimension(1024),
+    ///     GlweDimension(1),
+    ///     PolynomialSize(1024),
+    /// );
+    /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
+    /// // A constant function is applied during the bootstrap
+    /// let lut = vec![8_u64 << 20; poly_size.0];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let lwe_sk: LweSecretKey64 = default_engine.create_lwe_secret_key(lwe_dim)?;
+    /// let glwe_sk: GlweSecretKey64 = default_engine.create_glwe_secret_key(glwe_dim, poly_size)?;
+    /// let bsk: LweBootstrapKey64 =
+    ///     default_engine.create_lwe_bootstrap_key(&lwe_sk, &glwe_sk, dec_bl, dec_lc, noise)?;
+    /// let bsk: FftFourierLweBootstrapKey64 = fft_engine.convert_lwe_bootstrap_key(&bsk)?;
+    /// let lwe_sk_output: LweSecretKey64 = default_engine.create_lwe_secret_key(lwe_dim_output)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    /// let plaintext_vector = default_engine.create_plaintext_vector(&lut)?;
+    /// let acc = default_engine
+    ///     .trivially_encrypt_glwe_ciphertext(glwe_dim.to_glwe_size(), &plaintext_vector)?;
+    ///
+    /// // Get the GlweCiphertext as a View
+    /// let raw_glwe = default_engine.consume_retrieve_glwe_ciphertext(acc)?;
+    /// let acc: GlweCiphertextView64 =
+    ///     default_engine.create_glwe_ciphertext(&raw_glwe[..], poly_size)?;
+    ///
+    /// let mut raw_input_container = vec![0_u64; lwe_sk.lwe_dimension().to_lwe_size().0];
+    /// let input: LweCiphertextMutView64 =
+    ///     default_engine.create_lwe_ciphertext(&mut raw_input_container[..])?;
+    /// let input = default_engine.encrypt_lwe_ciphertext(&lwe_sk, &plaintext, noise)?;
+    ///
+    /// // Convert MutView to View
+    /// let raw_input = default_engine.consume_retrieve_lwe_ciphertext(input)?;
+    /// let input = default_engine.create_lwe_ciphertext(&raw_input[..])?;
+    ///
+    /// let mut raw_output_container = vec![0_u64; lwe_sk_output.lwe_dimension().to_lwe_size().0];
+    /// let mut output = default_engine.create_lwe_ciphertext(&mut raw_output_container[..])?;
+    ///
+    /// fft_engine.discard_bootstrap_lwe_ciphertext(&mut output, &input, &acc, &bsk)?;
+    /// #
+    /// assert_eq!(output.lwe_dimension(), lwe_dim_output);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_bootstrap_lwe_ciphertext(
+        &mut self,
+        output: &mut LweCiphertextMutView64,
+        input: &LweCiphertextView64,
+        acc: &GlweCiphertextView64,
+        bsk: &FftFourierLweBootstrapKey64,
+    ) -> Result<(), LweCiphertextDiscardingBootstrapError<Self::EngineError>> {
+        if !(acc.0.polynomial_size().0.is_power_of_two() && acc.0.polynomial_size().0 >= 32) {
+            return Err(LweCiphertextDiscardingBootstrapError::from(
+                FftError::UnsupportedPolynomialSize,
+            ));
+        }
+        LweCiphertextDiscardingBootstrapError::perform_generic_checks(output, input, acc, bsk)?;
+        unsafe { self.discard_bootstrap_lwe_ciphertext_unchecked(output, input, acc, bsk) };
+        Ok(())
+    }
+
+    unsafe fn discard_bootstrap_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut LweCiphertextMutView64,
+        input: &LweCiphertextView64,
+        acc: &GlweCiphertextView64,
+        bsk: &FftFourierLweBootstrapKey64,
+    ) {
+        let fft = Fft::new(acc.0.polynomial_size());
+        let fft = fft.as_view();
+        self.resize(
+            bootstrap_scratch::<u64>(acc.0.size(), acc.0.polynomial_size(), fft)
+                .unwrap()
+                .unaligned_bytes_required(),
+        );
+        let acc = GlweCiphertextView::new(
+            acc.0.tensor.as_slice(),
+            acc.0.polynomial_size(),
+            acc.0.size(),
+        );
+        bsk.0.as_view().bootstrap(
+            output.0.tensor.as_mut_slice(),
+            input.0.tensor.as_slice(),
+            acc,
+            fft,
+            self.stack(),
+        );
+    }
+}

--- a/concrete-core/src/backends/fft/implementation/engines/mod.rs
+++ b/concrete-core/src/backends/fft/implementation/engines/mod.rs
@@ -1,0 +1,12 @@
+//! A module containing the [engines](crate::specification::engines) exposed by the `Concrete-FFT`
+//! backend.
+
+mod computation_engine;
+
+pub use computation_engine::{FftEngine, FftError};
+
+mod ggsw_ciphertext_conversion;
+mod glwe_ciphertext_ggsw_ciphertext_discarding_external_product;
+mod glwe_ciphertexts_ggsw_ciphertext_fusing_cmux;
+mod lwe_bootstrap_key_conversion;
+mod lwe_ciphertext_discarding_bootstrap;

--- a/concrete-core/src/backends/fft/implementation/engines/serialization.rs
+++ b/concrete-core/src/backends/fft/implementation/engines/serialization.rs
@@ -1,0 +1,273 @@
+use super::super::super::private::crypto::bootstrap::FourierLweBootstrapKeyRef;
+use super::super::super::private::crypto::ggsw::FourierGgswCiphertextRef;
+use super::{FftSerializationEngine, FftSerializationError};
+use crate::prelude::{
+    EntitySerializationEngine, EntitySerializationError, FftFourierGgswCiphertext32,
+    FftFourierGgswCiphertext32Version, FftFourierGgswCiphertext64,
+    FftFourierGgswCiphertext64Version, FftFourierLweBootstrapKey32,
+    FftFourierLweBootstrapKey32Version, FftFourierLweBootstrapKey64,
+    FftFourierLweBootstrapKey64Version,
+};
+use serde::Serialize;
+
+impl EntitySerializationEngine<FftFourierGgswCiphertext32, Vec<u8>> for FftSerializationEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = 3_u32 << 20;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let key: GlweSecretKey32 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    ///
+    /// // We encrypt a GGSW ciphertext in the standard domain
+    /// let ciphertext =
+    ///     default_engine.encrypt_scalar_ggsw_ciphertext(&key, &plaintext, noise, level, base_log)?;
+    ///
+    /// // Then we convert it to the Fourier domain.
+    /// let fourier_ciphertext: FftFourierGgswCiphertext32 =
+    ///     fft_engine.convert_ggsw_ciphertext(&ciphertext)?;
+    ///
+    /// let mut serialization_engine = FftSerializationEngine::new(())?;
+    /// let serialized = serialization_engine.serialize(&fourier_ciphertext)?;
+    /// let recovered = serialization_engine.deserialize(serialized.as_slice())?;
+    /// assert_eq!(fourier_ciphertext, recovered);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn serialize(
+        &mut self,
+        entity: &FftFourierGgswCiphertext32,
+    ) -> Result<Vec<u8>, EntitySerializationError<Self::EngineError>> {
+        let entity = entity.0.as_ref();
+        #[derive(Serialize)]
+        struct SerializableFftFourierGgswCiphertext32<'a> {
+            version: FftFourierGgswCiphertext32Version,
+            inner: FourierGgswCiphertextRef<'a>,
+        }
+        let value = SerializableFftFourierGgswCiphertext32 {
+            version: FftFourierGgswCiphertext32Version::V0,
+            inner: entity,
+        };
+        bincode::serialize(&value)
+            .map_err(FftSerializationError::Serialization)
+            .map_err(EntitySerializationError::Engine)
+    }
+
+    unsafe fn serialize_unchecked(&mut self, entity: &FftFourierGgswCiphertext32) -> Vec<u8> {
+        self.serialize(entity).unwrap()
+    }
+}
+
+impl EntitySerializationEngine<FftFourierGgswCiphertext64, Vec<u8>> for FftSerializationEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// let level = DecompositionLevelCount(1);
+    /// let base_log = DecompositionBaseLog(4);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = 3_u64 << 50;
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let key: GlweSecretKey64 =
+    ///     default_engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext = default_engine.create_plaintext(&input)?;
+    ///
+    /// // We encrypt a GGSW ciphertext in the standard domain
+    /// let ciphertext =
+    ///     default_engine.encrypt_scalar_ggsw_ciphertext(&key, &plaintext, noise, level, base_log)?;
+    ///
+    /// // Then we convert it to the Fourier domain.
+    /// let fourier_ciphertext: FftFourierGgswCiphertext64 =
+    ///     fft_engine.convert_ggsw_ciphertext(&ciphertext)?;
+    ///
+    /// let mut serialization_engine = FftSerializationEngine::new(())?;
+    /// let serialized = serialization_engine.serialize(&fourier_ciphertext)?;
+    /// let recovered = serialization_engine.deserialize(serialized.as_slice())?;
+    /// assert_eq!(fourier_ciphertext, recovered);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn serialize(
+        &mut self,
+        entity: &FftFourierGgswCiphertext64,
+    ) -> Result<Vec<u8>, EntitySerializationError<Self::EngineError>> {
+        let entity = entity.0.as_ref();
+        #[derive(Serialize)]
+        struct SerializableFftFourierGgswCiphertext64<'a> {
+            version: FftFourierGgswCiphertext64Version,
+            inner: FourierGgswCiphertextRef<'a>,
+        }
+        let value = SerializableFftFourierGgswCiphertext64 {
+            version: FftFourierGgswCiphertext64Version::V0,
+            inner: entity,
+        };
+        bincode::serialize(&value)
+            .map_err(FftSerializationError::Serialization)
+            .map_err(EntitySerializationError::Engine)
+    }
+
+    unsafe fn serialize_unchecked(&mut self, entity: &FftFourierGgswCiphertext64) -> Vec<u8> {
+        self.serialize(entity).unwrap()
+    }
+}
+
+impl EntitySerializationEngine<FftFourierLweBootstrapKey32, Vec<u8>> for FftSerializationEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let (lwe_dim, glwe_dim, poly_size) = (LweDimension(4), GlweDimension(6), PolynomialSize(256));
+    /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let lwe_sk: LweSecretKey32 = default_engine.create_lwe_secret_key(lwe_dim)?;
+    /// let glwe_sk: GlweSecretKey32 = default_engine.create_glwe_secret_key(glwe_dim, poly_size)?;
+    /// let bsk: LweBootstrapKey32 =
+    ///     default_engine.create_lwe_bootstrap_key(&lwe_sk, &glwe_sk, dec_bl, dec_lc, noise)?;
+    ///
+    /// let fourier_bsk: FftFourierLweBootstrapKey32 = fft_engine.convert_lwe_bootstrap_key(&bsk)?;
+    ///
+    /// let mut serialization_engine = FftSerializationEngine::new(())?;
+    /// let serialized = serialization_engine.serialize(&fourier_bsk)?;
+    /// let recovered = serialization_engine.deserialize(serialized.as_slice())?;
+    /// assert_eq!(fourier_bsk, recovered);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn serialize(
+        &mut self,
+        entity: &FftFourierLweBootstrapKey32,
+    ) -> Result<Vec<u8>, EntitySerializationError<Self::EngineError>> {
+        let entity = entity.0.as_ref();
+        #[derive(Serialize)]
+        struct SerializableFftFourierLweBootstrapKey32<'a> {
+            version: FftFourierLweBootstrapKey32Version,
+            inner: FourierLweBootstrapKeyRef<'a>,
+        }
+        let value = SerializableFftFourierLweBootstrapKey32 {
+            version: FftFourierLweBootstrapKey32Version::V0,
+            inner: entity,
+        };
+        bincode::serialize(&value)
+            .map_err(FftSerializationError::Serialization)
+            .map_err(EntitySerializationError::Engine)
+    }
+
+    unsafe fn serialize_unchecked(&mut self, entity: &FftFourierLweBootstrapKey32) -> Vec<u8> {
+        self.serialize(entity).unwrap()
+    }
+}
+
+impl EntitySerializationEngine<FftFourierLweBootstrapKey64, Vec<u8>> for FftSerializationEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let (lwe_dim, glwe_dim, poly_size) = (LweDimension(4), GlweDimension(6), PolynomialSize(256));
+    /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// // Unix seeder must be given a secret input.
+    /// // Here we just give it 0, which is totally unsafe.
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    /// let lwe_sk: LweSecretKey64 = default_engine.create_lwe_secret_key(lwe_dim)?;
+    /// let glwe_sk: GlweSecretKey64 = default_engine.create_glwe_secret_key(glwe_dim, poly_size)?;
+    /// let bsk: LweBootstrapKey64 =
+    ///     default_engine.create_lwe_bootstrap_key(&lwe_sk, &glwe_sk, dec_bl, dec_lc, noise)?;
+    ///
+    /// let fourier_bsk: FftFourierLweBootstrapKey64 = fft_engine.convert_lwe_bootstrap_key(&bsk)?;
+    ///
+    /// let mut serialization_engine = FftSerializationEngine::new(())?;
+    /// let serialized = serialization_engine.serialize(&fourier_bsk)?;
+    /// let recovered = serialization_engine.deserialize(serialized.as_slice())?;
+    /// assert_eq!(fourier_bsk, recovered);
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn serialize(
+        &mut self,
+        entity: &FftFourierLweBootstrapKey64,
+    ) -> Result<Vec<u8>, EntitySerializationError<Self::EngineError>> {
+        let entity = entity.0.as_ref();
+        #[derive(Serialize)]
+        struct SerializableFftFourierLweBootstrapKey64<'a> {
+            version: FftFourierLweBootstrapKey64Version,
+            inner: FourierLweBootstrapKeyRef<'a>,
+        }
+        let value = SerializableFftFourierLweBootstrapKey64 {
+            version: FftFourierLweBootstrapKey64Version::V0,
+            inner: entity,
+        };
+        bincode::serialize(&value)
+            .map_err(FftSerializationError::Serialization)
+            .map_err(EntitySerializationError::Engine)
+    }
+
+    unsafe fn serialize_unchecked(&mut self, entity: &FftFourierLweBootstrapKey64) -> Vec<u8> {
+        self.serialize(entity).unwrap()
+    }
+}

--- a/concrete-core/src/backends/fft/implementation/engines/serialization_engine.rs
+++ b/concrete-core/src/backends/fft/implementation/engines/serialization_engine.rs
@@ -1,0 +1,44 @@
+use crate::specification::engines::sealed::AbstractEngineSeal;
+use crate::specification::engines::AbstractEngine;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug)]
+pub enum FftSerializationError {
+    Serialization(bincode::Error),
+    Deserialization(bincode::Error),
+    UnsupportedVersion,
+}
+
+impl Display for FftSerializationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FftSerializationError::Serialization(bincode_error) => {
+                write!(f, "Failed to serialize entity: {}", bincode_error)
+            }
+            FftSerializationError::Deserialization(bincode_error) => {
+                write!(f, "Failed to deserialize entity: {}", bincode_error)
+            }
+            FftSerializationError::UnsupportedVersion => {
+                write!(
+                    f,
+                    "The version used to serialize the entity is not supported."
+                )
+            }
+        }
+    }
+}
+
+impl Error for FftSerializationError {}
+
+pub struct FftSerializationEngine;
+
+impl AbstractEngineSeal for FftSerializationEngine {}
+impl AbstractEngine for FftSerializationEngine {
+    type EngineError = FftSerializationError;
+    type Parameters = ();
+
+    fn new(_parameters: Self::Parameters) -> Result<Self, Self::EngineError> {
+        Ok(FftSerializationEngine)
+    }
+}

--- a/concrete-core/src/backends/fft/implementation/entities/ggsw_ciphertext.rs
+++ b/concrete-core/src/backends/fft/implementation/entities/ggsw_ciphertext.rs
@@ -1,0 +1,77 @@
+use super::super::super::private::crypto::ggsw::FourierGgswCiphertext;
+use crate::specification::entities::markers::GgswCiphertextKind;
+use crate::specification::entities::{AbstractEntity, GgswCiphertextEntity};
+use aligned_vec::ABox;
+use concrete_commons::parameters::{
+    DecompositionBaseLog, DecompositionLevelCount, GlweDimension, PolynomialSize,
+};
+use concrete_fft::c64;
+#[cfg(feature = "backend_fft_serialization")]
+use serde::{Deserialize, Serialize};
+
+/// A structure representing a GGSW ciphertext with 32 bits of precision in the Fourier domain.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FftFourierGgswCiphertext32(pub(crate) FourierGgswCiphertext<ABox<[c64]>>);
+
+/// A structure representing a GGSW ciphertext with 64 bits of precision in the Fourier domain.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FftFourierGgswCiphertext64(pub(crate) FourierGgswCiphertext<ABox<[c64]>>);
+
+impl AbstractEntity for FftFourierGgswCiphertext32 {
+    type Kind = GgswCiphertextKind;
+}
+impl AbstractEntity for FftFourierGgswCiphertext64 {
+    type Kind = GgswCiphertextKind;
+}
+
+impl GgswCiphertextEntity for FftFourierGgswCiphertext32 {
+    fn glwe_dimension(&self) -> GlweDimension {
+        self.0.glwe_size().to_glwe_dimension()
+    }
+
+    fn polynomial_size(&self) -> PolynomialSize {
+        self.0.polynomial_size()
+    }
+
+    fn decomposition_level_count(&self) -> DecompositionLevelCount {
+        self.0.decomposition_level_count()
+    }
+
+    fn decomposition_base_log(&self) -> DecompositionBaseLog {
+        self.0.decomposition_base_log()
+    }
+}
+
+impl GgswCiphertextEntity for FftFourierGgswCiphertext64 {
+    fn glwe_dimension(&self) -> GlweDimension {
+        self.0.glwe_size().to_glwe_dimension()
+    }
+
+    fn polynomial_size(&self) -> PolynomialSize {
+        self.0.polynomial_size()
+    }
+
+    fn decomposition_level_count(&self) -> DecompositionLevelCount {
+        self.0.decomposition_level_count()
+    }
+
+    fn decomposition_base_log(&self) -> DecompositionBaseLog {
+        self.0.decomposition_base_log()
+    }
+}
+
+#[cfg(feature = "backend_fft_serialization")]
+#[derive(Serialize, Deserialize)]
+pub(crate) enum FftFourierGgswCiphertext32Version {
+    V0,
+    #[serde(other)]
+    Unsupported,
+}
+
+#[cfg(feature = "backend_fft_serialization")]
+#[derive(Serialize, Deserialize)]
+pub(crate) enum FftFourierGgswCiphertext64Version {
+    V0,
+    #[serde(other)]
+    Unsupported,
+}

--- a/concrete-core/src/backends/fft/implementation/entities/lwe_bootstrap_key.rs
+++ b/concrete-core/src/backends/fft/implementation/entities/lwe_bootstrap_key.rs
@@ -1,0 +1,80 @@
+use super::super::super::private::crypto::bootstrap::FourierLweBootstrapKey;
+use crate::specification::entities::markers::LweBootstrapKeyKind;
+use crate::specification::entities::{AbstractEntity, LweBootstrapKeyEntity};
+use aligned_vec::ABox;
+use concrete_fft::c64;
+#[cfg(feature = "backend_fft_serialization")]
+use serde::{Deserialize, Serialize};
+
+/// A structure representing an LWE bootstrap key with 32 bits of precision, in the Fourier domain.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FftFourierLweBootstrapKey32(pub(crate) FourierLweBootstrapKey<ABox<[c64]>>);
+
+/// A structure representing an LWE bootstrap key with 64 bits of precision, in the Fourier domain.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FftFourierLweBootstrapKey64(pub(crate) FourierLweBootstrapKey<ABox<[c64]>>);
+
+impl AbstractEntity for FftFourierLweBootstrapKey32 {
+    type Kind = LweBootstrapKeyKind;
+}
+impl AbstractEntity for FftFourierLweBootstrapKey64 {
+    type Kind = LweBootstrapKeyKind;
+}
+
+impl LweBootstrapKeyEntity for FftFourierLweBootstrapKey32 {
+    fn glwe_dimension(&self) -> concrete_commons::parameters::GlweDimension {
+        self.0.glwe_size().to_glwe_dimension()
+    }
+
+    fn polynomial_size(&self) -> concrete_commons::parameters::PolynomialSize {
+        self.0.polynomial_size()
+    }
+
+    fn input_lwe_dimension(&self) -> concrete_commons::parameters::LweDimension {
+        self.0.key_size()
+    }
+
+    fn decomposition_base_log(&self) -> concrete_commons::parameters::DecompositionBaseLog {
+        self.0.decomposition_base_log()
+    }
+
+    fn decomposition_level_count(&self) -> concrete_commons::parameters::DecompositionLevelCount {
+        self.0.decomposition_level_count()
+    }
+}
+impl LweBootstrapKeyEntity for FftFourierLweBootstrapKey64 {
+    fn glwe_dimension(&self) -> concrete_commons::parameters::GlweDimension {
+        self.0.glwe_size().to_glwe_dimension()
+    }
+
+    fn polynomial_size(&self) -> concrete_commons::parameters::PolynomialSize {
+        self.0.polynomial_size()
+    }
+
+    fn input_lwe_dimension(&self) -> concrete_commons::parameters::LweDimension {
+        self.0.key_size()
+    }
+
+    fn decomposition_base_log(&self) -> concrete_commons::parameters::DecompositionBaseLog {
+        self.0.decomposition_base_log()
+    }
+
+    fn decomposition_level_count(&self) -> concrete_commons::parameters::DecompositionLevelCount {
+        self.0.decomposition_level_count()
+    }
+}
+
+#[cfg(feature = "backend_fft_serialization")]
+#[derive(Serialize, Deserialize)]
+pub(crate) enum FftFourierLweBootstrapKey32Version {
+    V0,
+    #[serde(other)]
+    Unsupported,
+}
+#[cfg(feature = "backend_fft_serialization")]
+#[derive(Serialize, Deserialize)]
+pub(crate) enum FftFourierLweBootstrapKey64Version {
+    V0,
+    #[serde(other)]
+    Unsupported,
+}

--- a/concrete-core/src/backends/fft/implementation/entities/mod.rs
+++ b/concrete-core/src/backends/fft/implementation/entities/mod.rs
@@ -1,0 +1,8 @@
+//! A module containing all the [entities](crate::specification::entities) exposed by the
+//! Concrete-FFT backend.
+
+mod ggsw_ciphertext;
+mod lwe_bootstrap_key;
+
+pub use ggsw_ciphertext::*;
+pub use lwe_bootstrap_key::*;

--- a/concrete-core/src/backends/fft/implementation/mod.rs
+++ b/concrete-core/src/backends/fft/implementation/mod.rs
@@ -1,0 +1,2 @@
+pub mod engines;
+pub mod entities;

--- a/concrete-core/src/backends/fft/mod.rs
+++ b/concrete-core/src/backends/fft/mod.rs
@@ -1,0 +1,6 @@
+//! An accelerated backend using `Concrete-FFT`.
+
+mod implementation;
+#[cfg_attr(not(feature = "__private_docs"), doc(hidden))]
+pub mod private;
+pub use implementation::{engines, entities};

--- a/concrete-core/src/backends/fft/private/crypto/bootstrap.rs
+++ b/concrete-core/src/backends/fft/private/crypto/bootstrap.rs
@@ -1,0 +1,379 @@
+use super::super::math::fft::FftView;
+use super::super::{c64, izip, Container, IntoChunks};
+use super::ggsw::{cmux, *};
+use super::glwe::{GlweCiphertextMutView, GlweCiphertextView};
+use crate::commons::math::torus::UnsignedTorus;
+use aligned_vec::CACHELINE_ALIGN;
+use concrete_commons::numeric::CastInto;
+use concrete_commons::parameters::{
+    DecompositionBaseLog, DecompositionLevelCount, GlweSize, LutCountLog, LweDimension,
+    ModulusSwitchOffset, PolynomialSize,
+};
+use dyn_stack::{DynStack, ReborrowMut, SizeOverflow, StackReq};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "backend_fft_serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct StandardLweBootstrapKey<C> {
+    data: C,
+    key_size: LweDimension,
+    polynomial_size: PolynomialSize,
+    glwe_size: GlweSize,
+    decomposition_base_log: DecompositionBaseLog,
+    decomposition_level_count: DecompositionLevelCount,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FourierLweBootstrapKey<C> {
+    data: C,
+    key_size: LweDimension,
+    polynomial_size: PolynomialSize,
+    glwe_size: GlweSize,
+    decomposition_base_log: DecompositionBaseLog,
+    decomposition_level_count: DecompositionLevelCount,
+}
+
+pub type StandardLweBootstrapKeyView<'a, Scalar> = StandardLweBootstrapKey<&'a [Scalar]>;
+pub type StandardLweBootstrapKeyMutView<'a, Scalar> = StandardLweBootstrapKey<&'a mut [Scalar]>;
+pub type FourierLweBootstrapKeyView<'a> = FourierLweBootstrapKey<&'a [c64]>;
+pub type FourierLweBootstrapKeyMutView<'a> = FourierLweBootstrapKey<&'a mut [c64]>;
+
+impl<C> StandardLweBootstrapKey<C> {
+    pub fn new(
+        data: C,
+        key_size: LweDimension,
+        polynomial_size: PolynomialSize,
+        glwe_size: GlweSize,
+        decomposition_base_log: DecompositionBaseLog,
+        decomposition_level_count: DecompositionLevelCount,
+    ) -> Self
+    where
+        C: Container,
+    {
+        assert_eq!(
+            data.container_len(),
+            key_size.0
+                * polynomial_size.0
+                * decomposition_level_count.0
+                * glwe_size.0
+                * glwe_size.0
+        );
+        Self {
+            data,
+            key_size,
+            polynomial_size,
+            glwe_size,
+            decomposition_base_log,
+            decomposition_level_count,
+        }
+    }
+
+    /// Returns an iterator over the GGSW ciphertexts composing the key.
+    pub fn into_ggsw_iter(self) -> impl DoubleEndedIterator<Item = StandardGgswCiphertext<C>>
+    where
+        C: IntoChunks + Container,
+    {
+        self.data.split_into(self.key_size.0).map(move |slice| {
+            StandardGgswCiphertext::new(
+                slice,
+                self.polynomial_size,
+                self.glwe_size,
+                self.decomposition_base_log,
+                self.decomposition_level_count,
+            )
+        })
+    }
+
+    pub fn key_size(&self) -> LweDimension {
+        self.key_size
+    }
+
+    pub fn polynomial_size(&self) -> PolynomialSize {
+        self.polynomial_size
+    }
+
+    pub fn glwe_size(&self) -> GlweSize {
+        self.glwe_size
+    }
+
+    pub fn decomposition_base_log(&self) -> DecompositionBaseLog {
+        self.decomposition_base_log
+    }
+
+    pub fn decomposition_level_count(&self) -> DecompositionLevelCount {
+        self.decomposition_level_count
+    }
+
+    pub fn data(self) -> C {
+        self.data
+    }
+
+    pub fn as_view<Scalar>(&self) -> StandardLweBootstrapKeyView<'_, Scalar>
+    where
+        C: AsRef<[Scalar]>,
+    {
+        StandardLweBootstrapKeyView {
+            data: self.data.as_ref(),
+            key_size: self.key_size,
+            polynomial_size: self.polynomial_size,
+            glwe_size: self.glwe_size,
+            decomposition_base_log: self.decomposition_base_log,
+            decomposition_level_count: self.decomposition_level_count,
+        }
+    }
+
+    pub fn as_mut_view<Scalar>(&mut self) -> StandardLweBootstrapKeyMutView<'_, Scalar>
+    where
+        C: AsMut<[Scalar]>,
+    {
+        StandardLweBootstrapKeyMutView {
+            data: self.data.as_mut(),
+            key_size: self.key_size,
+            polynomial_size: self.polynomial_size,
+            glwe_size: self.glwe_size,
+            decomposition_base_log: self.decomposition_base_log,
+            decomposition_level_count: self.decomposition_level_count,
+        }
+    }
+}
+
+impl<C> FourierLweBootstrapKey<C> {
+    pub fn new(
+        data: C,
+        key_size: LweDimension,
+        polynomial_size: PolynomialSize,
+        glwe_size: GlweSize,
+        decomposition_base_log: DecompositionBaseLog,
+        decomposition_level_count: DecompositionLevelCount,
+    ) -> Self
+    where
+        C: Container,
+    {
+        assert_eq!(polynomial_size.0 % 2, 0);
+        assert_eq!(
+            data.container_len(),
+            key_size.0 * polynomial_size.0 / 2
+                * decomposition_level_count.0
+                * glwe_size.0
+                * glwe_size.0
+        );
+        Self {
+            data,
+            key_size,
+            polynomial_size,
+            glwe_size,
+            decomposition_base_log,
+            decomposition_level_count,
+        }
+    }
+
+    /// Returns an iterator over the GGSW ciphertexts composing the key.
+    pub fn into_ggsw_iter(self) -> impl DoubleEndedIterator<Item = FourierGgswCiphertext<C>>
+    where
+        C: IntoChunks + Container,
+    {
+        self.data.split_into(self.key_size.0).map(move |slice| {
+            FourierGgswCiphertext::new(
+                slice,
+                self.polynomial_size,
+                self.glwe_size,
+                self.decomposition_base_log,
+                self.decomposition_level_count,
+            )
+        })
+    }
+
+    pub fn key_size(&self) -> LweDimension {
+        self.key_size
+    }
+
+    pub fn polynomial_size(&self) -> PolynomialSize {
+        self.polynomial_size
+    }
+
+    pub fn glwe_size(&self) -> GlweSize {
+        self.glwe_size
+    }
+
+    pub fn decomposition_base_log(&self) -> DecompositionBaseLog {
+        self.decomposition_base_log
+    }
+
+    pub fn decomposition_level_count(&self) -> DecompositionLevelCount {
+        self.decomposition_level_count
+    }
+
+    pub fn data(self) -> C {
+        self.data
+    }
+
+    pub fn as_view(&self) -> FourierLweBootstrapKeyView<'_>
+    where
+        C: AsRef<[c64]>,
+    {
+        FourierLweBootstrapKeyView {
+            data: self.data.as_ref(),
+            key_size: self.key_size,
+            polynomial_size: self.polynomial_size,
+            glwe_size: self.glwe_size,
+            decomposition_base_log: self.decomposition_base_log,
+            decomposition_level_count: self.decomposition_level_count,
+        }
+    }
+
+    pub fn as_mut_view(&mut self) -> FourierLweBootstrapKeyMutView<'_>
+    where
+        C: AsMut<[c64]>,
+    {
+        FourierLweBootstrapKeyMutView {
+            data: self.data.as_mut(),
+            key_size: self.key_size,
+            polynomial_size: self.polynomial_size,
+            glwe_size: self.glwe_size,
+            decomposition_base_log: self.decomposition_base_log,
+            decomposition_level_count: self.decomposition_level_count,
+        }
+    }
+}
+
+/// Returns the required memory for [`FourierLweBootstrapKeyMutView::fill_with_forward_fourier`].
+pub fn fill_with_forward_fourier_scratch(fft: FftView<'_>) -> Result<StackReq, SizeOverflow> {
+    fft.forward_scratch()
+}
+
+impl<'a> FourierLweBootstrapKeyMutView<'a> {
+    /// Fills a bootstrapping key with the Fourier transform of a bootstrapping key in the standard
+    /// domain.
+    pub fn fill_with_forward_fourier<Scalar: UnsignedTorus + CastInto<usize>>(
+        mut self,
+        coef_bsk: StandardLweBootstrapKeyView<Scalar>,
+        fft: FftView<'_>,
+        mut stack: DynStack<'_>,
+    ) {
+        for (fourier_ggsw, standard_ggsw) in izip!(
+            self.as_mut_view().into_ggsw_iter(),
+            coef_bsk.into_ggsw_iter()
+        ) {
+            fourier_ggsw.fill_with_forward_fourier(standard_ggsw, fft, stack.rb_mut());
+        }
+    }
+}
+
+/// Returns the required memory for [`FourierLweBootstrapKeyView::blind_rotate`].
+pub fn blind_rotate_scratch<Scalar>(
+    glwe_size: GlweSize,
+    polynomial_size: PolynomialSize,
+    fft: FftView<'_>,
+) -> Result<StackReq, SizeOverflow> {
+    StackReq::try_new_aligned::<Scalar>(glwe_size.0 * polynomial_size.0, CACHELINE_ALIGN)?
+        .try_and(cmux_scratch::<Scalar>(glwe_size, polynomial_size, fft)?)
+}
+
+/// Returns the required memory for [`FourierLweBootstrapKeyView::bootstrap`].
+pub fn bootstrap_scratch<Scalar>(
+    glwe_size: GlweSize,
+    polynomial_size: PolynomialSize,
+    fft: FftView<'_>,
+) -> Result<StackReq, SizeOverflow> {
+    blind_rotate_scratch::<Scalar>(glwe_size, polynomial_size, fft)?.try_and(
+        StackReq::try_new_aligned::<Scalar>(glwe_size.0 * polynomial_size.0, CACHELINE_ALIGN)?,
+    )
+}
+
+impl<'a> FourierLweBootstrapKeyView<'a> {
+    pub fn blind_rotate<Scalar: UnsignedTorus + CastInto<usize>>(
+        self,
+        mut lut: GlweCiphertextMutView<'_, Scalar>,
+        lwe: &[Scalar],
+        fft: FftView<'_>,
+        mut stack: DynStack<'_>,
+    ) {
+        let (lwe_body, lwe_mask) = lwe.split_last().unwrap();
+
+        let lut_poly_size = lut.polynomial_size();
+        let monomial_degree = pbs_modulus_switch(
+            *lwe_body,
+            lut_poly_size,
+            ModulusSwitchOffset(0),
+            LutCountLog(0),
+        );
+        lut.as_mut_view().into_polynomials().for_each(|poly| {
+            poly.update_with_wrapping_unit_monomial_div(monomial_degree);
+        });
+
+        // We initialize the ct_0 used for the successive cmuxes
+        let mut ct0 = lut;
+
+        for (lwe_mask_element, bootstrap_key_ggsw) in izip!(lwe_mask.iter(), self.into_ggsw_iter())
+        {
+            if *lwe_mask_element != Scalar::ZERO {
+                let stack = stack.rb_mut();
+                // We copy ct_0 to ct_1
+                let (mut ct1, stack) =
+                    stack.collect_aligned(CACHELINE_ALIGN, ct0.as_view().data().iter().copied());
+
+                let mut ct1 =
+                    GlweCiphertextMutView::new(&mut ct1, ct0.polynomial_size(), ct0.glwe_size());
+
+                // We rotate ct_1 by performing ct_1 <- ct_1 * X^{a_hat}
+                for poly in ct1.as_mut_view().into_polynomials() {
+                    poly.update_with_wrapping_unit_monomial_mul(pbs_modulus_switch(
+                        *lwe_mask_element,
+                        lut_poly_size,
+                        ModulusSwitchOffset(0),
+                        LutCountLog(0),
+                    ));
+                }
+
+                cmux(ct0.as_mut_view(), ct1, bootstrap_key_ggsw, fft, stack);
+            }
+        }
+    }
+
+    pub fn bootstrap<'out, Scalar: UnsignedTorus + CastInto<usize>>(
+        self,
+        lwe_out: &'out mut [Scalar],
+        lwe_in: &[Scalar],
+        accumulator: GlweCiphertextView<'_, Scalar>,
+        fft: FftView<'_>,
+        stack: DynStack<'_>,
+    ) {
+        let (mut local_accumulator_data, stack) =
+            stack.collect_aligned(CACHELINE_ALIGN, accumulator.data().iter().copied());
+        let mut local_accumulator = GlweCiphertextMutView::new(
+            &mut local_accumulator_data,
+            accumulator.polynomial_size(),
+            accumulator.glwe_size(),
+        );
+        self.blind_rotate(local_accumulator.as_mut_view(), lwe_in, fft, stack);
+        local_accumulator
+            .as_view()
+            .fill_lwe_with_sample_extraction(lwe_out, 0);
+    }
+}
+
+/// This function switches modulus for a single coefficient of a ciphertext,
+/// only in the context of a PBS
+///
+/// offset: the number of msb discarded
+/// lut_count_log: the right padding
+pub fn pbs_modulus_switch<Scalar: UnsignedTorus + CastInto<usize>>(
+    input: Scalar,
+    poly_size: PolynomialSize,
+    offset: ModulusSwitchOffset,
+    lut_count_log: LutCountLog,
+) -> usize {
+    // First, do the left shift (we discard the offset msb)
+    let mut output = input << offset.0;
+    // Start doing the right shift
+    output >>= Scalar::BITS - poly_size.log2().0 - 2 + lut_count_log.0;
+    // Do the rounding
+    output += output & Scalar::ONE;
+    // Finish the right shift
+    output >>= 1;
+    // Apply the lsb padding
+    output <<= lut_count_log.0;
+    <Scalar as CastInto<usize>>::cast_into(output)
+}

--- a/concrete-core/src/backends/fft/private/crypto/ggsw.rs
+++ b/concrete-core/src/backends/fft/private/crypto/ggsw.rs
@@ -1,0 +1,743 @@
+use core::mem::MaybeUninit;
+
+use super::super::math::decomposition::TensorSignedDecompositionLendingIter;
+use super::super::math::fft::FftView;
+use super::super::math::polynomial::{
+    FourierPolynomialUninitMutView, FourierPolynomialView, PolynomialView,
+};
+use super::super::{as_mut_uninit, assume_init_mut, c64, izip, Container, IntoChunks};
+use super::glwe::{GlweCiphertextMutView, GlweCiphertextView};
+use crate::commons::math::decomposition::{DecompositionLevel, SignedDecomposer};
+use crate::commons::math::torus::UnsignedTorus;
+use aligned_vec::CACHELINE_ALIGN;
+use concrete_commons::parameters::{
+    DecompositionBaseLog, DecompositionLevelCount, GlweSize, PolynomialSize,
+};
+use dyn_stack::{DynStack, ReborrowMut, SizeOverflow, StackReq};
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "backend_fft_serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct StandardGgswCiphertext<C> {
+    data: C,
+    polynomial_size: PolynomialSize,
+    glwe_size: GlweSize,
+    decomposition_base_log: DecompositionBaseLog,
+    decomposition_level_count: DecompositionLevelCount,
+}
+
+/// A GGSW ciphertext in the Fourier domain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FourierGgswCiphertext<C> {
+    data: C,
+    polynomial_size: PolynomialSize,
+    glwe_size: GlweSize,
+    decomposition_base_log: DecompositionBaseLog,
+    decomposition_level_count: DecompositionLevelCount,
+}
+
+/// A matrix containing a single level of gadget decomposition, in the Fourier domain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FourierGgswLevelMatrix<C> {
+    data: C,
+    polynomial_size: PolynomialSize,
+    glwe_size: GlweSize,
+    row_count: usize,
+    decomposition_level: DecompositionLevel,
+}
+
+/// A row of a GGSW level matrix, in the Fourier domain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FourierGgswLevelRow<C> {
+    data: C,
+    polynomial_size: PolynomialSize,
+    glwe_size: GlweSize,
+    decomposition_level: DecompositionLevel,
+}
+
+pub type StandardGgswCiphertextView<'a, Scalar> = StandardGgswCiphertext<&'a [Scalar]>;
+pub type StandardGgswCiphertextMutView<'a, Scalar> = StandardGgswCiphertext<&'a mut [Scalar]>;
+pub type FourierGgswCiphertextView<'a> = FourierGgswCiphertext<&'a [c64]>;
+pub type FourierGgswCiphertextMutView<'a> = FourierGgswCiphertext<&'a mut [c64]>;
+pub type FourierGgswLevelMatrixView<'a> = FourierGgswLevelMatrix<&'a [c64]>;
+pub type FourierGgswLevelMatrixMutView<'a> = FourierGgswLevelMatrix<&'a mut [c64]>;
+pub type FourierGgswLevelRowView<'a> = FourierGgswLevelRow<&'a [c64]>;
+pub type FourierGgswLevelRowMutView<'a> = FourierGgswLevelRow<&'a mut [c64]>;
+
+impl<C> StandardGgswCiphertext<C> {
+    pub fn new(
+        data: C,
+        polynomial_size: PolynomialSize,
+        glwe_size: GlweSize,
+        decomposition_base_log: DecompositionBaseLog,
+        decomposition_level_count: DecompositionLevelCount,
+    ) -> Self
+    where
+        C: Container,
+    {
+        assert_eq!(
+            data.container_len(),
+            polynomial_size.0 * glwe_size.0 * glwe_size.0 * decomposition_level_count.0
+        );
+
+        Self {
+            data,
+            polynomial_size,
+            glwe_size,
+            decomposition_base_log,
+            decomposition_level_count,
+        }
+    }
+
+    pub fn polynomial_size(&self) -> PolynomialSize {
+        self.polynomial_size
+    }
+
+    pub fn glwe_size(&self) -> GlweSize {
+        self.glwe_size
+    }
+
+    pub fn decomposition_base_log(&self) -> DecompositionBaseLog {
+        self.decomposition_base_log
+    }
+
+    pub fn decomposition_level_count(&self) -> DecompositionLevelCount {
+        self.decomposition_level_count
+    }
+
+    pub fn data(self) -> C {
+        self.data
+    }
+
+    pub fn as_view<Scalar>(&self) -> StandardGgswCiphertextView<'_, Scalar>
+    where
+        C: AsRef<[Scalar]>,
+    {
+        StandardGgswCiphertextView {
+            data: self.data.as_ref(),
+            polynomial_size: self.polynomial_size,
+            glwe_size: self.glwe_size,
+            decomposition_base_log: self.decomposition_base_log,
+            decomposition_level_count: self.decomposition_level_count,
+        }
+    }
+
+    pub fn as_mut_view<Scalar>(&mut self) -> StandardGgswCiphertextMutView<'_, Scalar>
+    where
+        C: AsMut<[Scalar]>,
+    {
+        StandardGgswCiphertextMutView {
+            data: self.data.as_mut(),
+            polynomial_size: self.polynomial_size,
+            glwe_size: self.glwe_size,
+            decomposition_base_log: self.decomposition_base_log,
+            decomposition_level_count: self.decomposition_level_count,
+        }
+    }
+}
+
+impl<C> FourierGgswCiphertext<C> {
+    pub fn new(
+        data: C,
+        polynomial_size: PolynomialSize,
+        glwe_size: GlweSize,
+        decomposition_base_log: DecompositionBaseLog,
+        decomposition_level_count: DecompositionLevelCount,
+    ) -> Self
+    where
+        C: Container,
+    {
+        assert_eq!(polynomial_size.0 % 2, 0);
+        assert_eq!(
+            data.container_len(),
+            polynomial_size.0 / 2 * glwe_size.0 * glwe_size.0 * decomposition_level_count.0
+        );
+
+        Self {
+            data,
+            polynomial_size,
+            glwe_size,
+            decomposition_base_log,
+            decomposition_level_count,
+        }
+    }
+
+    pub fn polynomial_size(&self) -> PolynomialSize {
+        self.polynomial_size
+    }
+
+    pub fn glwe_size(&self) -> GlweSize {
+        self.glwe_size
+    }
+
+    pub fn decomposition_base_log(&self) -> DecompositionBaseLog {
+        self.decomposition_base_log
+    }
+
+    pub fn decomposition_level_count(&self) -> DecompositionLevelCount {
+        self.decomposition_level_count
+    }
+
+    pub fn data(self) -> C {
+        self.data
+    }
+
+    pub fn as_view(&self) -> FourierGgswCiphertextView<'_>
+    where
+        C: AsRef<[c64]>,
+    {
+        FourierGgswCiphertextView {
+            data: self.data.as_ref(),
+            polynomial_size: self.polynomial_size,
+            glwe_size: self.glwe_size,
+            decomposition_base_log: self.decomposition_base_log,
+            decomposition_level_count: self.decomposition_level_count,
+        }
+    }
+
+    pub fn as_mut_view(&mut self) -> FourierGgswCiphertextMutView<'_>
+    where
+        C: AsMut<[c64]>,
+    {
+        FourierGgswCiphertextMutView {
+            data: self.data.as_mut(),
+            polynomial_size: self.polynomial_size,
+            glwe_size: self.glwe_size,
+            decomposition_base_log: self.decomposition_base_log,
+            decomposition_level_count: self.decomposition_level_count,
+        }
+    }
+}
+
+impl<C> FourierGgswLevelMatrix<C> {
+    pub fn new(
+        data: C,
+        polynomial_size: PolynomialSize,
+        glwe_size: GlweSize,
+        row_count: usize,
+        decomposition_level: DecompositionLevel,
+    ) -> Self
+    where
+        C: Container,
+    {
+        assert_eq!(polynomial_size.0 % 2, 0);
+        assert_eq!(
+            data.container_len(),
+            polynomial_size.0 / 2 * glwe_size.0 * row_count
+        );
+        Self {
+            data,
+            polynomial_size,
+            glwe_size,
+            row_count,
+            decomposition_level,
+        }
+    }
+
+    /// Returns an iterator over the rows of the level matrices.
+    pub fn into_rows(self) -> impl DoubleEndedIterator<Item = FourierGgswLevelRow<C>>
+    where
+        C: IntoChunks,
+    {
+        self.data
+            .split_into(self.row_count)
+            .map(move |slice| FourierGgswLevelRow {
+                data: slice,
+                polynomial_size: self.polynomial_size,
+                glwe_size: self.glwe_size,
+                decomposition_level: self.decomposition_level,
+            })
+    }
+
+    pub fn polynomial_size(&self) -> PolynomialSize {
+        self.polynomial_size
+    }
+
+    pub fn glwe_size(&self) -> GlweSize {
+        self.glwe_size
+    }
+
+    pub fn row_count(&self) -> usize {
+        self.row_count
+    }
+
+    pub fn decomposition_level(&self) -> DecompositionLevel {
+        self.decomposition_level
+    }
+
+    pub fn data(self) -> C {
+        self.data
+    }
+}
+
+impl<C> FourierGgswLevelRow<C> {
+    pub fn new(
+        data: C,
+        polynomial_size: PolynomialSize,
+        glwe_size: GlweSize,
+        decomposition_level: DecompositionLevel,
+    ) -> Self
+    where
+        C: Container,
+    {
+        assert_eq!(polynomial_size.0 % 2, 0);
+        assert_eq!(data.container_len(), polynomial_size.0 / 2 * glwe_size.0);
+        Self {
+            data,
+            polynomial_size,
+            glwe_size,
+            decomposition_level,
+        }
+    }
+
+    pub fn polynomial_size(&self) -> PolynomialSize {
+        self.polynomial_size
+    }
+
+    pub fn glwe_size(&self) -> GlweSize {
+        self.glwe_size
+    }
+
+    pub fn decomposition_level(&self) -> DecompositionLevel {
+        self.decomposition_level
+    }
+
+    pub fn data(self) -> C {
+        self.data
+    }
+}
+
+impl<'a> FourierGgswCiphertextView<'a> {
+    /// Returns an iterator over the level matrices.
+    pub fn into_levels(self) -> impl DoubleEndedIterator<Item = FourierGgswLevelMatrixView<'a>> {
+        self.data
+            .split_into(self.decomposition_level_count.0)
+            .enumerate()
+            .map(move |(i, slice)| {
+                FourierGgswLevelMatrixView::new(
+                    slice,
+                    self.polynomial_size,
+                    self.glwe_size,
+                    self.glwe_size.0,
+                    DecompositionLevel(i + 1),
+                )
+            })
+    }
+}
+
+/// Returns the required memory for [`FourierGgswCiphertextMutView::fill_with_forward_fourier`].
+pub fn fill_with_forward_fourier_scratch(fft: FftView<'_>) -> Result<StackReq, SizeOverflow> {
+    fft.forward_scratch()
+}
+
+impl<'a> FourierGgswCiphertextMutView<'a> {
+    /// Fills a GGSW ciphertext with the Fourier transform of a GGSW ciphertext in the standard
+    /// domain.
+    pub fn fill_with_forward_fourier<Scalar: UnsignedTorus>(
+        self,
+        coef_ggsw: StandardGgswCiphertextView<Scalar>,
+        fft: FftView<'_>,
+        mut stack: DynStack<'_>,
+    ) {
+        debug_assert_eq!(coef_ggsw.polynomial_size(), self.polynomial_size());
+        let poly_size = coef_ggsw.polynomial_size().0;
+
+        for (fourier_poly, coef_poly) in izip!(
+            self.data.into_chunks(poly_size / 2),
+            coef_ggsw.data.into_chunks(poly_size)
+        ) {
+            // SAFETY: forward_as_torus doesn't write any uninitialized values into its output
+            fft.forward_as_torus(
+                FourierPolynomialUninitMutView {
+                    data: unsafe { as_mut_uninit(fourier_poly) },
+                },
+                PolynomialView { data: coef_poly },
+                stack.rb_mut(),
+            );
+        }
+    }
+}
+
+/// Returns the required memory for [`external_product`].
+pub fn external_product_scratch<Scalar>(
+    glwe_size: GlweSize,
+    polynomial_size: PolynomialSize,
+    fft: FftView<'_>,
+) -> Result<StackReq, SizeOverflow> {
+    let align = CACHELINE_ALIGN;
+    let standard_scratch =
+        StackReq::try_new_aligned::<Scalar>(glwe_size.0 * polynomial_size.0, align)?;
+    let fourier_scratch =
+        StackReq::try_new_aligned::<c64>(glwe_size.0 * polynomial_size.0 / 2, align)?;
+    let fourier_scratch_single = StackReq::try_new_aligned::<c64>(polynomial_size.0 / 2, align)?;
+
+    let substack3 = fft.forward_scratch()?;
+    let substack2 = substack3.try_and(fourier_scratch_single)?;
+    let substack1 = substack2.try_and(standard_scratch)?;
+    let substack0 = StackReq::try_any_of([
+        substack1.try_and(standard_scratch)?,
+        fft.backward_scratch()?,
+    ])?;
+    substack0.try_and(fourier_scratch)
+}
+
+/// Performs the external product of `ggsw` and `glwe`, and stores the result in `out`.
+pub fn external_product<Scalar: UnsignedTorus>(
+    mut out: GlweCiphertextMutView<'_, Scalar>,
+    ggsw: FourierGgswCiphertextView<'_>,
+    glwe: GlweCiphertextView<'_, Scalar>,
+    fft: FftView<'_>,
+    stack: DynStack<'_>,
+) {
+    // we check that the polynomial sizes match
+    debug_assert_eq!(ggsw.polynomial_size(), glwe.polynomial_size());
+    debug_assert_eq!(ggsw.polynomial_size(), out.polynomial_size());
+    // we check that the glwe sizes match
+    debug_assert_eq!(ggsw.glwe_size(), glwe.glwe_size());
+    debug_assert_eq!(ggsw.glwe_size(), out.glwe_size());
+
+    let align = CACHELINE_ALIGN;
+    let poly_size = ggsw.polynomial_size.0;
+
+    // we round the input mask and body
+    let decomposer = SignedDecomposer::<Scalar>::new(
+        ggsw.decomposition_base_log(),
+        ggsw.decomposition_level_count(),
+    );
+
+    let (mut output_fft_buffer, mut substack0) =
+        stack.make_aligned_uninit::<c64>(poly_size / 2 * ggsw.glwe_size().0, align);
+    // output_fft_buffer is initially uninitialized, considered to be implicitly zero, to avoid
+    // the cost of filling it up with zeros. `is_output_uninit` is set to `false` once
+    // it has been fully initialized for the first time.
+    let output_fft_buffer = &mut *output_fft_buffer;
+    let mut is_output_uninit = true;
+
+    {
+        // ------------------------------------------------------ EXTERNAL PRODUCT IN FOURIER DOMAIN
+        // In this section, we perform the external product in the fourier domain, and accumulate
+        // the result in the output_fft_buffer variable.
+        let (mut decomposition, mut substack1) = TensorSignedDecompositionLendingIter::new(
+            glwe.data()
+                .iter()
+                .map(|s| decomposer.closest_representable(*s)),
+            DecompositionBaseLog(decomposer.base_log),
+            DecompositionLevelCount(decomposer.level_count),
+            substack0.rb_mut(),
+        );
+
+        // We loop through the levels (we reverse to match the order of the decomposition iterator.)
+        ggsw.into_levels().rev().for_each(|ggsw_decomp_matrix| {
+            // We retrieve the decomposition of this level.
+            let (glwe_level, glwe_decomp_term, mut substack2) =
+                collect_next_term(&mut decomposition, &mut substack1, align);
+            let glwe_decomp_term =
+                GlweCiphertextView::new(&glwe_decomp_term, ggsw.polynomial_size, ggsw.glwe_size);
+            debug_assert_eq!(ggsw_decomp_matrix.decomposition_level(), glwe_level);
+
+            // For each level we have to add the result of the vector-matrix product between the
+            // decomposition of the glwe, and the ggsw level matrix to the output. To do so, we
+            // iteratively add to the output, the product between every line of the matrix, and
+            // the corresponding (scalar) polynomial in the glwe decomposition:
+            //
+            //                ggsw_mat                        ggsw_mat
+            //   glwe_dec   | - - - - | <        glwe_dec   | - - - - |
+            //  | - - - | x | - - - - |         | - - - | x | - - - - | <
+            //    ^         | - - - - |             ^       | - - - - |
+            //
+            //        t = 1                           t = 2                     ...
+
+            izip!(
+                ggsw_decomp_matrix.into_rows(),
+                glwe_decomp_term.into_polynomials()
+            )
+            .for_each(|(ggsw_row, glwe_poly)| {
+                let (mut fourier, substack3) = substack2
+                    .rb_mut()
+                    .make_aligned_uninit::<c64>(poly_size / 2, align);
+                // We perform the forward fft transform for the glwe polynomial
+                let fourier = fft
+                    .forward_as_integer(
+                        FourierPolynomialUninitMutView { data: &mut fourier },
+                        glwe_poly,
+                        substack3,
+                    )
+                    .data;
+                // Now we loop through the polynomials of the output, and add the
+                // corresponding product of polynomials.
+
+                // SAFETY: see comment above definition of `output_fft_buffer`
+                unsafe {
+                    update_with_fmadd(
+                        output_fft_buffer,
+                        ggsw_row,
+                        fourier,
+                        is_output_uninit,
+                        poly_size,
+                    )
+                };
+
+                // we initialized `output_fft_buffer, so we can set this to false
+                is_output_uninit = false;
+            });
+        });
+    }
+
+    // --------------------------------------------  TRANSFORMATION OF RESULT TO STANDARD DOMAIN
+    // In this section, we bring the result from the fourier domain, back to the standard
+    // domain, and add it to the output.
+    //
+    // We iterate over the polynomials in the output.
+    if !is_output_uninit {
+        // SAFETY: output_fft_buffer is initialized, since `is_output_uninit` is false
+        let output_fft_buffer = &*unsafe { assume_init_mut(output_fft_buffer) };
+        izip!(
+            out.as_mut_view().into_polynomials(),
+            output_fft_buffer
+                .into_chunks(poly_size / 2)
+                .map(|slice| FourierPolynomialView { data: slice }),
+        )
+        .for_each(|(out, fourier)| {
+            fft.add_backward_as_torus(out, fourier, substack0.rb_mut());
+        });
+    }
+}
+
+fn collect_next_term<'a, Scalar: UnsignedTorus>(
+    decomposition: &mut TensorSignedDecompositionLendingIter<'_, Scalar>,
+    substack1: &'a mut DynStack,
+    align: usize,
+) -> (
+    DecompositionLevel,
+    dyn_stack::DynArray<'a, Scalar>,
+    DynStack<'a>,
+) {
+    let (glwe_level, _, glwe_decomp_term) = decomposition.next_term().unwrap();
+    let (glwe_decomp_term, substack2) = substack1.rb_mut().collect_aligned(align, glwe_decomp_term);
+    (glwe_level, glwe_decomp_term, substack2)
+}
+
+/// # Note
+///
+/// this function leaves all the elements of `output_fourier` in an initialized state.
+///
+/// # Safety
+///
+///  - if `is_output_uninit` is false, `output_fourier` must not hold any uninitialized values.
+///  - `is_x86_feature_detected!("avx512f")` must be true.
+#[cfg(all(
+    feature = "backend_fft_nightly_avx512",
+    any(target_arch = "x86_64", target_arch = "x86")
+))]
+#[target_feature(enable = "avx512f")]
+unsafe fn update_with_fmadd_avx512(
+    output_fourier: &mut [MaybeUninit<c64>],
+    ggsw_poly: &[c64],
+    fourier: &[c64],
+    is_output_uninit: bool,
+) {
+    let n = output_fourier.len();
+
+    debug_assert_eq!(n, ggsw_poly.len());
+    debug_assert_eq!(n, fourier.len());
+    debug_assert_eq!(n % 4, 0);
+
+    let out = output_fourier.as_mut_ptr();
+    let lhs = ggsw_poly.as_ptr();
+    let rhs = fourier.as_ptr();
+
+    // 4×c64 per register
+
+    if is_output_uninit {
+        for i in 0..n / 4 {
+            let i = 4 * i;
+            let ab = _mm512_loadu_pd(lhs.add(i) as _);
+            let xy = _mm512_loadu_pd(rhs.add(i) as _);
+            let aa = _mm512_unpacklo_pd(ab, ab);
+            let bb = _mm512_unpackhi_pd(ab, ab);
+            let yx = _mm512_permute_pd::<0b01010101>(xy);
+            _mm512_storeu_pd(
+                out.add(i) as _,
+                _mm512_fmaddsub_pd(aa, xy, _mm512_mul_pd(bb, yx)),
+            );
+        }
+    } else {
+        for i in 0..n / 4 {
+            let i = 4 * i;
+            let ab = _mm512_loadu_pd(lhs.add(i) as _);
+            let xy = _mm512_loadu_pd(rhs.add(i) as _);
+            let aa = _mm512_unpacklo_pd(ab, ab);
+            let bb = _mm512_unpackhi_pd(ab, ab);
+            let yx = _mm512_permute_pd::<0b01010101>(xy);
+            _mm512_storeu_pd(
+                out.add(i) as _,
+                _mm512_fmaddsub_pd(
+                    aa,
+                    xy,
+                    _mm512_fmaddsub_pd(bb, yx, _mm512_loadu_pd(out.add(i) as _)),
+                ),
+            );
+        }
+    }
+}
+
+/// # Note
+///
+/// this function leaves all the elements of `output_fourier` in an initialized state.
+///
+/// # Safety
+///
+///  - if `is_output_uninit` is false, `output_fourier` must not hold any uninitialized values.
+///  - `is_x86_feature_detected!("fma")` must be true.
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "fma")]
+unsafe fn update_with_fmadd_fma(
+    output_fourier: &mut [MaybeUninit<c64>],
+    ggsw_poly: &[c64],
+    fourier: &[c64],
+    is_output_uninit: bool,
+) {
+    let n = output_fourier.len();
+
+    debug_assert_eq!(n, ggsw_poly.len());
+    debug_assert_eq!(n, fourier.len());
+    debug_assert_eq!(n % 4, 0);
+
+    let out = output_fourier.as_mut_ptr();
+    let lhs = ggsw_poly.as_ptr();
+    let rhs = fourier.as_ptr();
+
+    // 2×c64 per register
+
+    if is_output_uninit {
+        for i in 0..n / 2 {
+            let i = 2 * i;
+            let ab = _mm256_loadu_pd(lhs.add(i) as _);
+            let xy = _mm256_loadu_pd(rhs.add(i) as _);
+            let aa = _mm256_unpacklo_pd(ab, ab);
+            let bb = _mm256_unpackhi_pd(ab, ab);
+            let yx = _mm256_permute_pd::<0b0101>(xy);
+            _mm256_storeu_pd(
+                out.add(i) as _,
+                _mm256_fmaddsub_pd(aa, xy, _mm256_mul_pd(bb, yx)),
+            );
+        }
+    } else {
+        for i in 0..n / 2 {
+            let i = 2 * i;
+            let ab = _mm256_loadu_pd(lhs.add(i) as _);
+            let xy = _mm256_loadu_pd(rhs.add(i) as _);
+            let aa = _mm256_unpacklo_pd(ab, ab);
+            let bb = _mm256_unpackhi_pd(ab, ab);
+            let yx = _mm256_permute_pd::<0b0101>(xy);
+            _mm256_storeu_pd(
+                out.add(i) as _,
+                _mm256_fmaddsub_pd(
+                    aa,
+                    xy,
+                    _mm256_fmaddsub_pd(bb, yx, _mm256_loadu_pd(out.add(i) as _)),
+                ),
+            );
+        }
+    }
+}
+
+/// # Note
+///
+/// this function leaves all the elements of `output_fourier` in an initialized state.
+///
+/// # Safety
+///
+///  - if `is_output_uninit` is false, `output_fourier` must not hold any uninitialized values.
+unsafe fn update_with_fmadd_scalar(
+    output_fourier: &mut [MaybeUninit<c64>],
+    ggsw_poly: &[c64],
+    fourier: &[c64],
+    is_output_uninit: bool,
+) {
+    if is_output_uninit {
+        // we're writing to output_fft_buffer for the first time
+        // so its contents are uninitialized
+        izip!(output_fourier, ggsw_poly, fourier).for_each(|(out_fourier, lhs, rhs)| {
+            out_fourier.write(lhs * rhs);
+        });
+    } else {
+        // we already wrote to output_fft_buffer, so we can assume its contents are
+        // initialized.
+        izip!(output_fourier, ggsw_poly, fourier).for_each(|(out_fourier, lhs, rhs)| {
+            *{ out_fourier.assume_init_mut() } += lhs * rhs;
+        });
+    }
+}
+
+/// # Note
+///
+/// this function leaves all the elements of `output_fourier` in an initialized state.
+///
+/// # Safety
+///
+///  - if `is_output_uninit` is false, `output_fourier` must not hold any uninitialized values.
+unsafe fn update_with_fmadd(
+    output_fft_buffer: &mut [MaybeUninit<c64>],
+    ggsw_row: FourierGgswLevelRowView,
+    fourier: &[c64],
+    is_output_uninit: bool,
+    poly_size: usize,
+) {
+    #[allow(clippy::type_complexity)]
+    let ptr_fn = || -> unsafe fn(&mut [MaybeUninit<c64>], &[c64], &[c64], bool) {
+        #[cfg(all(
+            feature = "backend_fft_nightly_avx512",
+            any(target_arch = "x86_64", target_arch = "x86")
+        ))]
+        if is_x86_feature_detected!("avx512f") {
+            return update_with_fmadd_avx512;
+        }
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        if is_x86_feature_detected!("fma") {
+            return update_with_fmadd_fma;
+        }
+
+        update_with_fmadd_scalar
+    };
+
+    let ptr = ptr_fn();
+
+    izip!(
+        output_fft_buffer.into_chunks(poly_size / 2),
+        ggsw_row.data.into_chunks(poly_size / 2)
+    )
+    .for_each(|(output_fourier, ggsw_poly)| {
+        ptr(output_fourier, ggsw_poly, fourier, is_output_uninit);
+    });
+}
+
+/// Returns the required memory for [`cmux`].
+pub fn cmux_scratch<Scalar>(
+    glwe_size: GlweSize,
+    polynomial_size: PolynomialSize,
+    fft: FftView<'_>,
+) -> Result<StackReq, SizeOverflow> {
+    external_product_scratch::<Scalar>(glwe_size, polynomial_size, fft)
+}
+
+/// This cmux mutates both ct1 and ct0. The result is in ct0 after the method was called.
+pub fn cmux<Scalar: UnsignedTorus>(
+    ct0: GlweCiphertextMutView<'_, Scalar>,
+    mut ct1: GlweCiphertextMutView<'_, Scalar>,
+    ggsw: FourierGgswCiphertextView<'_>,
+    fft: FftView<'_>,
+    stack: DynStack<'_>,
+) {
+    izip!(ct1.as_mut_view().data(), ct0.as_view().data()).for_each(|(c1, c0)| {
+        *c1 = c1.wrapping_sub(*c0);
+    });
+    external_product(ct0, ggsw, ct1.as_view(), fft, stack);
+}

--- a/concrete-core/src/backends/fft/private/crypto/glwe.rs
+++ b/concrete-core/src/backends/fft/private/crypto/glwe.rs
@@ -1,0 +1,108 @@
+use super::super::math::polynomial::*;
+use super::super::{Container, IntoChunks};
+use crate::commons::math::torus::UnsignedTorus;
+use concrete_commons::parameters::{GlweSize, PolynomialSize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "backend_fft_serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct GlweCiphertext<C> {
+    data: C,
+    polynomial_size: PolynomialSize,
+    glwe_size: GlweSize,
+}
+
+pub type GlweCiphertextView<'a, Scalar> = GlweCiphertext<&'a [Scalar]>;
+pub type GlweCiphertextMutView<'a, Scalar> = GlweCiphertext<&'a mut [Scalar]>;
+
+impl<C> GlweCiphertext<C> {
+    pub fn new(data: C, polynomial_size: PolynomialSize, glwe_size: GlweSize) -> Self
+    where
+        C: Container,
+    {
+        assert_eq!(data.container_len(), polynomial_size.0 * glwe_size.0);
+
+        Self {
+            data,
+            polynomial_size,
+            glwe_size,
+        }
+    }
+
+    /// Returns an iterator over the polynomials in `self`.
+    pub fn into_polynomials(self) -> impl DoubleEndedIterator<Item = Polynomial<C>>
+    where
+        C: IntoChunks,
+    {
+        self.data
+            .split_into(self.glwe_size.0)
+            .map(|chunk| Polynomial { data: chunk })
+    }
+
+    pub fn data(self) -> C {
+        self.data
+    }
+
+    pub fn polynomial_size(&self) -> PolynomialSize {
+        self.polynomial_size
+    }
+
+    pub fn glwe_size(&self) -> GlweSize {
+        self.glwe_size
+    }
+
+    pub fn as_view<Scalar>(&self) -> GlweCiphertextView<'_, Scalar>
+    where
+        C: AsRef<[Scalar]>,
+    {
+        GlweCiphertext {
+            data: self.data.as_ref(),
+            polynomial_size: self.polynomial_size,
+            glwe_size: self.glwe_size,
+        }
+    }
+
+    pub fn as_mut_view<Scalar>(&mut self) -> GlweCiphertextMutView<'_, Scalar>
+    where
+        C: AsMut<[Scalar]>,
+    {
+        GlweCiphertext {
+            data: self.data.as_mut(),
+            polynomial_size: self.polynomial_size,
+            glwe_size: self.glwe_size,
+        }
+    }
+}
+
+impl<'a, Scalar> GlweCiphertextView<'a, Scalar> {
+    /// Fills an LWE ciphertext with the extraction of one coefficient of the current GLWE
+    /// ciphertext.
+    pub fn fill_lwe_with_sample_extraction(self, lwe: &mut [Scalar], nth: usize)
+    where
+        Scalar: UnsignedTorus,
+    {
+        let (lwe_body, lwe_mask) = lwe.split_last_mut().unwrap();
+        let (glwe_mask, glwe_body) = self
+            .data
+            .split_at(self.polynomial_size.0 * (self.glwe_size.0 - 1));
+
+        // We copy the body
+        *lwe_body = glwe_body[nth];
+
+        // We copy the mask (each polynomial is in the wrong order)
+        lwe_mask.copy_from_slice(glwe_mask);
+
+        // We compute the number of elements which must be
+        // turned into their opposite
+        let opposite_count = self.polynomial_size.0 - nth - 1;
+        for lwe_mask_poly in lwe_mask.into_chunks(self.polynomial_size.0) {
+            lwe_mask_poly.reverse();
+            for x in &mut lwe_mask_poly[0..opposite_count] {
+                *x = x.wrapping_neg();
+            }
+            lwe_mask_poly.rotate_left(opposite_count);
+        }
+    }
+}

--- a/concrete-core/src/backends/fft/private/crypto/mod.rs
+++ b/concrete-core/src/backends/fft/private/crypto/mod.rs
@@ -1,0 +1,3 @@
+pub mod bootstrap;
+pub mod ggsw;
+pub mod glwe;

--- a/concrete-core/src/backends/fft/private/math/decomposition.rs
+++ b/concrete-core/src/backends/fft/private/math/decomposition.rs
@@ -1,0 +1,86 @@
+pub use crate::commons::math::decomposition::DecompositionLevel;
+use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+use dyn_stack::{DynArray, DynStack};
+use std::iter::Map;
+use std::slice::IterMut;
+
+// copied from src/commons/math/decomposition/*.rs
+// in order to avoid allocations
+
+pub struct TensorSignedDecompositionLendingIter<'buffers, Scalar: UnsignedInteger> {
+    // The base log of the decomposition
+    base_log: usize,
+    // The current level
+    current_level: usize,
+    // A mask which allows to compute the mod B of a value. For B=2^4, this guy is of the form:
+    // ...0001111
+    mod_b_mask: Scalar,
+    // The internal states of each decomposition
+    states: DynArray<'buffers, Scalar>,
+    // A flag which stores whether the iterator is a fresh one (for the recompose method).
+    fresh: bool,
+}
+
+impl<'buffers, Scalar: UnsignedInteger> TensorSignedDecompositionLendingIter<'buffers, Scalar> {
+    pub(crate) fn new(
+        input: impl Iterator<Item = Scalar>,
+        base_log: DecompositionBaseLog,
+        level: DecompositionLevelCount,
+        stack: DynStack<'buffers>,
+    ) -> (Self, DynStack<'buffers>) {
+        let (states, stack) = stack.collect_aligned(
+            aligned_vec::CACHELINE_ALIGN,
+            input.map(|i| i >> (Scalar::BITS - base_log.0 * level.0)),
+        );
+        (
+            TensorSignedDecompositionLendingIter {
+                base_log: base_log.0,
+                current_level: level.0,
+                mod_b_mask: (Scalar::ONE << base_log.0) - Scalar::ONE,
+                states,
+                fresh: true,
+            },
+            stack,
+        )
+    }
+
+    // inlining this improves perf of external product by about 25%, even in LTO builds
+    #[inline]
+    pub fn next_term<'short>(
+        &'short mut self,
+    ) -> Option<(
+        DecompositionLevel,
+        DecompositionBaseLog,
+        Map<IterMut<'short, Scalar>, impl FnMut(&'short mut Scalar) -> Scalar>,
+    )> {
+        // The iterator is not fresh anymore.
+        self.fresh = false;
+        // We check if the decomposition is over
+        if self.current_level == 0 {
+            return None;
+        }
+        let current_level = self.current_level;
+        let base_log = self.base_log;
+        let mod_b_mask = self.mod_b_mask;
+        self.current_level -= 1;
+
+        Some((
+            DecompositionLevel(current_level),
+            DecompositionBaseLog(self.base_log),
+            self.states
+                .iter_mut()
+                .map(move |state| decompose_one_level(base_log, state, mod_b_mask)),
+        ))
+    }
+}
+
+#[inline]
+fn decompose_one_level<S: UnsignedInteger>(base_log: usize, state: &mut S, mod_b_mask: S) -> S {
+    let res = *state & mod_b_mask;
+    *state >>= base_log;
+    let mut carry = (res.wrapping_sub(S::ONE) | *state) & res;
+    carry >>= base_log - 1;
+    *state += carry;
+    res.wrapping_sub(carry << base_log)
+}

--- a/concrete-core/src/backends/fft/private/math/fft.rs
+++ b/concrete-core/src/backends/fft/private/math/fft.rs
@@ -1,0 +1,730 @@
+use super::super::{assume_init_mut, c64, izip};
+use super::polynomial::{
+    FourierPolynomialMutView, FourierPolynomialUninitMutView, FourierPolynomialView,
+    PolynomialMutView, PolynomialUninitMutView, PolynomialView,
+};
+use crate::commons::math::torus::UnsignedTorus;
+use aligned_vec::{avec, ABox};
+use concrete_commons::numeric::CastInto;
+use concrete_commons::parameters::PolynomialSize;
+use concrete_fft::unordered::{Method, Plan};
+use dyn_stack::{DynStack, SizeOverflow, StackReq};
+use once_cell::sync::OnceCell;
+use std::any::TypeId;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::mem::{align_of, size_of, MaybeUninit};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+/// Twisting factors from the paper:
+/// [Fast and Error-Free Negacyclic Integer Convolution using Extended Fourier Transform][paper]
+///
+/// The real and imaginary parts form (the first `N/2`) `2N`-th roots of unity.
+///
+/// [paper]: https://eprint.iacr.org/2021/480
+#[derive(Clone, Debug, PartialEq)]
+pub struct Twisties {
+    re: ABox<[f64]>,
+    im: ABox<[f64]>,
+}
+
+/// View type for [`Twisties`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TwistiesView<'a> {
+    re: &'a [f64],
+    im: &'a [f64],
+}
+
+impl Twisties {
+    pub fn as_view(&self) -> TwistiesView<'_> {
+        TwistiesView {
+            re: &self.re,
+            im: &self.im,
+        }
+    }
+}
+
+impl Twisties {
+    /// Creates a new [`Twisties`] containing the `2N`-th roots of unity with `n = N/2`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is not a power of two.
+    pub fn new(n: usize) -> Self {
+        debug_assert!(n.is_power_of_two());
+        let mut re = avec![0.0; n].into_boxed_slice();
+        let mut im = avec![0.0; n].into_boxed_slice();
+
+        let unit = core::f64::consts::PI / (2.0 * n as f64);
+        for (i, (re, im)) in izip!(&mut *re, &mut *im).enumerate() {
+            (*im, *re) = (i as f64 * unit).sin_cos();
+        }
+
+        Twisties { re, im }
+    }
+}
+
+/// Negacyclic Fast Fourier Transform. See [`FftView`] for transform functions.
+///
+/// This structure contains the twisting factors as well as the
+/// FFT plan needed for the negacyclic convolution over the reals.
+#[derive(Clone, Debug)]
+pub struct Fft {
+    plan: Arc<(Twisties, Plan)>,
+}
+
+/// View type for [`Fft`].
+#[derive(Clone, Copy, Debug)]
+pub struct FftView<'a> {
+    plan: &'a Plan,
+    twisties: TwistiesView<'a>,
+}
+
+impl Fft {
+    #[inline]
+    pub fn as_view(&self) -> FftView<'_> {
+        FftView {
+            plan: &self.plan.1,
+            twisties: self.plan.0.as_view(),
+        }
+    }
+}
+
+type PlanMap = RwLock<HashMap<usize, Arc<OnceCell<Arc<(Twisties, Plan)>>>>>;
+static PLANS: OnceCell<PlanMap> = OnceCell::new();
+fn plans() -> &'static PlanMap {
+    PLANS.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Returns the input slice, cast to the same type.
+///
+/// This is useful when the fact that `From` and `To` are the same type cannot be proven in the
+/// type system, but is known to be true at runtime.
+///
+/// # Panics
+///
+/// Panics if `From` and `To` are not the same type
+#[inline]
+fn cast_same_type<From: 'static, To: 'static>(slice: &mut [From]) -> &mut [To] {
+    assert_eq!(size_of::<From>(), size_of::<To>());
+    assert_eq!(align_of::<From>(), align_of::<To>());
+    assert_eq!(TypeId::of::<From>(), TypeId::of::<To>());
+
+    let len = slice.len();
+    let ptr = slice.as_mut_ptr();
+    unsafe { core::slice::from_raw_parts_mut(ptr as *mut To, len) }
+}
+
+impl Fft {
+    /// Real polynomial of size `size`.
+    pub fn new(size: PolynomialSize) -> Self {
+        let global_plans = plans();
+
+        let n = size.0;
+        let get_plan = || {
+            let plans = global_plans.read().unwrap();
+            let plan = plans.get(&n).cloned();
+            drop(plans);
+
+            plan.map(|p| {
+                p.get_or_init(|| {
+                    Arc::new((
+                        Twisties::new(n / 2),
+                        Plan::new(n / 2, Method::Measure(Duration::from_millis(10))),
+                    ))
+                })
+                .clone()
+            })
+        };
+
+        // could not find a plan of the given size, we lock the map again and try to insert it
+        let mut plans = global_plans.write().unwrap();
+        if let Entry::Vacant(v) = plans.entry(n) {
+            v.insert(Arc::new(OnceCell::new()));
+        }
+
+        drop(plans);
+
+        Self {
+            plan: get_plan().unwrap(),
+        }
+    }
+}
+
+fn convert_forward_torus<Scalar: UnsignedTorus>(
+    out: &mut [MaybeUninit<c64>],
+    in_re: &[Scalar],
+    in_im: &[Scalar],
+    twisties: TwistiesView<'_>,
+) {
+    let normalization = 2.0_f64.powi(-(Scalar::BITS as i32));
+
+    izip!(out, in_re, in_im, twisties.re, twisties.im).for_each(
+        |(out, in_re, in_im, w_re, w_im)| {
+            let in_re: f64 = in_re.into_signed().cast_into() * normalization;
+            let in_im: f64 = in_im.into_signed().cast_into() * normalization;
+            out.write(
+                c64 {
+                    re: in_re,
+                    im: in_im,
+                } * c64 {
+                    re: *w_re,
+                    im: *w_im,
+                },
+            );
+        },
+    );
+}
+
+fn convert_forward_integer<Scalar: UnsignedTorus>(
+    out: &mut [MaybeUninit<c64>],
+    in_re: &[Scalar],
+    in_im: &[Scalar],
+    twisties: TwistiesView<'_>,
+) {
+    izip!(out, in_re, in_im, twisties.re, twisties.im).for_each(
+        |(out, in_re, in_im, w_re, w_im)| {
+            let in_re: f64 = in_re.into_signed().cast_into();
+            let in_im: f64 = in_im.into_signed().cast_into();
+            out.write(
+                c64 {
+                    re: in_re,
+                    im: in_im,
+                } * c64 {
+                    re: *w_re,
+                    im: *w_im,
+                },
+            );
+        },
+    );
+}
+
+fn convert_backward_torus<Scalar: UnsignedTorus>(
+    out_re: &mut [MaybeUninit<Scalar>],
+    out_im: &mut [MaybeUninit<Scalar>],
+    inp: &[c64],
+    twisties: TwistiesView<'_>,
+) {
+    let normalization = 1.0 / inp.len() as f64;
+    izip!(out_re, out_im, inp, twisties.re, twisties.im).for_each(
+        |(out_re, out_im, inp, w_re, w_im)| {
+            let tmp = inp
+                * (c64 {
+                    re: *w_re,
+                    im: -*w_im,
+                } * normalization);
+
+            out_re.write(Scalar::from_torus(tmp.re));
+            out_im.write(Scalar::from_torus(tmp.im));
+        },
+    );
+}
+
+/// Performs common work for `u32` and `u64`, used by the backward torus transformation.
+///
+/// # Safety
+///
+///  - `w_re.add(i)`, `w_im.add(i)`, and `inp.add(i)` must point to an array of at least 4
+///  elements.
+///  - `is_x86_feature_detected!("fma")` must be true.
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[inline(always)]
+unsafe fn convert_torus_prologue_fma(
+    normalization: __m256d,
+    w_re: *const f64,
+    i: usize,
+    w_im: *const f64,
+    inp: *const c64,
+    scaling: __m256d,
+) -> (__m256d, __m256d) {
+    let w_re = _mm256_mul_pd(normalization, _mm256_loadu_pd(w_re.add(i)));
+    let w_im = _mm256_mul_pd(normalization, _mm256_loadu_pd(w_im.add(i)));
+
+    // re0 im0
+    // re1 im1
+    // re2 im2
+    // re3 im3
+    let inp0 = _mm_loadu_pd(inp.add(i) as _);
+    let inp1 = _mm_loadu_pd(inp.add(i + 1) as _);
+    let inp2 = _mm_loadu_pd(inp.add(i + 2) as _);
+    let inp3 = _mm_loadu_pd(inp.add(i + 3) as _);
+
+    let inp_re01 = _mm_unpacklo_pd(inp0, inp1);
+    let inp_im01 = _mm_unpackhi_pd(inp0, inp1);
+    let inp_re23 = _mm_unpacklo_pd(inp2, inp3);
+    let inp_im23 = _mm_unpackhi_pd(inp2, inp3);
+
+    let inp_re = _mm256_insertf128_pd::<0b1>(_mm256_castpd128_pd256(inp_re01), inp_re23);
+    let inp_im = _mm256_insertf128_pd::<0b1>(_mm256_castpd128_pd256(inp_im01), inp_im23);
+
+    let mul_re = _mm256_fmadd_pd(inp_re, w_re, _mm256_mul_pd(inp_im, w_im));
+    let mul_im = _mm256_fnmadd_pd(inp_re, w_im, _mm256_mul_pd(inp_im, w_re));
+
+    const ROUNDING: i32 = _MM_FROUND_NINT | _MM_FROUND_NO_EXC;
+
+    let fract_re = _mm256_sub_pd(mul_re, _mm256_round_pd::<ROUNDING>(mul_re));
+    let fract_im = _mm256_sub_pd(mul_im, _mm256_round_pd::<ROUNDING>(mul_im));
+    let fract_re = _mm256_round_pd::<ROUNDING>(_mm256_mul_pd(scaling, fract_re));
+    let fract_im = _mm256_round_pd::<ROUNDING>(_mm256_mul_pd(scaling, fract_im));
+
+    (fract_re, fract_im)
+}
+
+/// See [`convert_add_backward_torus`].
+///
+/// # Safety
+///
+///  - Same preconditions as [`convert_add_backward_torus`].
+///  - `is_x86_feature_detected!("fma")` must be true.
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "fma")]
+unsafe fn convert_add_backward_torus_u32_fma(
+    out_re: &mut [MaybeUninit<u32>],
+    out_im: &mut [MaybeUninit<u32>],
+    inp: &[c64],
+    twisties: TwistiesView<'_>,
+) {
+    let n = out_re.len();
+    debug_assert_eq!(n % 4, 0);
+    debug_assert_eq!(n, out_re.len());
+    debug_assert_eq!(n, out_im.len());
+    debug_assert_eq!(n, inp.len());
+    debug_assert_eq!(n, twisties.re.len());
+    debug_assert_eq!(n, twisties.im.len());
+
+    let normalization = _mm256_set1_pd(1.0 / n as f64);
+    let scaling = _mm256_set1_pd(2.0_f64.powi(u32::BITS as i32));
+    let out_re = out_re.as_mut_ptr() as *mut u32;
+    let out_im = out_im.as_mut_ptr() as *mut u32;
+    let inp = inp.as_ptr();
+    let w_re = twisties.re.as_ptr();
+    let w_im = twisties.im.as_ptr();
+
+    for i in 0..n / 4 {
+        let i = i * 4;
+
+        let (fract_re, fract_im) =
+            convert_torus_prologue_fma(normalization, w_re, i, w_im, inp, scaling);
+
+        let fract_re = _mm256_cvtpd_epi32(fract_re);
+        let fract_im = _mm256_cvtpd_epi32(fract_im);
+        _mm_storeu_si128(
+            out_re.add(i) as _,
+            _mm_add_epi32(fract_re, _mm_loadu_si128(out_re.add(i) as _)),
+        );
+        _mm_storeu_si128(
+            out_im.add(i) as _,
+            _mm_add_epi32(fract_im, _mm_loadu_si128(out_im.add(i) as _)),
+        );
+    }
+}
+
+/// Performs common work for `u32` and `u64`, used by the backward torus transformation.
+///
+/// # Safety
+///
+///  - `w_re.add(i)`, `w_im.add(i)`, and `inp.add(i)` must point to an array of at least 8
+///  elements.
+///  - `is_x86_feature_detected!("avx512f")` must be true.
+#[cfg(all(
+    feature = "backend_fft_nightly_avx512",
+    any(target_arch = "x86_64", target_arch = "x86")
+))]
+#[inline(always)]
+unsafe fn convert_torus_prologue_avx512f(
+    normalization: __m512d,
+    w_re: *const f64,
+    i: usize,
+    w_im: *const f64,
+    inp: *const c64,
+    scaling: __m512d,
+) -> (__m512d, __m512d) {
+    let w_re = _mm512_mul_pd(normalization, _mm512_loadu_pd(w_re.add(i)));
+    let w_im = _mm512_mul_pd(normalization, _mm512_loadu_pd(w_im.add(i)));
+
+    // re0 im0
+    // re1 im1
+    // re2 im2
+    // re3 im3
+    // re4 im4
+    // re5 im5
+    // re6 im6
+    // re7 im7
+    let inp0 = _mm_loadu_pd(inp.add(i) as _);
+    let inp1 = _mm_loadu_pd(inp.add(i + 1) as _);
+    let inp2 = _mm_loadu_pd(inp.add(i + 2) as _);
+    let inp3 = _mm_loadu_pd(inp.add(i + 3) as _);
+    let inp4 = _mm_loadu_pd(inp.add(i + 4) as _);
+    let inp5 = _mm_loadu_pd(inp.add(i + 5) as _);
+    let inp6 = _mm_loadu_pd(inp.add(i + 6) as _);
+    let inp7 = _mm_loadu_pd(inp.add(i + 7) as _);
+
+    let inp_re01 = _mm_unpacklo_pd(inp0, inp1);
+    let inp_im01 = _mm_unpackhi_pd(inp0, inp1);
+    let inp_re23 = _mm_unpacklo_pd(inp2, inp3);
+    let inp_im23 = _mm_unpackhi_pd(inp2, inp3);
+    let inp_re45 = _mm_unpacklo_pd(inp4, inp5);
+    let inp_im45 = _mm_unpackhi_pd(inp4, inp5);
+    let inp_re67 = _mm_unpacklo_pd(inp6, inp7);
+    let inp_im67 = _mm_unpackhi_pd(inp6, inp7);
+
+    let inp_re0123 = _mm256_insertf128_pd::<0b1>(_mm256_castpd128_pd256(inp_re01), inp_re23);
+    let inp_im0123 = _mm256_insertf128_pd::<0b1>(_mm256_castpd128_pd256(inp_im01), inp_im23);
+    let inp_re4567 = _mm256_insertf128_pd::<0b1>(_mm256_castpd128_pd256(inp_re45), inp_re67);
+    let inp_im4567 = _mm256_insertf128_pd::<0b1>(_mm256_castpd128_pd256(inp_im45), inp_im67);
+
+    let cast = _mm512_castpd256_pd512;
+
+    let inp_re = _mm512_shuffle_f64x2::<0b01000100>(cast(inp_re0123), cast(inp_re4567));
+    let inp_im = _mm512_shuffle_f64x2::<0b01000100>(cast(inp_im0123), cast(inp_im4567));
+
+    let mul_re = _mm512_fmadd_pd(inp_re, w_re, _mm512_mul_pd(inp_im, w_im));
+    let mul_im = _mm512_fnmadd_pd(inp_re, w_im, _mm512_mul_pd(inp_im, w_re));
+
+    const ROUNDING: i32 = _MM_FROUND_TO_NEAREST_INT;
+
+    let fract_re = _mm512_sub_pd(mul_re, _mm512_roundscale_pd::<ROUNDING>(mul_re));
+    let fract_im = _mm512_sub_pd(mul_im, _mm512_roundscale_pd::<ROUNDING>(mul_im));
+    let fract_re = _mm512_roundscale_pd::<ROUNDING>(_mm512_mul_pd(scaling, fract_re));
+    let fract_im = _mm512_roundscale_pd::<ROUNDING>(_mm512_mul_pd(scaling, fract_im));
+
+    (fract_re, fract_im)
+}
+
+/// See [`convert_add_backward_torus`].
+///
+/// # Safety
+///
+///  - Same preconditions as [`convert_add_backward_torus`].
+///  - `is_x86_feature_detected!("avx512f")` must be true.
+#[cfg(all(
+    feature = "backend_fft_nightly_avx512",
+    any(target_arch = "x86_64", target_arch = "x86")
+))]
+#[target_feature(enable = "avx512f")]
+unsafe fn convert_add_backward_torus_u32_avx512f(
+    out_re: &mut [MaybeUninit<u32>],
+    out_im: &mut [MaybeUninit<u32>],
+    inp: &[c64],
+    twisties: TwistiesView<'_>,
+) {
+    let n = out_re.len();
+    debug_assert_eq!(n % 8, 0);
+    debug_assert_eq!(n, out_re.len());
+    debug_assert_eq!(n, out_im.len());
+    debug_assert_eq!(n, inp.len());
+    debug_assert_eq!(n, twisties.re.len());
+    debug_assert_eq!(n, twisties.im.len());
+
+    let normalization = _mm512_set1_pd(1.0 / n as f64);
+    let scaling = _mm512_set1_pd(2.0_f64.powi(u32::BITS as i32));
+    let out_re = out_re.as_mut_ptr() as *mut u32;
+    let out_im = out_im.as_mut_ptr() as *mut u32;
+    let inp = inp.as_ptr();
+    let w_re = twisties.re.as_ptr();
+    let w_im = twisties.im.as_ptr();
+
+    for i in 0..n / 8 {
+        let i = i * 8;
+
+        let (fract_re, fract_im) =
+            convert_torus_prologue_avx512f(normalization, w_re, i, w_im, inp, scaling);
+
+        let fract_re = _mm512_cvtpd_epi32(fract_re);
+        let fract_im = _mm512_cvtpd_epi32(fract_im);
+        _mm256_storeu_si256(
+            out_re.add(i) as _,
+            _mm256_add_epi32(fract_re, _mm256_loadu_si256(out_re.add(i) as _)),
+        );
+        _mm256_storeu_si256(
+            out_im.add(i) as _,
+            _mm256_add_epi32(fract_im, _mm256_loadu_si256(out_im.add(i) as _)),
+        );
+    }
+}
+
+/// See [`convert_add_backward_torus`].
+///
+/// # Safety
+///
+///  - Same preconditions as [`convert_add_backward_torus`].
+unsafe fn convert_add_backward_torus_scalar<Scalar: UnsignedTorus>(
+    out_re: &mut [MaybeUninit<Scalar>],
+    out_im: &mut [MaybeUninit<Scalar>],
+    inp: &[c64],
+    twisties: TwistiesView<'_>,
+) {
+    let normalization = 1.0 / inp.len() as f64;
+    izip!(out_re, out_im, inp, twisties.re, twisties.im).for_each(
+        |(out_re, out_im, inp, w_re, w_im)| {
+            let tmp = inp
+                * (c64 {
+                    re: *w_re,
+                    im: -*w_im,
+                } * normalization);
+
+            let out_re = out_re.assume_init_mut();
+            let out_im = out_im.assume_init_mut();
+
+            *out_re = Scalar::wrapping_add(*out_re, Scalar::from_torus(tmp.re));
+            *out_im = Scalar::wrapping_add(*out_im, Scalar::from_torus(tmp.im));
+        },
+    );
+}
+
+/// # Warning
+///
+/// This function is actually unsafe, but can't be marked as such since we need it to implement
+/// `Fn(...)`, as there's no equivalent `unsafe Fn(...)` trait.
+///
+/// # Safety
+///
+/// - `out_re` and `out_im` must not hold any uninitialized values.
+fn convert_add_backward_torus<Scalar: UnsignedTorus>(
+    out_re: &mut [MaybeUninit<Scalar>],
+    out_im: &mut [MaybeUninit<Scalar>],
+    inp: &[c64],
+    twisties: TwistiesView<'_>,
+) {
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    {
+        if Scalar::BITS == 32 {
+            #[allow(clippy::type_complexity)]
+            let ptr_fn = || -> unsafe fn (
+                &mut [MaybeUninit<u32>],
+                &mut [MaybeUninit<u32>],
+                &[c64],
+                TwistiesView<'_>,
+            ) {
+                #[cfg(feature = "backend_fft_nightly_avx512")]
+                if is_x86_feature_detected!("avx512f") {
+                    return convert_add_backward_torus_u32_avx512f;
+                }
+
+                if is_x86_feature_detected!("fma") {
+                    convert_add_backward_torus_u32_fma
+                } else {
+                    convert_add_backward_torus_scalar::<u32>
+                }
+            };
+            let ptr = ptr_fn();
+
+            // SAFETY: the target x86 feature availability was checked, and `out_re` and `out_im`
+            // do not hold any uninitialized values since that is a precondition of calling this
+            // function
+            unsafe {
+                ptr(
+                    cast_same_type(out_re),
+                    cast_same_type(out_im),
+                    inp,
+                    twisties,
+                )
+            }
+        } else {
+            let ptr = convert_add_backward_torus_scalar::<Scalar>;
+            // SAFETY: same as above
+            unsafe { ptr(out_re, out_im, inp, twisties) };
+        }
+    }
+
+    // SAFETY: same as above
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+    unsafe {
+        convert_add_backward_torus_scalar::<Scalar>(out_re, out_im, inp, twisties)
+    };
+}
+
+impl<'a> FftView<'a> {
+    /// Returns the polynomial size that this FFT was made for.
+    pub fn polynomial_size(self) -> PolynomialSize {
+        PolynomialSize(2 * self.plan.fft_size())
+    }
+
+    /// Serializes data in the Fourier domain.
+    #[cfg(feature = "backend_fft_serialization")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "backend_fft_serialization")))]
+    pub fn serialize_fourier_buffer<S: serde::Serializer>(
+        self,
+        serializer: S,
+        buf: &[c64],
+    ) -> Result<S::Ok, S::Error> {
+        self.plan.serialize_fourier_buffer(serializer, buf)
+    }
+
+    /// Deserializes data in the Fourier domain
+    #[cfg(feature = "backend_fft_serialization")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "backend_fft_serialization")))]
+    pub fn deserialize_fourier_buffer<'de, D: serde::Deserializer<'de>>(
+        self,
+        deserializer: D,
+        buf: &mut [c64],
+    ) -> Result<(), D::Error> {
+        self.plan.deserialize_fourier_buffer(deserializer, buf)
+    }
+
+    /// Returns the memory required for a forward negacyclic FFT.
+    pub fn forward_scratch(self) -> Result<StackReq, SizeOverflow> {
+        self.plan.fft_scratch()
+    }
+
+    /// Returns the memory required for a backward negacyclic FFT.
+    pub fn backward_scratch(self) -> Result<StackReq, SizeOverflow> {
+        self.plan
+            .fft_scratch()?
+            .try_and(StackReq::try_new_aligned::<c64>(
+                self.polynomial_size().0 / 2,
+                aligned_vec::CACHELINE_ALIGN,
+            )?)
+    }
+
+    /// Performs a negacyclic real FFT of `standard`, viewed as torus elements, and stores the
+    /// result in `fourier`.
+    ///
+    /// # Note
+    ///
+    /// this function leaves all the elements of `out` in an initialized state.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `standard` and `self` have differing polynomial sizes, or if `fourier` doesn't
+    /// have size equal to that amount divided by two.
+    pub fn forward_as_torus<'out, Scalar: UnsignedTorus>(
+        self,
+        fourier: FourierPolynomialUninitMutView<'out>,
+        standard: PolynomialView<'_, Scalar>,
+        stack: DynStack<'_>,
+    ) -> FourierPolynomialMutView<'out> {
+        // SAFETY: `convert_forward_torus` initializes the output slice that is passed to it
+        unsafe { self.forward_with_conv(fourier, standard, convert_forward_torus, stack) }
+    }
+
+    /// Performs a negacyclic real FFT of `standard`, viewed as integers, and stores the result in
+    /// `fourier`.
+    ///
+    /// # Note
+    ///
+    /// this function leaves all the elements of `out` in an initialized state.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `standard` and `self` have differing polynomial sizes, or if `fourier` doesn't
+    /// have size equal to that amount divided by two.
+    pub fn forward_as_integer<'out, Scalar: UnsignedTorus>(
+        self,
+        fourier: FourierPolynomialUninitMutView<'out>,
+        standard: PolynomialView<'_, Scalar>,
+        stack: DynStack<'_>,
+    ) -> FourierPolynomialMutView<'out> {
+        // SAFETY: `convert_forward_integer` initializes the output slice that is passed to it
+        unsafe { self.forward_with_conv(fourier, standard, convert_forward_integer, stack) }
+    }
+
+    /// Performs an inverse negacyclic real FFT of `fourier` and stores the result in `standard`,
+    /// viewed as torus elements.
+    ///
+    /// # Note
+    ///
+    /// this function leaves all the elements of `out_re` and `out_im` in an initialized state.
+    ///
+    /// # Panics
+    ///
+    /// See [`Self::forward_as_torus`]
+    pub fn backward_as_torus<'out, Scalar: UnsignedTorus>(
+        self,
+        standard: PolynomialUninitMutView<'out, Scalar>,
+        fourier: FourierPolynomialView<'_>,
+        stack: DynStack<'_>,
+    ) -> PolynomialMutView<'out, Scalar> {
+        // SAFETY: `convert_backward_torus` initializes the output slices that are passed to it
+        unsafe { self.backward_with_conv(standard, fourier, convert_backward_torus, stack) }
+    }
+
+    /// Performs an inverse negacyclic real FFT of `fourier` and adds the result to `standard`,
+    /// viewed as torus elements.
+    ///
+    /// # Note
+    ///
+    /// this function leaves all the elements of `out_re` and `out_im` in an initialized state.
+    ///
+    /// # Panics
+    ///
+    /// See [`Self::forward_as_torus`]
+    pub fn add_backward_as_torus<'out, Scalar: UnsignedTorus>(
+        self,
+        standard: PolynomialMutView<'out, Scalar>,
+        fourier: FourierPolynomialView<'_>,
+        stack: DynStack<'_>,
+    ) -> PolynomialMutView<'out, Scalar> {
+        // SAFETY: `convert_add_backward_torus` initializes the output slices that are passed to it
+        unsafe {
+            self.backward_with_conv(
+                standard.into_uninit(),
+                fourier,
+                convert_add_backward_torus,
+                stack,
+            )
+        }
+    }
+
+    /// # Safety
+    ///
+    /// `conv_fn` must initialize the entirety of the mutable slice that it receives.
+    unsafe fn forward_with_conv<
+        'out,
+        Scalar: UnsignedTorus,
+        F: Fn(&mut [MaybeUninit<c64>], &[Scalar], &[Scalar], TwistiesView<'_>),
+    >(
+        self,
+        fourier: FourierPolynomialUninitMutView<'out>,
+        standard: PolynomialView<'_, Scalar>,
+        conv_fn: F,
+        stack: DynStack<'_>,
+    ) -> FourierPolynomialMutView<'out> {
+        let fourier = fourier.data;
+        let standard = standard.data;
+        let n = standard.len();
+        debug_assert_eq!(n, 2 * fourier.len());
+        let (standard_re, standard_im) = standard.split_at(n / 2);
+        conv_fn(fourier, standard_re, standard_im, self.twisties);
+        let fourier = assume_init_mut(fourier);
+        self.plan.fwd(fourier, stack);
+        FourierPolynomialMutView { data: fourier }
+    }
+
+    /// # Safety
+    ///
+    /// `conv_fn` must initialize the entirety of the mutable slices that it receives.
+    unsafe fn backward_with_conv<
+        'out,
+        Scalar: UnsignedTorus,
+        F: Fn(&mut [MaybeUninit<Scalar>], &mut [MaybeUninit<Scalar>], &[c64], TwistiesView<'_>),
+    >(
+        self,
+        standard: PolynomialUninitMutView<'out, Scalar>,
+        fourier: FourierPolynomialView<'_>,
+        conv_fn: F,
+        stack: DynStack<'_>,
+    ) -> PolynomialMutView<'out, Scalar> {
+        let fourier = fourier.data;
+        let standard = standard.data;
+        let n = standard.len();
+        debug_assert_eq!(n, 2 * fourier.len());
+        let (mut tmp, stack) =
+            stack.collect_aligned(aligned_vec::CACHELINE_ALIGN, fourier.iter().copied());
+        self.plan.inv(&mut tmp, stack);
+
+        let (standard_re, standard_im) = standard.split_at_mut(n / 2);
+        conv_fn(standard_re, standard_im, &tmp, self.twisties);
+        let standard = assume_init_mut(standard);
+        PolynomialMutView { data: standard }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/concrete-core/src/backends/fft/private/math/fft/tests.rs
+++ b/concrete-core/src/backends/fft/private/math/fft/tests.rs
@@ -1,0 +1,181 @@
+use dyn_stack::{GlobalMemBuffer, ReborrowMut};
+
+use super::super::super::super::private::math::polynomial::{FourierPolynomial, Polynomial};
+use super::*;
+use crate::commons::test_tools::new_random_generator;
+use aligned_vec::avec;
+
+fn abs_diff<Scalar: UnsignedTorus>(a: Scalar, b: Scalar) -> Scalar {
+    if a > b {
+        a - b
+    } else {
+        b - a
+    }
+}
+
+fn test_roundtrip<Scalar: UnsignedTorus>() {
+    let mut generator = new_random_generator();
+    for i in 2..=10 {
+        let size = 1_usize << i;
+
+        let fft = Fft::new(PolynomialSize(size));
+        let fft = fft.as_view();
+
+        let mut poly = Polynomial {
+            data: avec![Scalar::ZERO; size].into_boxed_slice(),
+        };
+        let mut roundtrip = Polynomial {
+            data: avec![Scalar::ZERO; size].into_boxed_slice(),
+        };
+        let mut fourier = FourierPolynomial {
+            data: avec![c64::default(); size / 2].into_boxed_slice(),
+        };
+
+        for x in poly.data.iter_mut() {
+            *x = generator.random_uniform();
+        }
+
+        let mut mem = GlobalMemBuffer::new(
+            fft.forward_scratch()
+                .unwrap()
+                .and(fft.backward_scratch().unwrap()),
+        );
+        let mut stack = DynStack::new(&mut mem);
+
+        fft.forward_as_torus(
+            unsafe { fourier.as_mut_view().into_uninit() },
+            poly.as_view(),
+            stack.rb_mut(),
+        );
+        fft.backward_as_torus(
+            unsafe { roundtrip.as_mut_view().into_uninit() },
+            fourier.as_view(),
+            stack.rb_mut(),
+        );
+
+        for (expected, actual) in izip!(&*poly.data, &*roundtrip.data) {
+            assert!(abs_diff(*expected, *actual) < (Scalar::ONE << (Scalar::BITS - 10)));
+        }
+    }
+}
+
+fn test_product<Scalar: UnsignedTorus>() {
+    fn convolution_naive<Scalar: UnsignedTorus>(
+        out: &mut [Scalar],
+        lhs: &[Scalar],
+        rhs: &[Scalar],
+    ) {
+        assert_eq!(out.len(), lhs.len());
+        assert_eq!(out.len(), rhs.len());
+        let n = out.len();
+        let mut full_prod = vec![Scalar::ZERO; 2 * n];
+        for i in 0..n {
+            for j in 0..n {
+                full_prod[i + j] = full_prod[i + j].wrapping_add(lhs[i].wrapping_mul(rhs[j]));
+            }
+        }
+        for i in 0..n {
+            out[i] = full_prod[i].wrapping_sub(full_prod[i + n]);
+        }
+    }
+
+    let mut generator = new_random_generator();
+    for i in 1..=10 {
+        for _ in 0..100 {
+            let size = 1_usize << i;
+
+            let fft = Fft::new(PolynomialSize(size));
+            let fft = fft.as_view();
+
+            let mut poly0 = Polynomial {
+                data: avec![Scalar::ZERO; size].into_boxed_slice(),
+            };
+            let mut poly1 = Polynomial {
+                data: avec![Scalar::ZERO; size].into_boxed_slice(),
+            };
+
+            let mut convolution_from_fft = Polynomial {
+                data: avec![Scalar::ZERO; size].into_boxed_slice(),
+            };
+            let mut convolution_from_naive = Polynomial {
+                data: avec![Scalar::ZERO; size].into_boxed_slice(),
+            };
+
+            let mut fourier0 = FourierPolynomial {
+                data: avec![c64::default(); size / 2].into_boxed_slice(),
+            };
+            let mut fourier1 = FourierPolynomial {
+                data: avec![c64::default(); size / 2 ].into_boxed_slice(),
+            };
+
+            for (x, y) in izip!(&mut *poly0.data, &mut *poly1.data) {
+                *x = generator.random_uniform();
+                *y = generator.random_uniform();
+                if Scalar::BITS == 64 {
+                    *x >>= 32;
+                    *y >>= 32;
+                } else {
+                    *x >>= 16;
+                    *y >>= 16;
+                }
+            }
+
+            let mut mem = GlobalMemBuffer::new(
+                fft.forward_scratch()
+                    .unwrap()
+                    .and(fft.backward_scratch().unwrap()),
+            );
+            let mut stack = DynStack::new(&mut mem);
+
+            // SAFETY: forward_as_torus doesn't write any uninitialized values into its output
+            fft.forward_as_torus(
+                unsafe { fourier0.as_mut_view().into_uninit() },
+                poly0.as_view(),
+                stack.rb_mut(),
+            );
+            // SAFETY: forward_as_integer doesn't write any uninitialized values into its output
+            fft.forward_as_integer(
+                unsafe { fourier1.as_mut_view().into_uninit() },
+                poly1.as_view(),
+                stack.rb_mut(),
+            );
+
+            for (f0, f1) in izip!(&mut *fourier0.data, &*fourier1.data) {
+                *f0 *= *f1;
+            }
+
+            // SAFETY: backward_as_torus doesn't write any uninitialized values into its output
+            fft.backward_as_torus(
+                unsafe { convolution_from_fft.as_mut_view().into_uninit() },
+                fourier0.as_view(),
+                stack.rb_mut(),
+            );
+            convolution_naive(&mut convolution_from_naive.data, &poly0.data, &poly1.data);
+
+            for (expected, actual) in
+                izip!(&*convolution_from_naive.data, &*convolution_from_fft.data)
+            {
+                assert!(abs_diff(*expected, *actual) < (Scalar::ONE << (Scalar::BITS - 5)));
+            }
+        }
+    }
+}
+
+#[test]
+fn test_product_u32() {
+    test_product::<u32>();
+}
+
+#[test]
+fn test_product_u64() {
+    test_product::<u64>();
+}
+
+#[test]
+fn test_roundtrip_u32() {
+    test_roundtrip::<u32>();
+}
+#[test]
+fn test_roundtrip_u64() {
+    test_roundtrip::<u64>();
+}

--- a/concrete-core/src/backends/fft/private/math/mod.rs
+++ b/concrete-core/src/backends/fft/private/math/mod.rs
@@ -1,0 +1,3 @@
+pub mod decomposition;
+pub mod fft;
+pub mod polynomial;

--- a/concrete-core/src/backends/fft/private/math/polynomial.rs
+++ b/concrete-core/src/backends/fft/private/math/polynomial.rs
@@ -1,0 +1,137 @@
+use super::super::{as_mut_uninit, c64};
+use concrete_commons::numeric::UnsignedInteger;
+
+//--------------------------------------------------------------------------------
+// Structure definitions
+//--------------------------------------------------------------------------------
+
+/// Polynomial in the standard domain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Polynomial<C> {
+    pub data: C,
+}
+
+/// Polynomial in the Fourier domain.
+///
+/// # Note
+///
+/// Polynomials in the Fourier domain have half the size of the corresponding polynomials in
+/// the standard domain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FourierPolynomial<C> {
+    pub data: C,
+}
+
+pub type PolynomialView<'a, Scalar> = Polynomial<&'a [Scalar]>;
+pub type PolynomialMutView<'a, Scalar> = Polynomial<&'a mut [Scalar]>;
+pub type FourierPolynomialView<'a> = FourierPolynomial<&'a [c64]>;
+pub type FourierPolynomialMutView<'a> = FourierPolynomial<&'a mut [c64]>;
+
+/// Polynomial in the standard domain, with possibly uninitialized coefficients.
+///
+/// This is used for the Fourier transforms to avoid the cost of initializing the output buffer,
+/// which can be non negligible.
+pub type PolynomialUninitMutView<'a, Scalar> = Polynomial<&'a mut [core::mem::MaybeUninit<Scalar>]>;
+
+/// Polynomial in the Fourier domain, with possibly uninitialized coefficients.
+///
+/// This is used for the Fourier transforms to avoid the cost of initializing the output buffer,
+/// which can be non negligible.
+///
+/// # Note
+///
+/// Polynomials in the Fourier domain have half the size of the corresponding polynomials in
+/// the standard domain.
+pub type FourierPolynomialUninitMutView<'a> =
+    FourierPolynomial<&'a mut [core::mem::MaybeUninit<c64>]>;
+
+impl<C> Polynomial<C> {
+    pub fn as_view<Scalar>(&self) -> PolynomialView<'_, Scalar>
+    where
+        C: AsRef<[Scalar]>,
+    {
+        Polynomial {
+            data: self.data.as_ref(),
+        }
+    }
+
+    pub fn as_mut_view<Scalar>(&mut self) -> PolynomialMutView<'_, Scalar>
+    where
+        C: AsMut<[Scalar]>,
+    {
+        Polynomial {
+            data: self.data.as_mut(),
+        }
+    }
+}
+
+impl<C> FourierPolynomial<C> {
+    pub fn as_view(&self) -> FourierPolynomialView<'_>
+    where
+        C: AsRef<[c64]>,
+    {
+        FourierPolynomial {
+            data: self.data.as_ref(),
+        }
+    }
+
+    pub fn as_mut_view(&mut self) -> FourierPolynomialMutView<'_>
+    where
+        C: AsMut<[c64]>,
+    {
+        FourierPolynomial {
+            data: self.data.as_mut(),
+        }
+    }
+}
+
+impl<'a, Scalar> PolynomialMutView<'a, Scalar> {
+    /// # Safety
+    ///
+    /// No uninitialized values must be written into the output buffer when the borrow ends
+    pub unsafe fn into_uninit(self) -> PolynomialUninitMutView<'a, Scalar> {
+        PolynomialUninitMutView {
+            data: as_mut_uninit(self.data),
+        }
+    }
+}
+
+impl<'a> FourierPolynomialMutView<'a> {
+    /// # Safety
+    ///
+    /// No uninitialized values must be written into the output buffer when the borrow ends
+    pub unsafe fn into_uninit(self) -> FourierPolynomialUninitMutView<'a> {
+        FourierPolynomialUninitMutView {
+            data: as_mut_uninit(self.data),
+        }
+    }
+}
+
+impl<'a, Scalar: UnsignedInteger> PolynomialMutView<'a, Scalar> {
+    pub fn update_with_wrapping_unit_monomial_mul(self, monomial_degree: usize) {
+        let full_cycles_count = monomial_degree / self.data.len();
+        let remaining_degree = monomial_degree % self.data.len();
+        if full_cycles_count % 2 == 1 {
+            self.data.iter_mut().for_each(|a| *a = a.wrapping_neg());
+        }
+        self.data.rotate_right(remaining_degree);
+        self.data
+            .iter_mut()
+            .take(remaining_degree)
+            .for_each(|a| *a = a.wrapping_neg());
+    }
+
+    pub fn update_with_wrapping_unit_monomial_div(self, monomial_degree: usize) {
+        let full_cycles_count = monomial_degree / self.data.len();
+        let remaining_degree = monomial_degree % self.data.len();
+        if full_cycles_count % 2 == 1 {
+            self.data.iter_mut().for_each(|a| *a = a.wrapping_neg());
+        }
+        self.data.rotate_left(remaining_degree);
+        self.data
+            .iter_mut()
+            .rev()
+            .take(remaining_degree)
+            .for_each(|a| *a = a.wrapping_neg());
+    }
+}

--- a/concrete-core/src/backends/fft/private/mod.rs
+++ b/concrete-core/src/backends/fft/private/mod.rs
@@ -1,0 +1,144 @@
+pub use concrete_fft::c64;
+use core::mem::MaybeUninit;
+use std::slice::{ChunksExact, ChunksExactMut};
+
+pub mod crypto;
+pub mod math;
+
+pub trait Container {
+    fn container_len(&self) -> usize;
+}
+
+impl<T> Container for aligned_vec::ABox<[T]> {
+    fn container_len(&self) -> usize {
+        (**self).len()
+    }
+}
+
+impl<'a, T> Container for &'a [T] {
+    fn container_len(&self) -> usize {
+        (**self).len()
+    }
+}
+
+impl<'a, T> Container for &'a mut [T] {
+    fn container_len(&self) -> usize {
+        (**self).len()
+    }
+}
+
+pub trait IntoChunks {
+    type Chunks: DoubleEndedIterator<Item = Self> + ExactSizeIterator<Item = Self>;
+
+    fn into_chunks(self, chunk_size: usize) -> Self::Chunks;
+    fn split_into(self, chunk_count: usize) -> Self::Chunks;
+}
+
+impl<'a, T> IntoChunks for &'a [T] {
+    type Chunks = ChunksExact<'a, T>;
+
+    #[inline]
+    fn into_chunks(self, chunk_size: usize) -> Self::Chunks {
+        debug_assert_eq!(self.len() % chunk_size, 0);
+        self.chunks_exact(chunk_size)
+    }
+    #[inline]
+    fn split_into(self, chunk_count: usize) -> Self::Chunks {
+        debug_assert_eq!(self.len() % chunk_count, 0);
+        self.chunks_exact(self.len() / chunk_count)
+    }
+}
+
+impl<'a, T> IntoChunks for &'a mut [T] {
+    type Chunks = ChunksExactMut<'a, T>;
+
+    #[inline]
+    fn into_chunks(self, chunk_size: usize) -> Self::Chunks {
+        debug_assert_eq!(self.len() % chunk_size, 0);
+        self.chunks_exact_mut(chunk_size)
+    }
+    #[inline]
+    fn split_into(self, chunk_count: usize) -> Self::Chunks {
+        debug_assert_eq!(self.len() % chunk_count, 0);
+        self.chunks_exact_mut(self.len() / chunk_count)
+    }
+}
+
+/// Convert a mutable slice reference to an uninitialized mutable slice reference.
+///
+/// # Safety
+///
+/// No uninitialized values must be written into the output slice by the time the borrow ends
+#[inline(always)]
+pub unsafe fn as_mut_uninit<T>(slice: &mut [T]) -> &mut [MaybeUninit<T>] {
+    let len = slice.len();
+    let ptr = slice.as_mut_ptr();
+    // SAFETY: T and MaybeUninit<T> have the same layout
+    core::slice::from_raw_parts_mut(ptr as *mut _, len)
+}
+
+/// Convert an uninitialized mutable slice reference to an initialized mutable slice reference.
+///
+/// # Safety
+///
+/// All the elements of the input slice must be initialized and in a valid state.
+#[inline(always)]
+pub unsafe fn assume_init_mut<T>(slice: &mut [MaybeUninit<T>]) -> &mut [T] {
+    let len = slice.len();
+    let ptr = slice.as_mut_ptr();
+    // SAFETY: T and MaybeUninit<T> have the same layout
+    core::slice::from_raw_parts_mut(ptr as *mut _, len)
+}
+
+fn assert_same_len(a: (usize, Option<usize>), b: (usize, Option<usize>)) {
+    debug_assert_eq!(a.1, Some(a.0));
+    debug_assert_eq!(b.1, Some(b.0));
+    debug_assert_eq!(a.0, b.0);
+}
+
+/// Returns a Zip iterator, but checks that the two components have the same length.
+pub trait ZipChecked: IntoIterator + Sized {
+    fn zip_checked<B: IntoIterator>(
+        self,
+        b: B,
+    ) -> core::iter::Zip<<Self as IntoIterator>::IntoIter, <B as IntoIterator>::IntoIter> {
+        let a = self.into_iter();
+        let b = b.into_iter();
+        assert_same_len(a.size_hint(), b.size_hint());
+        core::iter::zip(a, b)
+    }
+}
+
+impl<A: IntoIterator> ZipChecked for A {}
+
+// https://docs.rs/itertools/0.7.8/src/itertools/lib.rs.html#247-269
+macro_rules! izip {
+    // eg. __izip_closure!(((a, b), c) => (a, b, c) , dd , ee )
+    (@ __closure @ $p:pat => $tup:expr) => {
+        |$p| $tup
+    };
+
+    // The "b" identifier is a different identifier on each recursion level thanks to hygiene.
+    (@ __closure @ $p:pat => ( $($tup:tt)* ) , $_iter:expr $( , $tail:expr )*) => {
+        $crate::backends::fft::private::izip!(@ __closure @ ($p, b) => ( $($tup)*, b ) $( , $tail )*)
+    };
+
+    ( $first:expr $(,)?) => {
+        {
+            #[allow(unused_imports)]
+            use $crate::backends::fft::private::ZipChecked;
+            ::core::iter::IntoIterator::into_iter($first)
+        }
+    };
+    ( $first:expr, $($rest:expr),+ $(,)?) => {
+        {
+            #[allow(unused_imports)]
+            use $crate::backends::fft::private::ZipChecked;
+            ::core::iter::IntoIterator::into_iter($first)
+                $(.zip_checked($rest))*
+                .map($crate::backends::fft::private::izip!(@ __closure @ a => (a) $( , $rest )*))
+        }
+    };
+}
+
+pub(crate) use izip;

--- a/concrete-core/src/backends/mod.rs
+++ b/concrete-core/src/backends/mod.rs
@@ -6,5 +6,8 @@ pub mod default;
 #[cfg(feature = "backend_fftw")]
 pub mod fftw;
 
+#[cfg(feature = "backend_fft")]
+pub mod fft;
+
 #[cfg(all(feature = "backend_cuda", not(feature = "_ci_do_not_compile")))]
 pub mod cuda;

--- a/concrete-core/src/commons/crypto/bootstrap/standard/mod.rs
+++ b/concrete-core/src/commons/crypto/bootstrap/standard/mod.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "__commons_serialization", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StandardBootstrapKey<Cont> {
-    tensor: Tensor<Cont>,
+    pub(crate) tensor: Tensor<Cont>,
     poly_size: PolynomialSize,
     rlwe_size: GlweSize,
     decomp_level: DecompositionLevelCount,

--- a/concrete-core/src/commons/crypto/ggsw/standard.rs
+++ b/concrete-core/src/commons/crypto/ggsw/standard.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "__commons_serialization", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StandardGgswCiphertext<Cont> {
-    tensor: Tensor<Cont>,
+    pub(crate) tensor: Tensor<Cont>,
     poly_size: PolynomialSize,
     rlwe_size: GlweSize,
     decomp_base_log: DecompositionBaseLog,

--- a/concrete-core/src/commons/math/decomposition/decomposer.rs
+++ b/concrete-core/src/commons/math/decomposition/decomposer.rs
@@ -94,6 +94,7 @@ where
     /// let closest = decomposer.closest_representable(1_340_987_234_u32);
     /// assert_eq!(closest, 1_341_128_704_u32);
     /// ```
+    #[inline]
     pub fn closest_representable(&self, input: Scalar) -> Scalar {
         // The closest number representable by the decomposition can be computed by performing
         // the rounding at the appropriate bit.

--- a/concrete-core/src/commons/math/torus/mod.rs
+++ b/concrete-core/src/commons/math/torus/mod.rs
@@ -48,6 +48,7 @@ macro_rules! implement {
             F: FloatingPoint + CastInto<Self>,
             Self: CastInto<F>,
         {
+            #[inline]
             fn into_torus(self) -> F {
                 let self_f: F = self.cast_into();
                 return self_f * (F::TWO.powi(-(<Self as Numeric>::BITS as i32)));
@@ -55,18 +56,16 @@ macro_rules! implement {
         }
         impl<F> FromTorus<F> for $Type
         where
-            F: FloatingPoint + CastInto<Self>,
+            F: FloatingPoint + CastInto<Self> + CastInto<Self::Signed>,
             Self: CastInto<F>,
         {
+            #[inline]
             fn from_torus(input: F) -> Self {
-                let mut fract = input - F::floor(input);
+                let mut fract = input - F::round(input);
                 fract *= F::TWO.powi(<Self as Numeric>::BITS as i32);
-                let carry = fract - F::floor(fract);
-                let zero_point_five = F::ONE / F::TWO;
-                if carry >= zero_point_five {
-                    fract += F::ONE;
-                };
-                return fract.cast_into();
+                fract = F::round(fract);
+                let signed: Self::Signed = fract.cast_into();
+                return signed.cast_into();
             }
         }
     };

--- a/concrete-core/src/lib.rs
+++ b/concrete-core/src/lib.rs
@@ -1,4 +1,9 @@
 #![deny(rustdoc::broken_intra_doc_links)]
+#![cfg_attr(
+    feature = "backend_fft_nightly_avx512",
+    feature(stdsimd, avx512_target_feature)
+)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! Welcome to the `concrete-core` documentation!
 //!
 //! This library contains a set of low-level primitives which can be used to implement *Fully

--- a/concrete-core/src/prelude.rs
+++ b/concrete-core/src/prelude.rs
@@ -15,6 +15,11 @@ pub use super::backends::default::entities::*;
 pub use super::backends::fftw::engines::*;
 #[cfg(feature = "backend_fftw")]
 pub use super::backends::fftw::entities::*;
+// --------------------------------------------------------------------------------- FFT BACKEND
+#[cfg(feature = "backend_fft")]
+pub use super::backends::fft::engines::*;
+#[cfg(feature = "backend_fft")]
+pub use super::backends::fft::entities::*;
 
 // ------------------------------------------------------------------------------------ CUDA BACKEND
 #[cfg(all(feature = "backend_cuda", not(feature = "_ci_do_not_compile")))]


### PR DESCRIPTION
### Description
this PR intergrates a new pure rust fft backend. right now the dependency points to the concrete-fft github repo. but this should be changed to a crates.io version once the crate is published.

### Checklist 

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]
