### PR TITLE
Refactor/private cbs vp fixes

### DIFF
--- a/concrete-core/src/backends/fftw/private/crypto/wop_pbs/mod.rs
+++ b/concrete-core/src/backends/fftw/private/crypto/wop_pbs/mod.rs
@@ -406,17 +406,10 @@ pub fn vertical_packing<Scalar, C1, C2, C3>(
     let glwe_dimension = vec_ggsw[0].glwe_size().to_glwe_dimension();
 
     debug_assert!(
-        lut.polynomial_count().0 == 1 << vec_ggsw.len(),
-        "Need {} polynomials in `lut`, got {}",
-        1 << vec_ggsw.len(),
-        lut.polynomial_count().0
-    );
-
-    debug_assert!(
         lwe_out.lwe_size().to_lwe_dimension().0 == polynomial_size.0 * glwe_dimension.0,
         "Output LWE ciphertext needs to have an LweDimension of {}, got {}",
+        polynomial_size.0 * glwe_dimension.0,
         lwe_out.lwe_size().to_lwe_dimension().0,
-        polynomial_size.0 * glwe_dimension.0
     );
 
     // Get the base 2 logarithm (rounded down) of the number of polynomials in the list i.e. if
@@ -455,6 +448,8 @@ where
     C1: AsRefSlice<Element = Scalar>,
     C2: AsRefSlice<Element = Complex64>,
 {
+    debug_assert!(lut_per_layer.polynomial_count().0 == 1 << vec_ggsw.len());
+
     if !vec_ggsw.is_empty() {
         let polynomial_size = vec_ggsw[0].polynomial_size();
         let nb_layer = vec_ggsw.len();
@@ -476,8 +471,6 @@ where
         let mut cmux_buffer = empty_glwe;
 
         let mut t_fill = vec![0_usize; nb_layer];
-
-        debug_assert!(lut_per_layer.polynomial_count().0 == 1 << (nb_layer - 1));
 
         // Returns lut[2 * i] polynomial where i is the iteration index
         let lut_iter_0 = lut_per_layer.polynomial_iter().step_by(2);

--- a/concrete-core/src/backends/fftw/private/crypto/wop_pbs/mod.rs
+++ b/concrete-core/src/backends/fftw/private/crypto/wop_pbs/mod.rs
@@ -150,11 +150,11 @@ pub fn extract_bits<Scalar, C1, C2, C3, C4>(
     }
 }
 
-/// Circuit bootstrapping for binary messages, i.e. containing only one bit of message
+/// Circuit bootstrapping for boolean messages, i.e. containing only one bit of message
 ///
 /// The output GGSW ciphertext `ggsw_out` decomposition base log and level count are used as the
-/// circuit_bootstrap_binary decomposition base log and level count.
-pub fn circuit_bootstrap_binary<Scalar, C1, C2, C3, C4>(
+/// circuit_bootstrap_boolean decomposition base log and level count.
+pub fn circuit_bootstrap_boolean<Scalar, C1, C2, C3, C4>(
     fourier_bsk: &FourierBootstrapKey<C1, Scalar>,
     lwe_in: &LweCiphertext<C2>,
     ggsw_out: &mut StandardGgswCiphertext<C3>,
@@ -234,7 +234,7 @@ pub fn circuit_bootstrap_binary<Scalar, C1, C2, C3, C4>(
     let mut out_pfksk_buffer_iter = glwe_out_pfksk_buffer.ciphertext_iter_mut();
 
     for level_idx in 0..level_cbs.0 {
-        homomorphic_shift_binary(
+        homomorphic_shift_boolean(
             fourier_bsk,
             &mut lwe_out_bs_buffer,
             lwe_in,
@@ -255,7 +255,7 @@ pub fn circuit_bootstrap_binary<Scalar, C1, C2, C3, C4>(
 ///
 /// Starts by shifting the message bit at bit #delta_log to the padding bit and then shifts it to
 /// the right by base_log * level.
-pub fn homomorphic_shift_binary<Scalar, C1, C2, C3>(
+pub fn homomorphic_shift_boolean<Scalar, C1, C2, C3>(
     fourier_bsk: &FourierBootstrapKey<C1, Scalar>,
     lwe_out: &mut LweCiphertext<C2>,
     lwe_in: &LweCiphertext<C3>,
@@ -312,14 +312,14 @@ pub fn homomorphic_shift_binary<Scalar, C1, C2, C3>(
         .wrapping_add(Scalar::ONE << (ciphertext_n_bits - 1 - base_log_cbs.0 * level_count_cbs.0));
 }
 
-/// Perform a circuit bootstrap followed by a vertical packing on ciphertexts encrypting binary
+/// Perform a circuit bootstrap followed by a vertical packing on ciphertexts encrypting boolean
 /// messages.
 ///
 /// The circuit bootstrapping uses the private functional packing key switch.
 ///
-/// This is supposed to be used only with binary (1 bit of message) LWE ciphertexts.
+/// This is supposed to be used only with boolean (1 bit of message) LWE ciphertexts.
 #[allow(clippy::too_many_arguments)]
-pub fn circuit_bootstrap_binary_vertical_packing<Scalar, C1, C2, C3, C4, C5>(
+pub fn circuit_bootstrap_boolean_vertical_packing<Scalar, C1, C2, C3, C4, C5>(
     big_lut_as_polynomial_list: &PolynomialList<C1>,
     buffers: &mut FourierBuffers<Scalar>,
     fourier_bsk: &FourierBootstrapKey<C2, Scalar>,
@@ -338,11 +338,10 @@ pub fn circuit_bootstrap_binary_vertical_packing<Scalar, C1, C2, C3, C4, C5>(
 {
     debug_assert!(lwe_list_in.count().0 != 0, "Got empty `lwe_list_in`");
     debug_assert!(
-        lwe_list_out.lwe_size().to_lwe_dimension().0
-            == fourier_bsk.polynomial_size().0 * fourier_bsk.glwe_size().to_glwe_dimension().0,
+        lwe_list_out.lwe_size().to_lwe_dimension() == fourier_bsk.output_lwe_dimension(),
         "Output LWE ciphertext needs to have an LweDimension of {}, got {}",
         lwe_list_out.lwe_size().to_lwe_dimension().0,
-        fourier_bsk.polynomial_size().0 * fourier_bsk.glwe_size().to_glwe_dimension().0
+        fourier_bsk.output_lwe_dimension().0
     );
 
     // TODO: Currently we need split_at and split_at_mut so can't switch to a list-like struct
@@ -365,7 +364,7 @@ pub fn circuit_bootstrap_binary_vertical_packing<Scalar, C1, C2, C3, C4, C5>(
         base_log_cbs,
     );
     for (lwe_in, ggsw) in lwe_list_in.ciphertext_iter().zip(vec_ggsw.iter_mut()) {
-        circuit_bootstrap_binary(
+        circuit_bootstrap_boolean(
             fourier_bsk,
             &lwe_in,
             &mut ggsw_res,

--- a/concrete-core/src/backends/fftw/private/crypto/wop_pbs/test.rs
+++ b/concrete-core/src/backends/fftw/private/crypto/wop_pbs/test.rs
@@ -565,7 +565,7 @@ pub fn test_extract_bit_circuit_bootstrapping_vertical_packing() {
 
     let number_of_test_runs = 10;
 
-    for _ in 0..number_of_test_runs {
+    for run_number in 0..number_of_test_runs {
         let cleartext =
             test_tools::random_uint_between(0..2u64.pow(number_of_bits_in_input_lwe as u32));
 
@@ -609,17 +609,34 @@ pub fn test_extract_bit_circuit_bootstrapping_vertical_packing() {
         // LUT creation
         let number_of_luts_and_output_vp_ciphertexts = 1;
         let mut lut_size = polynomial_size.0;
-        if lut_size < (1 << extracted_bits_lwe_list.count().0) {
-            lut_size = 1 << extracted_bits_lwe_list.count().0;
-        }
-        let mut lut = Vec::with_capacity(lut_size);
 
-        for i in 0..lut_size {
-            lut.push((i as u64) << delta_lut.0);
-        }
+        let lut_poly_list = if run_number % 2 == 0 {
+            // Test with a small lut, only triggering a blind rotate
+            if lut_size < (1 << extracted_bits_lwe_list.count().0) {
+                lut_size = 1 << extracted_bits_lwe_list.count().0;
+            }
+            let mut lut = Vec::with_capacity(lut_size);
 
-        // Here we have a single lut, so store it directly in the polynomial list
-        let lut_poly_list = PolynomialList::from_container(lut, PolynomialSize(lut_size));
+            for i in 0..lut_size {
+                lut.push((i as u64 % (1 << (64 - delta_log.0))) << delta_lut.0);
+            }
+
+            // Here we have a single lut, so store it directly in the polynomial list
+            PolynomialList::from_container(lut, PolynomialSize(lut_size))
+        } else {
+            // Test with a big lut, triggering an actual cmux tree
+            let mut lut_poly_list = PolynomialList::allocate(
+                0u64,
+                PolynomialCount(1 << number_of_bits_in_input_lwe),
+                polynomial_size,
+            );
+            for (i, mut polynomial) in lut_poly_list.polynomial_iter_mut().enumerate() {
+                polynomial
+                    .as_mut_tensor()
+                    .fill_with_element((i as u64 % (1 << (64 - delta_log.0))) << delta_lut.0);
+            }
+            lut_poly_list
+        };
 
         // We need as many output ciphertexts as we have input luts
         let mut vertical_packing_lwe_list_out = LweList::allocate(

--- a/concrete-core/src/backends/fftw/private/crypto/wop_pbs/test.rs
+++ b/concrete-core/src/backends/fftw/private/crypto/wop_pbs/test.rs
@@ -1,7 +1,7 @@
 use crate::backends::fftw::private::crypto::bootstrap::{FourierBootstrapKey, FourierBuffers};
 use crate::backends::fftw::private::crypto::ggsw::FourierGgswCiphertext;
 use crate::backends::fftw::private::crypto::wop_pbs::{
-    circuit_bootstrap_binary, circuit_bootstrap_binary_vertical_packing,
+    circuit_bootstrap_boolean, circuit_bootstrap_boolean_vertical_packing,
     cmux_tree_memory_optimized, extract_bits,
 };
 use crate::backends::fftw::private::math::fft::Complex64;
@@ -252,7 +252,7 @@ pub fn test_circuit_bootstrapping_binary() {
     );
 
     // Execute the CBS
-    circuit_bootstrap_binary(
+    circuit_bootstrap_boolean(
         &fourier_bsk,
         &lwe_in,
         &mut cbs_res,
@@ -629,7 +629,7 @@ pub fn test_extract_bit_circuit_bootstrapping_vertical_packing() {
         );
 
         // Perform circuit bootstrap + vertical packing
-        circuit_bootstrap_binary_vertical_packing(
+        circuit_bootstrap_boolean_vertical_packing(
             &lut_poly_list,
             &mut buffers,
             &fourier_bsk,


### PR DESCRIPTION
### Resolves:

### Description

some size checks made no sense in the private API (but we don't currently trigger them in tests, we have an issue for that : https://github.com/zama-ai/concrete-core-internal/issues/414)

use the boolean terminology when referring to ciphertexts containing 1 bit of message (vs binary before) for the cbs primitive

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
