### PR TITLE
feat(cuda): add LweCiphertextVectorView conversions

### DIFF
--- a/concrete-core-bench/src/cuda.rs
+++ b/concrete-core-bench/src/cuda.rs
@@ -34,6 +34,10 @@ macro_rules! bench {
 
 bench! {
     ((BinaryKeyDistribution), LweCiphertextVectorConversionFixture, (CudaLweCiphertextVector, LweCiphertextVector)),
+    ((BinaryKeyDistribution), LweCiphertextVectorConversionFixture, (LweCiphertextVectorView,
+        CudaLweCiphertextVector)),
+    ((BinaryKeyDistribution), LweCiphertextVectorDiscardingConversionFixture,
+        (CudaLweCiphertextVector, LweCiphertextVectorMutView)),
     ((BinaryKeyDistribution, BinaryKeyDistribution), LweCiphertextVectorDiscardingKeyswitchFixture, (CudaLweKeyswitchKey, CudaLweCiphertextVector,
         CudaLweCiphertextVector)),
     ((BinaryKeyDistribution, BinaryKeyDistribution), LweCiphertextVectorDiscardingBootstrapFixture1, (CudaFourierLweBootstrapKey,

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_trivial_decryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_trivial_decryption.rs
@@ -44,22 +44,10 @@ where
         Box::new(
             vec![
                 LweCiphertextTrivialDecryptionParameters {
-                    lwe_dimension: LweDimension(100),
-                },
-                LweCiphertextTrivialDecryptionParameters {
-                    lwe_dimension: LweDimension(300),
-                },
-                LweCiphertextTrivialDecryptionParameters {
-                    lwe_dimension: LweDimension(600),
+                    lwe_dimension: LweDimension(1),
                 },
                 LweCiphertextTrivialDecryptionParameters {
                     lwe_dimension: LweDimension(1000),
-                },
-                LweCiphertextTrivialDecryptionParameters {
-                    lwe_dimension: LweDimension(3000),
-                },
-                LweCiphertextTrivialDecryptionParameters {
-                    lwe_dimension: LweDimension(6000),
                 },
             ]
             .into_iter(),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_trivial_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_trivial_encryption.rs
@@ -44,22 +44,10 @@ where
         Box::new(
             vec![
                 LweCiphertextTrivialEncryptionParameters {
-                    lwe_dimension: LweDimension(100),
-                },
-                LweCiphertextTrivialEncryptionParameters {
-                    lwe_dimension: LweDimension(300),
-                },
-                LweCiphertextTrivialEncryptionParameters {
-                    lwe_dimension: LweDimension(600),
+                    lwe_dimension: LweDimension(1),
                 },
                 LweCiphertextTrivialEncryptionParameters {
                     lwe_dimension: LweDimension(1000),
-                },
-                LweCiphertextTrivialEncryptionParameters {
-                    lwe_dimension: LweDimension(3000),
-                },
-                LweCiphertextTrivialEncryptionParameters {
-                    lwe_dimension: LweDimension(6000),
                 },
             ]
             .into_iter(),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_conversion.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_conversion.rs
@@ -53,37 +53,12 @@ where
             vec![
                 LweCiphertextVectorConversionParameters {
                     noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(100),
+                    lwe_dimension: LweDimension(1),
                     lwe_ciphertext_count: LweCiphertextCount(1),
                 },
                 LweCiphertextVectorConversionParameters {
                     noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(100),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorConversionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(300),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorConversionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(600),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorConversionParameters {
-                    noise: Variance(0.00000001),
                     lwe_dimension: LweDimension(1000),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorConversionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(3000),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorConversionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(6000),
                     lwe_ciphertext_count: LweCiphertextCount(100),
                 },
             ]

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_decryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_decryption.rs
@@ -54,37 +54,12 @@ where
             vec![
                 LweCiphertextVectorDecryptionParameters {
                     noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(100),
+                    lwe_dimension: LweDimension(1),
                     lwe_ciphertext_count: LweCiphertextCount(1),
                 },
                 LweCiphertextVectorDecryptionParameters {
                     noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(100),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDecryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(300),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDecryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(600),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDecryptionParameters {
-                    noise: Variance(0.00000001),
                     lwe_dimension: LweDimension(1000),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDecryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(3000),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDecryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(6000),
                     lwe_ciphertext_count: LweCiphertextCount(100),
                 },
             ]

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_conversion.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_conversion.rs
@@ -1,0 +1,214 @@
+use concrete_core::prelude::{
+    LweCiphertextCount, LweCiphertextVectorDiscardingConversionEngine, LweCiphertextVectorEntity,
+    LweDimension, Variance,
+};
+
+use crate::fixture::Fixture;
+use crate::generation::prototyping::{
+    PrototypesLweCiphertextVector, PrototypesLweSecretKey, PrototypesPlaintextVector,
+};
+use crate::generation::synthesizing::SynthesizesLweCiphertextVector;
+use crate::generation::{IntegerPrecision, KeyDistributionMarker, Maker};
+use crate::raw::generation::RawUnsignedIntegers;
+use crate::raw::statistical_test::assert_noise_distribution;
+
+/// A fixture for the types implementing the `LweCiphertextVectorDiscardingConversionEngine` trait.
+pub struct LweCiphertextVectorDiscardingConversionFixture;
+
+#[derive(Debug)]
+pub struct LweCiphertextVectorDiscardingConversionParameters {
+    pub noise: Variance,
+    pub lwe_dimension: LweDimension,
+    pub lwe_ciphertext_count: LweCiphertextCount,
+}
+
+impl<Precision, KeyDistribution, Engine, InputCiphertextVector, OutputCiphertextVector>
+    Fixture<Precision, (KeyDistribution,), Engine, (InputCiphertextVector, OutputCiphertextVector)>
+    for LweCiphertextVectorDiscardingConversionFixture
+where
+    Precision: IntegerPrecision,
+    KeyDistribution: KeyDistributionMarker,
+    Engine: LweCiphertextVectorDiscardingConversionEngine<
+        InputCiphertextVector,
+        OutputCiphertextVector,
+    >,
+    InputCiphertextVector: LweCiphertextVectorEntity,
+    OutputCiphertextVector: LweCiphertextVectorEntity,
+    Maker: SynthesizesLweCiphertextVector<Precision, KeyDistribution, InputCiphertextVector>
+        + SynthesizesLweCiphertextVector<Precision, KeyDistribution, OutputCiphertextVector>,
+{
+    type Parameters = LweCiphertextVectorDiscardingConversionParameters;
+    type RepetitionPrototypes =
+        (<Maker as PrototypesLweSecretKey<Precision, KeyDistribution>>::LweSecretKeyProto,);
+    type SamplePrototypes = (
+        <Maker as PrototypesLweCiphertextVector<
+            Precision,
+            KeyDistribution,
+        >>::LweCiphertextVectorProto,
+        <Maker as PrototypesLweCiphertextVector<
+            Precision,
+            KeyDistribution,
+        >>::LweCiphertextVectorProto,
+    );
+    type PreExecutionContext = (InputCiphertextVector, OutputCiphertextVector);
+    type PostExecutionContext = (InputCiphertextVector, OutputCiphertextVector);
+    type Criteria = (Variance,);
+    type Outcome = (Vec<Precision::Raw>, Vec<Precision::Raw>);
+
+    fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
+        Box::new(
+            vec![
+                LweCiphertextVectorDiscardingConversionParameters {
+                    noise: Variance(0.00000001),
+                    lwe_dimension: LweDimension(100),
+                    lwe_ciphertext_count: LweCiphertextCount(1),
+                },
+                LweCiphertextVectorDiscardingConversionParameters {
+                    noise: Variance(0.00000001),
+                    lwe_dimension: LweDimension(100),
+                    lwe_ciphertext_count: LweCiphertextCount(100),
+                },
+                LweCiphertextVectorDiscardingConversionParameters {
+                    noise: Variance(0.00000001),
+                    lwe_dimension: LweDimension(300),
+                    lwe_ciphertext_count: LweCiphertextCount(100),
+                },
+                LweCiphertextVectorDiscardingConversionParameters {
+                    noise: Variance(0.00000001),
+                    lwe_dimension: LweDimension(600),
+                    lwe_ciphertext_count: LweCiphertextCount(100),
+                },
+                LweCiphertextVectorDiscardingConversionParameters {
+                    noise: Variance(0.00000001),
+                    lwe_dimension: LweDimension(1000),
+                    lwe_ciphertext_count: LweCiphertextCount(100),
+                },
+                LweCiphertextVectorDiscardingConversionParameters {
+                    noise: Variance(0.00000001),
+                    lwe_dimension: LweDimension(3000),
+                    lwe_ciphertext_count: LweCiphertextCount(100),
+                },
+                LweCiphertextVectorDiscardingConversionParameters {
+                    noise: Variance(0.00000001),
+                    lwe_dimension: LweDimension(6000),
+                    lwe_ciphertext_count: LweCiphertextCount(100),
+                },
+            ]
+            .into_iter(),
+        )
+    }
+
+    fn generate_random_repetition_prototypes(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+    ) -> Self::RepetitionPrototypes {
+        let proto_secret_key = maker.new_lwe_secret_key(parameters.lwe_dimension);
+        (proto_secret_key,)
+    }
+
+    fn generate_random_sample_prototypes(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::SamplePrototypes {
+        let (key,) = repetition_proto;
+        let raw_plaintext_vector = Precision::Raw::uniform_vec(parameters.lwe_ciphertext_count.0);
+        let proto_plaintext_vector =
+            maker.transform_raw_vec_to_plaintext_vector(raw_plaintext_vector.as_slice());
+        let proto_ciphertext_vector = maker.encrypt_plaintext_vector_to_lwe_ciphertext_vector(
+            key,
+            &proto_plaintext_vector,
+            parameters.noise,
+        );
+        let proto_output_ciphertext_vector = maker
+            .trivially_encrypt_zeros_to_lwe_ciphertext_vector(
+                parameters.lwe_dimension,
+                parameters.lwe_ciphertext_count,
+            );
+        (proto_ciphertext_vector, proto_output_ciphertext_vector)
+    }
+
+    fn prepare_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+    ) -> Self::PreExecutionContext {
+        let (proto_ciphertext_vector, proto_output_ciphertext_vector) = sample_proto;
+        (
+            <Maker as SynthesizesLweCiphertextVector<
+                Precision,
+                KeyDistribution,
+                InputCiphertextVector,
+            >>::synthesize_lwe_ciphertext_vector(maker, proto_ciphertext_vector),
+            <Maker as SynthesizesLweCiphertextVector<
+                Precision,
+                KeyDistribution,
+                OutputCiphertextVector,
+            >>::synthesize_lwe_ciphertext_vector(maker, proto_output_ciphertext_vector),
+        )
+    }
+
+    fn execute_engine(
+        _parameters: &Self::Parameters,
+        engine: &mut Engine,
+        context: Self::PreExecutionContext,
+    ) -> Self::PostExecutionContext {
+        let (input_ciphertext_vector, mut output_ciphertext_vector) = context;
+        unsafe {
+            engine.discard_convert_lwe_ciphertext_vector_unchecked(
+                &mut output_ciphertext_vector,
+                &input_ciphertext_vector,
+            )
+        };
+        (input_ciphertext_vector, output_ciphertext_vector)
+    }
+
+    fn process_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+        context: Self::PostExecutionContext,
+    ) -> Self::Outcome {
+        let (key,) = repetition_proto;
+        let (proto_ciphertext_vector, _) = sample_proto;
+        let (input_ciphertext_vector, output_ciphertext_vector) = context;
+        let proto_output_ciphertext_vector =
+            <Maker as SynthesizesLweCiphertextVector<
+                Precision,
+                KeyDistribution,
+                OutputCiphertextVector,
+            >>::unsynthesize_lwe_ciphertext_vector(maker, output_ciphertext_vector);
+        let proto_plaintext_vector =
+            maker.decrypt_lwe_ciphertext_vector_to_plaintext_vector(key, proto_ciphertext_vector);
+        let proto_output_plaintext_vector = <Maker as PrototypesLweCiphertextVector<
+            Precision,
+            KeyDistribution,
+        >>::decrypt_lwe_ciphertext_vector_to_plaintext_vector(
+            maker,
+            key,
+            &proto_output_ciphertext_vector,
+        );
+        maker.destroy_lwe_ciphertext_vector(input_ciphertext_vector);
+        (
+            maker.transform_plaintext_vector_to_raw_vec(&proto_plaintext_vector),
+            maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),
+        )
+    }
+
+    fn compute_criteria(
+        parameters: &Self::Parameters,
+        _maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::Criteria {
+        (parameters.noise,)
+    }
+
+    fn verify(criteria: &Self::Criteria, outputs: &[Self::Outcome]) -> bool {
+        let (means, actual): (Vec<_>, Vec<_>) = outputs.iter().cloned().unzip();
+        let means: Vec<Precision::Raw> = means.into_iter().flatten().collect();
+        let actual: Vec<Precision::Raw> = actual.into_iter().flatten().collect();
+        assert_noise_distribution(actual.as_slice(), means.as_slice(), criteria.0)
+    }
+}

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_conversion.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_conversion.rs
@@ -60,37 +60,12 @@ where
             vec![
                 LweCiphertextVectorDiscardingConversionParameters {
                     noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(100),
+                    lwe_dimension: LweDimension(1),
                     lwe_ciphertext_count: LweCiphertextCount(1),
                 },
                 LweCiphertextVectorDiscardingConversionParameters {
                     noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(100),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingConversionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(300),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingConversionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(600),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingConversionParameters {
-                    noise: Variance(0.00000001),
                     lwe_dimension: LweDimension(1000),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingConversionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(3000),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingConversionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(6000),
                     lwe_ciphertext_count: LweCiphertextCount(100),
                 },
             ]

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_decryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_decryption.rs
@@ -62,37 +62,12 @@ where
             vec![
                 LweCiphertextVectorDiscardingDecryptionParameters {
                     noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(100),
+                    lwe_dimension: LweDimension(1),
                     lwe_ciphertext_count: LweCiphertextCount(1),
                 },
                 LweCiphertextVectorDiscardingDecryptionParameters {
                     noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(100),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingDecryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(300),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingDecryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(600),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingDecryptionParameters {
-                    noise: Variance(0.00000001),
                     lwe_dimension: LweDimension(1000),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingDecryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(3000),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingDecryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(6000),
                     lwe_ciphertext_count: LweCiphertextCount(100),
                 },
             ]

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_encryption.rs
@@ -61,37 +61,12 @@ where
             vec![
                 LweCiphertextVectorDiscardingEncryptionParameters {
                     noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(100),
+                    lwe_dimension: LweDimension(1),
                     lwe_ciphertext_count: LweCiphertextCount(1),
                 },
                 LweCiphertextVectorDiscardingEncryptionParameters {
                     noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(100),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingEncryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(300),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingEncryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(600),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingEncryptionParameters {
-                    noise: Variance(0.00000001),
                     lwe_dimension: LweDimension(1000),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingEncryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(3000),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorDiscardingEncryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(6000),
                     lwe_ciphertext_count: LweCiphertextCount(100),
                 },
             ]

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_encryption.rs
@@ -53,37 +53,12 @@ where
             vec![
                 LweCiphertextVectorEncryptionParameters {
                     noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(100),
+                    lwe_dimension: LweDimension(1),
                     lwe_ciphertext_count: LweCiphertextCount(1),
                 },
                 LweCiphertextVectorEncryptionParameters {
                     noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(100),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorEncryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(300),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorEncryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(600),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorEncryptionParameters {
-                    noise: Variance(0.00000001),
                     lwe_dimension: LweDimension(1000),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorEncryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(3000),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorEncryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(6000),
                     lwe_ciphertext_count: LweCiphertextCount(100),
                 },
             ]

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_zero_encryption.rs
@@ -48,37 +48,12 @@ where
             vec![
                 LweCiphertextVectorZeroEncryptionParameters {
                     noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(100),
+                    lwe_dimension: LweDimension(1),
                     lwe_ciphertext_count: LweCiphertextCount(1),
                 },
                 LweCiphertextVectorZeroEncryptionParameters {
                     noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(100),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorZeroEncryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(300),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorZeroEncryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(600),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorZeroEncryptionParameters {
-                    noise: Variance(0.00000001),
                     lwe_dimension: LweDimension(1000),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorZeroEncryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(3000),
-                    lwe_ciphertext_count: LweCiphertextCount(100),
-                },
-                LweCiphertextVectorZeroEncryptionParameters {
-                    noise: Variance(0.00000001),
-                    lwe_dimension: LweDimension(6000),
                     lwe_ciphertext_count: LweCiphertextCount(100),
                 },
             ]

--- a/concrete-core-fixture/src/fixture/mod.rs
+++ b/concrete-core-fixture/src/fixture/mod.rs
@@ -387,6 +387,9 @@ pub use lwe_ciphertext_vector_encryption::*;
 mod lwe_ciphertext_vector_conversion;
 pub use lwe_ciphertext_vector_conversion::*;
 
+mod lwe_ciphertext_vector_discarding_conversion;
+pub use lwe_ciphertext_vector_discarding_conversion::*;
+
 mod lwe_ciphertext_vector_fusing_addition;
 pub use lwe_ciphertext_vector_fusing_addition::*;
 

--- a/concrete-core-fixture/src/generation/synthesizing/lwe_ciphertext_vector.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/lwe_ciphertext_vector.rs
@@ -27,7 +27,9 @@ mod backend_default {
     };
     use crate::generation::synthesizing::SynthesizesLweCiphertextVector;
     use crate::generation::{BinaryKeyDistribution, Maker, Precision32, Precision64};
-    use concrete_core::prelude::{LweCiphertextVector32, LweCiphertextVector64};
+    use concrete_core::prelude::{
+        LweCiphertextVector32, LweCiphertextVector64, LweCiphertextVectorEntity,
+    };
 
     impl SynthesizesLweCiphertextVector<Precision32, BinaryKeyDistribution, LweCiphertextVector32>
         for Maker
@@ -68,7 +70,225 @@ mod backend_default {
 
         fn destroy_lwe_ciphertext_vector(&mut self, _entity: LweCiphertextVector64) {}
     }
+
+    use concrete_core::prelude::{
+        LweCiphertextVectorConsumingRetrievalEngine, LweCiphertextVectorCreationEngine,
+        LweCiphertextVectorView32, LweCiphertextVectorView64,
+    };
+
+    impl<'a>
+        SynthesizesLweCiphertextVector<
+            Precision32,
+            BinaryKeyDistribution,
+            LweCiphertextVectorView32<'a>,
+        > for Maker
+    {
+        fn synthesize_lwe_ciphertext_vector(
+            &mut self,
+            prototype: &Self::LweCiphertextVectorProto,
+        ) -> LweCiphertextVectorView32<'a> {
+            let ciphertext_vector = prototype.0.to_owned();
+            let container = self
+                .default_engine
+                .consume_retrieve_lwe_ciphertext_vector(ciphertext_vector)
+                .unwrap();
+            self.default_engine
+                .create_lwe_ciphertext_vector_from(
+                    container.leak() as &[u32],
+                    prototype.0.lwe_dimension().to_lwe_size(),
+                )
+                .unwrap()
+        }
+
+        fn unsynthesize_lwe_ciphertext_vector(
+            &mut self,
+            entity: LweCiphertextVectorView32,
+        ) -> Self::LweCiphertextVectorProto {
+            let lwe_size = entity.lwe_dimension().to_lwe_size();
+            let slice = self
+                .default_engine
+                .consume_retrieve_lwe_ciphertext_vector(entity)
+                .unwrap();
+            let reconstructed_vec = unsafe {
+                Vec::from_raw_parts(slice.as_ptr() as *mut u32, slice.len(), slice.len())
+            };
+            ProtoBinaryLweCiphertextVector32(
+                self.default_engine
+                    .create_lwe_ciphertext_vector_from(reconstructed_vec, lwe_size)
+                    .unwrap(),
+            )
+        }
+
+        fn destroy_lwe_ciphertext_vector(&mut self, entity: LweCiphertextVectorView32) {
+            // Re-construct the vector so that it frees memory when it's dropped
+            let slice = self
+                .default_engine
+                .consume_retrieve_lwe_ciphertext_vector(entity)
+                .unwrap();
+            unsafe { Vec::from_raw_parts(slice.as_ptr() as *mut u32, slice.len(), slice.len()) };
+        }
+    }
+
+    impl<'a>
+        SynthesizesLweCiphertextVector<
+            Precision64,
+            BinaryKeyDistribution,
+            LweCiphertextVectorView64<'a>,
+        > for Maker
+    {
+        fn synthesize_lwe_ciphertext_vector(
+            &mut self,
+            prototype: &Self::LweCiphertextVectorProto,
+        ) -> LweCiphertextVectorView64<'a> {
+            let ciphertext_vector = prototype.0.to_owned();
+            let container = self
+                .default_engine
+                .consume_retrieve_lwe_ciphertext_vector(ciphertext_vector)
+                .unwrap();
+            self.default_engine
+                .create_lwe_ciphertext_vector_from(
+                    container.leak() as &[u64],
+                    prototype.0.lwe_dimension().to_lwe_size(),
+                )
+                .unwrap()
+        }
+
+        fn unsynthesize_lwe_ciphertext_vector(
+            &mut self,
+            entity: LweCiphertextVectorView64,
+        ) -> Self::LweCiphertextVectorProto {
+            let lwe_size = entity.lwe_dimension().to_lwe_size();
+            let slice = self
+                .default_engine
+                .consume_retrieve_lwe_ciphertext_vector(entity)
+                .unwrap();
+            let reconstructed_vec = unsafe {
+                Vec::from_raw_parts(slice.as_ptr() as *mut u64, slice.len(), slice.len())
+            };
+            ProtoBinaryLweCiphertextVector64(
+                self.default_engine
+                    .create_lwe_ciphertext_vector_from(reconstructed_vec, lwe_size)
+                    .unwrap(),
+            )
+        }
+
+        fn destroy_lwe_ciphertext_vector(&mut self, entity: LweCiphertextVectorView64) {
+            // Re-construct the vector so that it frees memory when it's dropped
+            let slice = self
+                .default_engine
+                .consume_retrieve_lwe_ciphertext_vector(entity)
+                .unwrap();
+            unsafe { Vec::from_raw_parts(slice.as_ptr() as *mut u32, slice.len(), slice.len()) };
+        }
+    }
+
+    use concrete_core::prelude::{LweCiphertextVectorMutView32, LweCiphertextVectorMutView64};
+
+    impl<'a>
+        SynthesizesLweCiphertextVector<
+            Precision32,
+            BinaryKeyDistribution,
+            LweCiphertextVectorMutView32<'a>,
+        > for Maker
+    {
+        fn synthesize_lwe_ciphertext_vector(
+            &mut self,
+            prototype: &Self::LweCiphertextVectorProto,
+        ) -> LweCiphertextVectorMutView32<'a> {
+            let ciphertext_vector = prototype.0.to_owned();
+            let container = self
+                .default_engine
+                .consume_retrieve_lwe_ciphertext_vector(ciphertext_vector)
+                .unwrap();
+            self.default_engine
+                .create_lwe_ciphertext_vector_from(
+                    container.leak(),
+                    prototype.0.lwe_dimension().to_lwe_size(),
+                )
+                .unwrap()
+        }
+
+        fn unsynthesize_lwe_ciphertext_vector(
+            &mut self,
+            entity: LweCiphertextVectorMutView32,
+        ) -> Self::LweCiphertextVectorProto {
+            let lwe_size = entity.lwe_dimension().to_lwe_size();
+            let slice = self
+                .default_engine
+                .consume_retrieve_lwe_ciphertext_vector(entity)
+                .unwrap();
+            let reconstructed_vec =
+                unsafe { Vec::from_raw_parts(slice.as_mut_ptr(), slice.len(), slice.len()) };
+            ProtoBinaryLweCiphertextVector32(
+                self.default_engine
+                    .create_lwe_ciphertext_vector_from(reconstructed_vec, lwe_size)
+                    .unwrap(),
+            )
+        }
+
+        fn destroy_lwe_ciphertext_vector(&mut self, entity: LweCiphertextVectorMutView32) {
+            // Re-construct the vector so that it frees memory when it's dropped
+            let slice = self
+                .default_engine
+                .consume_retrieve_lwe_ciphertext_vector(entity)
+                .unwrap();
+            unsafe { Vec::from_raw_parts(slice.as_mut_ptr(), slice.len(), slice.len()) };
+        }
+    }
+
+    impl<'a>
+        SynthesizesLweCiphertextVector<
+            Precision64,
+            BinaryKeyDistribution,
+            LweCiphertextVectorMutView64<'a>,
+        > for Maker
+    {
+        fn synthesize_lwe_ciphertext_vector(
+            &mut self,
+            prototype: &Self::LweCiphertextVectorProto,
+        ) -> LweCiphertextVectorMutView64<'a> {
+            let ciphertext_vector = prototype.0.to_owned();
+            let container = self
+                .default_engine
+                .consume_retrieve_lwe_ciphertext_vector(ciphertext_vector)
+                .unwrap();
+            self.default_engine
+                .create_lwe_ciphertext_vector_from(
+                    container.leak(),
+                    prototype.0.lwe_dimension().to_lwe_size(),
+                )
+                .unwrap()
+        }
+
+        fn unsynthesize_lwe_ciphertext_vector(
+            &mut self,
+            entity: LweCiphertextVectorMutView64,
+        ) -> Self::LweCiphertextVectorProto {
+            let lwe_size = entity.lwe_dimension().to_lwe_size();
+            let slice = self
+                .default_engine
+                .consume_retrieve_lwe_ciphertext_vector(entity)
+                .unwrap();
+            let reconstructed_vec =
+                unsafe { Vec::from_raw_parts(slice.as_mut_ptr(), slice.len(), slice.len()) };
+            ProtoBinaryLweCiphertextVector64(
+                self.default_engine
+                    .create_lwe_ciphertext_vector_from(reconstructed_vec, lwe_size)
+                    .unwrap(),
+            )
+        }
+
+        fn destroy_lwe_ciphertext_vector(&mut self, entity: LweCiphertextVectorMutView64) {
+            // Re-construct the vector so that it frees memory when it's dropped
+            let slice = self
+                .default_engine
+                .consume_retrieve_lwe_ciphertext_vector(entity)
+                .unwrap();
+            unsafe { Vec::from_raw_parts(slice.as_mut_ptr(), slice.len(), slice.len()) };
+        }
+    }
 }
+
 #[cfg(all(feature = "backend_cuda", not(feature = "_ci_do_not_compile")))]
 mod backend_cuda {
     use crate::generation::prototypes::{

--- a/concrete-core-test/src/cuda.rs
+++ b/concrete-core-test/src/cuda.rs
@@ -34,6 +34,10 @@ macro_rules! test {
 
 test! {
     ((BinaryKeyDistribution), LweCiphertextVectorConversionFixture, (CudaLweCiphertextVector, LweCiphertextVector)),
+    ((BinaryKeyDistribution), LweCiphertextVectorConversionFixture, (LweCiphertextVectorView,
+        CudaLweCiphertextVector)),
+    ((BinaryKeyDistribution), LweCiphertextVectorDiscardingConversionFixture,
+        (CudaLweCiphertextVector, LweCiphertextVectorMutView)),
     ((BinaryKeyDistribution), LweCiphertextConversionFixture, (CudaLweCiphertext, LweCiphertext)),
     ((BinaryKeyDistribution, BinaryKeyDistribution), LweCiphertextVectorDiscardingKeyswitchFixture, (CudaLweKeyswitchKey, CudaLweCiphertextVector,
         CudaLweCiphertextVector)),

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_vector_conversion.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_vector_conversion.rs
@@ -9,7 +9,10 @@ use crate::backends::cuda::private::crypto::lwe::list::{
 use crate::backends::cuda::private::device::GpuIndex;
 use crate::backends::cuda::private::{compute_number_of_samples_on_gpu, number_of_active_gpus};
 use crate::commons::crypto::lwe::LweList;
-use crate::prelude::{CiphertextCount, LweCiphertextVector32, LweCiphertextVector64};
+use crate::prelude::{
+    CiphertextCount, LweCiphertextVector32, LweCiphertextVector64, LweCiphertextVectorMutView32,
+    LweCiphertextVectorMutView64, LweCiphertextVectorView32, LweCiphertextVectorView64,
+};
 use crate::specification::engines::{
     LweCiphertextVectorConversionEngine, LweCiphertextVectorConversionError,
 };
@@ -40,7 +43,7 @@ impl LweCiphertextVectorConversionEngine<LweCiphertextVector32, CudaLweCiphertex
     /// let lwe_dimension = LweDimension(6);
     /// // Here a hard-set encoding is applied (shift by 20 bits)
     /// let input = vec![3_u32 << 20; 3];
-    /// let noise = Variance(2_f64.powf(-25.));
+    /// let noise = Variance(2_f64.powf(-50.));
     ///
     /// const UNSAFE_SECRET: u128 = 0;
     /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
@@ -119,7 +122,7 @@ impl LweCiphertextVectorConversionEngine<CudaLweCiphertextVector32, LweCiphertex
     /// let lwe_dimension = LweDimension(6);
     /// // Here a hard-set encoding is applied (shift by 20 bits)
     /// let input = vec![3_u32 << 20; 3];
-    /// let noise = Variance(2_f64.powf(-25.));
+    /// let noise = Variance(2_f64.powf(-50.));
     ///
     /// const UNSAFE_SECRET: u128 = 0;
     /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
@@ -188,7 +191,7 @@ impl LweCiphertextVectorConversionEngine<LweCiphertextVector64, CudaLweCiphertex
     /// let lwe_dimension = LweDimension(6);
     /// // Here a hard-set encoding is applied (shift by 20 bits)
     /// let input = vec![3_u64 << 20; 3];
-    /// let noise = Variance(2_f64.powf(-25.));
+    /// let noise = Variance(2_f64.powf(-50.));
     ///
     /// const UNSAFE_SECRET: u128 = 0;
     /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
@@ -267,7 +270,7 @@ impl LweCiphertextVectorConversionEngine<CudaLweCiphertextVector64, LweCiphertex
     /// let lwe_dimension = LweDimension(6);
     /// // Here a hard-set encoding is applied (shift by 20 bits)
     /// let input = vec![3_u64 << 20; 3];
-    /// let noise = Variance(2_f64.powf(-25.));
+    /// let noise = Variance(2_f64.powf(-50.));
     ///
     /// const UNSAFE_SECRET: u128 = 0;
     /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
@@ -314,5 +317,362 @@ impl LweCiphertextVectorConversionEngine<CudaLweCiphertextVector64, LweCiphertex
             output,
             input.lwe_dimension().to_lwe_size(),
         ))
+    }
+}
+
+/// # Description
+/// Convert an LWE ciphertext vector view with 32 bits of precision from CPU to GPU.
+///
+/// The input ciphertext vector view is split over GPUs, so that each GPU contains
+/// the total amount of ciphertexts divided by the number of GPUs on the machine.
+/// The last GPU takes the remainder of the division if there is any.
+impl LweCiphertextVectorConversionEngine<LweCiphertextVectorView32<'_>, CudaLweCiphertextVector32>
+    for CudaEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(6);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = vec![3_u32 << 20; 3];
+    /// let noise = Variance(2_f64.powf(-50.));
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let h_key: LweSecretKey32 = default_engine.generate_new_lwe_secret_key(lwe_dimension)?;
+    /// let h_plaintext_vector: PlaintextVector32 =
+    ///     default_engine.create_plaintext_vector_from(&input)?;
+    /// let mut h_ciphertext_vector: LweCiphertextVector32 =
+    ///     default_engine.encrypt_lwe_ciphertext_vector(&h_key, &h_plaintext_vector, noise)?;
+    /// let lwe_ciphertext_count = h_ciphertext_vector.lwe_ciphertext_count();
+    /// let lwe_size = h_ciphertext_vector.lwe_dimension().to_lwe_size();
+    ///
+    /// let h_raw_ciphertext_vector: Vec<u32> =
+    ///     default_engine.consume_retrieve_lwe_ciphertext_vector(h_ciphertext_vector)?;
+    /// let mut h_view_ciphertext_vector: LweCiphertextVectorView32 = default_engine
+    ///     .create_lwe_ciphertext_vector_from(h_raw_ciphertext_vector.as_slice(), lwe_size)?;
+    ///
+    /// let mut cuda_engine = CudaEngine::new(())?;
+    /// let d_ciphertext_vector: CudaLweCiphertextVector32 =
+    ///     cuda_engine.convert_lwe_ciphertext_vector(&h_view_ciphertext_vector)?;
+    ///
+    /// assert_eq!(d_ciphertext_vector.lwe_dimension(), lwe_dimension);
+    /// assert_eq!(
+    ///     d_ciphertext_vector.lwe_ciphertext_count(),
+    ///     lwe_ciphertext_count
+    /// );
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn convert_lwe_ciphertext_vector(
+        &mut self,
+        input: &LweCiphertextVectorView32,
+    ) -> Result<CudaLweCiphertextVector32, LweCiphertextVectorConversionError<CudaError>> {
+        let number_of_gpus = number_of_active_gpus(
+            self.get_number_of_gpus(),
+            CiphertextCount(input.lwe_ciphertext_count().0),
+        );
+        for gpu_index in 0..number_of_gpus.0 {
+            let stream = &self.streams[gpu_index];
+            let samples = compute_number_of_samples_on_gpu(
+                self.get_number_of_gpus(),
+                CiphertextCount(input.lwe_ciphertext_count().0),
+                GpuIndex(gpu_index),
+            );
+            let data_per_gpu = samples.0 * input.lwe_dimension().to_lwe_size().0;
+            let size = data_per_gpu as u64 * std::mem::size_of::<u32>() as u64;
+            stream.check_device_memory(size)?;
+        }
+        Ok(unsafe { self.convert_lwe_ciphertext_vector_unchecked(input) })
+    }
+
+    unsafe fn convert_lwe_ciphertext_vector_unchecked(
+        &mut self,
+        input: &LweCiphertextVectorView32,
+    ) -> CudaLweCiphertextVector32 {
+        let vecs = copy_lwe_ciphertext_vector_from_cpu_to_gpu::<u32, _>(
+            self.get_cuda_streams(),
+            &input.0,
+            self.get_number_of_gpus(),
+        );
+        CudaLweCiphertextVector32(CudaLweList::<u32> {
+            d_vecs: vecs,
+            lwe_ciphertext_count: input.lwe_ciphertext_count(),
+            lwe_dimension: input.lwe_dimension(),
+        })
+    }
+}
+
+/// # Description
+/// Convert an LWE ciphertext vector view with 64 bits of precision from CPU to GPU.
+///
+/// The input ciphertext vector view is split over GPUs, so that each GPU contains
+/// the total amount of ciphertexts divided by the number of GPUs on the machine.
+/// The last GPU takes the remainder of the division if there is any.
+impl LweCiphertextVectorConversionEngine<LweCiphertextVectorView64<'_>, CudaLweCiphertextVector64>
+    for CudaEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(6);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = vec![3_u64 << 50; 3];
+    /// let noise = Variance(2_f64.powf(-50.));
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let h_key: LweSecretKey64 = default_engine.generate_new_lwe_secret_key(lwe_dimension)?;
+    /// let h_plaintext_vector: PlaintextVector64 =
+    ///     default_engine.create_plaintext_vector_from(&input)?;
+    /// let mut h_ciphertext_vector: LweCiphertextVector64 =
+    ///     default_engine.encrypt_lwe_ciphertext_vector(&h_key, &h_plaintext_vector, noise)?;
+    /// let lwe_ciphertext_count = h_ciphertext_vector.lwe_ciphertext_count();
+    /// let lwe_size = h_ciphertext_vector.lwe_dimension().to_lwe_size();
+    ///
+    /// let h_raw_ciphertext_vector: Vec<u64> =
+    ///     default_engine.consume_retrieve_lwe_ciphertext_vector(h_ciphertext_vector)?;
+    /// let mut h_view_ciphertext_vector: LweCiphertextVectorView64 = default_engine
+    ///     .create_lwe_ciphertext_vector_from(h_raw_ciphertext_vector.as_slice(), lwe_size)?;
+    ///
+    /// let mut cuda_engine = CudaEngine::new(())?;
+    /// let d_ciphertext_vector: CudaLweCiphertextVector64 =
+    ///     cuda_engine.convert_lwe_ciphertext_vector(&h_view_ciphertext_vector)?;
+    ///
+    /// assert_eq!(d_ciphertext_vector.lwe_dimension(), lwe_dimension);
+    /// assert_eq!(
+    ///     d_ciphertext_vector.lwe_ciphertext_count(),
+    ///     lwe_ciphertext_count
+    /// );
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn convert_lwe_ciphertext_vector(
+        &mut self,
+        input: &LweCiphertextVectorView64,
+    ) -> Result<CudaLweCiphertextVector64, LweCiphertextVectorConversionError<CudaError>> {
+        let number_of_gpus = number_of_active_gpus(
+            self.get_number_of_gpus(),
+            CiphertextCount(input.lwe_ciphertext_count().0),
+        );
+        for gpu_index in 0..number_of_gpus.0 {
+            let stream = &self.streams[gpu_index];
+            let samples = compute_number_of_samples_on_gpu(
+                self.get_number_of_gpus(),
+                CiphertextCount(input.lwe_ciphertext_count().0),
+                GpuIndex(gpu_index),
+            );
+            let data_per_gpu = samples.0 * input.lwe_dimension().to_lwe_size().0;
+            let size = data_per_gpu as u64 * std::mem::size_of::<u64>() as u64;
+            stream.check_device_memory(size)?;
+        }
+        Ok(unsafe { self.convert_lwe_ciphertext_vector_unchecked(input) })
+    }
+
+    unsafe fn convert_lwe_ciphertext_vector_unchecked(
+        &mut self,
+        input: &LweCiphertextVectorView64,
+    ) -> CudaLweCiphertextVector64 {
+        let vecs = copy_lwe_ciphertext_vector_from_cpu_to_gpu::<u64, _>(
+            self.get_cuda_streams(),
+            &input.0,
+            self.get_number_of_gpus(),
+        );
+        CudaLweCiphertextVector64(CudaLweList::<u64> {
+            d_vecs: vecs,
+            lwe_ciphertext_count: input.lwe_ciphertext_count(),
+            lwe_dimension: input.lwe_dimension(),
+        })
+    }
+}
+/// # Description
+/// Convert a mutable LWE ciphertext vector view with 32 bits of precision from CPU to GPU.
+///
+/// The input ciphertext vector view is split over GPUs, so that each GPU contains
+/// the total amount of ciphertexts divided by the number of GPUs on the machine.
+/// The last GPU takes the remainder of the division if there is any.
+impl
+    LweCiphertextVectorConversionEngine<LweCiphertextVectorMutView32<'_>, CudaLweCiphertextVector32>
+    for CudaEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(6);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = vec![3_u32 << 20; 3];
+    /// let noise = Variance(2_f64.powf(-50.));
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let h_key: LweSecretKey32 = default_engine.generate_new_lwe_secret_key(lwe_dimension)?;
+    /// let h_plaintext_vector: PlaintextVector32 =
+    ///     default_engine.create_plaintext_vector_from(&input)?;
+    /// let mut h_ciphertext_vector: LweCiphertextVector32 =
+    ///     default_engine.encrypt_lwe_ciphertext_vector(&h_key, &h_plaintext_vector, noise)?;
+    /// let lwe_ciphertext_count = h_ciphertext_vector.lwe_ciphertext_count();
+    /// let lwe_size = h_ciphertext_vector.lwe_dimension().to_lwe_size();
+    ///
+    /// let mut h_raw_ciphertext_vector: Vec<u32> =
+    ///     default_engine.consume_retrieve_lwe_ciphertext_vector(h_ciphertext_vector)?;
+    /// let mut h_view_ciphertext_vector: LweCiphertextVectorMutView32 = default_engine
+    ///     .create_lwe_ciphertext_vector_from(h_raw_ciphertext_vector.as_mut_slice(), lwe_size)?;
+    ///
+    /// let mut cuda_engine = CudaEngine::new(())?;
+    /// let d_ciphertext_vector: CudaLweCiphertextVector32 =
+    ///     cuda_engine.convert_lwe_ciphertext_vector(&h_view_ciphertext_vector)?;
+    ///
+    /// assert_eq!(d_ciphertext_vector.lwe_dimension(), lwe_dimension);
+    /// assert_eq!(
+    ///     d_ciphertext_vector.lwe_ciphertext_count(),
+    ///     lwe_ciphertext_count
+    /// );
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn convert_lwe_ciphertext_vector(
+        &mut self,
+        input: &LweCiphertextVectorMutView32,
+    ) -> Result<CudaLweCiphertextVector32, LweCiphertextVectorConversionError<CudaError>> {
+        let number_of_gpus = number_of_active_gpus(
+            self.get_number_of_gpus(),
+            CiphertextCount(input.lwe_ciphertext_count().0),
+        );
+        for gpu_index in 0..number_of_gpus.0 {
+            let stream = &self.streams[gpu_index];
+            let samples = compute_number_of_samples_on_gpu(
+                self.get_number_of_gpus(),
+                CiphertextCount(input.lwe_ciphertext_count().0),
+                GpuIndex(gpu_index),
+            );
+            let data_per_gpu = samples.0 * input.lwe_dimension().to_lwe_size().0;
+            let size = data_per_gpu as u64 * std::mem::size_of::<u32>() as u64;
+            stream.check_device_memory(size)?;
+        }
+        Ok(unsafe { self.convert_lwe_ciphertext_vector_unchecked(input) })
+    }
+
+    unsafe fn convert_lwe_ciphertext_vector_unchecked(
+        &mut self,
+        input: &LweCiphertextVectorMutView32,
+    ) -> CudaLweCiphertextVector32 {
+        let vecs = copy_lwe_ciphertext_vector_from_cpu_to_gpu::<u32, _>(
+            self.get_cuda_streams(),
+            &input.0,
+            self.get_number_of_gpus(),
+        );
+        CudaLweCiphertextVector32(CudaLweList::<u32> {
+            d_vecs: vecs,
+            lwe_ciphertext_count: input.lwe_ciphertext_count(),
+            lwe_dimension: input.lwe_dimension(),
+        })
+    }
+}
+
+/// # Description
+/// Convert a mutable LWE ciphertext vector view with 64 bits of precision from CPU to GPU.
+///
+/// The input ciphertext vector view is split over GPUs, so that each GPU contains
+/// the total amount of ciphertexts divided by the number of GPUs on the machine.
+/// The last GPU takes the remainder of the division if there is any.
+impl
+    LweCiphertextVectorConversionEngine<LweCiphertextVectorMutView64<'_>, CudaLweCiphertextVector64>
+    for CudaEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let lwe_dimension = LweDimension(6);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = vec![3_u64 << 50; 3];
+    /// let noise = Variance(2_f64.powf(-50.));
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let h_key: LweSecretKey64 = default_engine.generate_new_lwe_secret_key(lwe_dimension)?;
+    /// let h_plaintext_vector: PlaintextVector64 =
+    ///     default_engine.create_plaintext_vector_from(&input)?;
+    /// let mut h_ciphertext_vector: LweCiphertextVector64 =
+    ///     default_engine.encrypt_lwe_ciphertext_vector(&h_key, &h_plaintext_vector, noise)?;
+    /// let lwe_ciphertext_count = h_ciphertext_vector.lwe_ciphertext_count();
+    /// let lwe_size = h_ciphertext_vector.lwe_dimension().to_lwe_size();
+    ///
+    /// let mut h_raw_ciphertext_vector: Vec<u64> =
+    ///     default_engine.consume_retrieve_lwe_ciphertext_vector(h_ciphertext_vector)?;
+    /// let mut h_view_ciphertext_vector: LweCiphertextVectorMutView64 = default_engine
+    ///     .create_lwe_ciphertext_vector_from(h_raw_ciphertext_vector.as_mut_slice(), lwe_size)?;
+    ///
+    /// let mut cuda_engine = CudaEngine::new(())?;
+    /// let d_ciphertext_vector: CudaLweCiphertextVector64 =
+    ///     cuda_engine.convert_lwe_ciphertext_vector(&h_view_ciphertext_vector)?;
+    ///
+    /// assert_eq!(d_ciphertext_vector.lwe_dimension(), lwe_dimension);
+    /// assert_eq!(
+    ///     d_ciphertext_vector.lwe_ciphertext_count(),
+    ///     lwe_ciphertext_count
+    /// );
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn convert_lwe_ciphertext_vector(
+        &mut self,
+        input: &LweCiphertextVectorMutView64,
+    ) -> Result<CudaLweCiphertextVector64, LweCiphertextVectorConversionError<CudaError>> {
+        let number_of_gpus = number_of_active_gpus(
+            self.get_number_of_gpus(),
+            CiphertextCount(input.lwe_ciphertext_count().0),
+        );
+        for gpu_index in 0..number_of_gpus.0 {
+            let stream = &self.streams[gpu_index];
+            let samples = compute_number_of_samples_on_gpu(
+                self.get_number_of_gpus(),
+                CiphertextCount(input.lwe_ciphertext_count().0),
+                GpuIndex(gpu_index),
+            );
+            let data_per_gpu = samples.0 * input.lwe_dimension().to_lwe_size().0;
+            let size = data_per_gpu as u64 * std::mem::size_of::<u64>() as u64;
+            stream.check_device_memory(size)?;
+        }
+        Ok(unsafe { self.convert_lwe_ciphertext_vector_unchecked(input) })
+    }
+
+    unsafe fn convert_lwe_ciphertext_vector_unchecked(
+        &mut self,
+        input: &LweCiphertextVectorMutView64,
+    ) -> CudaLweCiphertextVector64 {
+        let vecs = copy_lwe_ciphertext_vector_from_cpu_to_gpu::<u64, _>(
+            self.get_cuda_streams(),
+            &input.0,
+            self.get_number_of_gpus(),
+        );
+        CudaLweCiphertextVector64(CudaLweList::<u64> {
+            d_vecs: vecs,
+            lwe_ciphertext_count: input.lwe_ciphertext_count(),
+            lwe_dimension: input.lwe_dimension(),
+        })
     }
 }

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_vector_discarding_conversion.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_vector_discarding_conversion.rs
@@ -1,0 +1,205 @@
+use crate::backends::cuda::implementation::engines::{CudaEngine, CudaError};
+use crate::backends::cuda::implementation::entities::{
+    CudaLweCiphertextVector32, CudaLweCiphertextVector64,
+};
+use crate::backends::cuda::private::crypto::lwe::list::discard_copy_lwe_ciphertext_vector_from_gpu_to_cpu;
+use crate::prelude::{LweCiphertextVectorMutView32, LweCiphertextVectorMutView64};
+use crate::specification::engines::{
+    LweCiphertextVectorDiscardingConversionEngine, LweCiphertextVectorDiscardingConversionError,
+};
+
+impl From<CudaError> for LweCiphertextVectorDiscardingConversionError<CudaError> {
+    fn from(err: CudaError) -> Self {
+        Self::Engine(err)
+    }
+}
+
+/// # Description
+/// Convert an LWE ciphertext vector with 32 bits of precision from GPU to a view on CPU.
+/// The data from each GPU is copied into a part of an LweCiphertextVectorMutView32 on the CPU.
+impl
+    LweCiphertextVectorDiscardingConversionEngine<
+        CudaLweCiphertextVector32,
+        LweCiphertextVectorMutView32<'_>,
+    > for CudaEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// use std::borrow::BorrowMut;
+    /// let lwe_dimension = LweDimension(6);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = vec![3_u32 << 20; 3];
+    /// let noise = Variance(2_f64.powf(-50.));
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let h_key: LweSecretKey32 = default_engine.generate_new_lwe_secret_key(lwe_dimension)?;
+    /// let h_plaintext_vector: PlaintextVector32 =
+    ///     default_engine.create_plaintext_vector_from(&input)?;
+    /// let mut h_ciphertext_vector: LweCiphertextVector32 =
+    ///     default_engine.encrypt_lwe_ciphertext_vector(&h_key, &h_plaintext_vector, noise)?;
+    ///
+    /// let mut cuda_engine = CudaEngine::new(())?;
+    /// let d_ciphertext_vector: CudaLweCiphertextVector32 =
+    ///     cuda_engine.convert_lwe_ciphertext_vector(&h_ciphertext_vector)?;
+    /// let lwe_ciphertext_count = d_ciphertext_vector.lwe_ciphertext_count();
+    /// let lwe_size = d_ciphertext_vector.lwe_dimension().to_lwe_size();
+    ///
+    /// // Prepares the output container
+    /// let mut h_raw_output_ciphertext_vector = vec![0_u32; lwe_size.0 * lwe_ciphertext_count.0];
+    /// let mut h_view_output_ciphertext_vector: LweCiphertextVectorMutView32 = default_engine
+    ///     .create_lwe_ciphertext_vector_from(
+    ///         h_raw_output_ciphertext_vector.as_mut_slice(),
+    ///         lwe_size,
+    ///     )?;
+    ///
+    /// cuda_engine.discard_convert_lwe_ciphertext_vector(
+    ///     h_view_output_ciphertext_vector.borrow_mut(),
+    ///     &d_ciphertext_vector,
+    /// )?;
+    ///
+    /// assert_eq!(
+    ///     h_view_output_ciphertext_vector.lwe_dimension(),
+    ///     lwe_dimension
+    /// );
+    /// assert_eq!(
+    ///     h_view_output_ciphertext_vector.lwe_ciphertext_count(),
+    ///     lwe_ciphertext_count
+    /// );
+    ///
+    /// // Extracts the internal container
+    /// let h_raw_input_ciphertext_vector: Vec<u32> =
+    ///     default_engine.consume_retrieve_lwe_ciphertext_vector(h_ciphertext_vector)?;
+    /// let h_raw_output_ciphertext_vector: &[u32] =
+    ///     default_engine.consume_retrieve_lwe_ciphertext_vector(h_view_output_ciphertext_vector)?;
+    /// assert_eq!(
+    ///     h_raw_input_ciphertext_vector,
+    ///     h_raw_output_ciphertext_vector.to_vec()
+    /// );
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_convert_lwe_ciphertext_vector(
+        &mut self,
+        output: &mut LweCiphertextVectorMutView32,
+        input: &CudaLweCiphertextVector32,
+    ) -> Result<(), LweCiphertextVectorDiscardingConversionError<CudaError>> {
+        unsafe { self.discard_convert_lwe_ciphertext_vector_unchecked(output, input) };
+        Ok(())
+    }
+
+    unsafe fn discard_convert_lwe_ciphertext_vector_unchecked(
+        &mut self,
+        output: &mut LweCiphertextVectorMutView32,
+        input: &CudaLweCiphertextVector32,
+    ) {
+        discard_copy_lwe_ciphertext_vector_from_gpu_to_cpu::<u32>(
+            &mut output.0,
+            self.get_cuda_streams(),
+            &input.0,
+            self.get_number_of_gpus(),
+        );
+    }
+}
+
+/// # Description
+/// Convert an LWE ciphertext vector with 64 bits of precision from GPU to a view on CPU.
+/// The data from each GPU is copied into a part of an LweCiphertextVectorMutView64 on the CPU.
+impl
+    LweCiphertextVectorDiscardingConversionEngine<
+        CudaLweCiphertextVector64,
+        LweCiphertextVectorMutView64<'_>,
+    > for CudaEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// use std::borrow::BorrowMut;
+    /// let lwe_dimension = LweDimension(6);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = vec![3_u64 << 50; 3];
+    /// let noise = Variance(2_f64.powf(-50.));
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let h_key: LweSecretKey64 = default_engine.generate_new_lwe_secret_key(lwe_dimension)?;
+    /// let h_plaintext_vector: PlaintextVector64 =
+    ///     default_engine.create_plaintext_vector_from(&input)?;
+    /// let mut h_ciphertext_vector: LweCiphertextVector64 =
+    ///     default_engine.encrypt_lwe_ciphertext_vector(&h_key, &h_plaintext_vector, noise)?;
+    ///
+    /// let mut cuda_engine = CudaEngine::new(())?;
+    /// let d_ciphertext_vector: CudaLweCiphertextVector64 =
+    ///     cuda_engine.convert_lwe_ciphertext_vector(&h_ciphertext_vector)?;
+    /// let lwe_ciphertext_count = d_ciphertext_vector.lwe_ciphertext_count();
+    /// let lwe_size = d_ciphertext_vector.lwe_dimension().to_lwe_size();
+    ///
+    /// // Prepares the output container
+    /// let mut h_raw_output_ciphertext_vector = vec![0_u64; lwe_size.0 * lwe_ciphertext_count.0];
+    /// let mut h_view_output_ciphertext_vector: LweCiphertextVectorMutView64 = default_engine
+    ///     .create_lwe_ciphertext_vector_from(
+    ///         h_raw_output_ciphertext_vector.as_mut_slice(),
+    ///         lwe_size,
+    ///     )?;
+    ///
+    /// cuda_engine.discard_convert_lwe_ciphertext_vector(
+    ///     h_view_output_ciphertext_vector.borrow_mut(),
+    ///     &d_ciphertext_vector,
+    /// )?;
+    ///
+    /// assert_eq!(
+    ///     h_view_output_ciphertext_vector.lwe_dimension(),
+    ///     lwe_dimension
+    /// );
+    /// assert_eq!(
+    ///     h_view_output_ciphertext_vector.lwe_ciphertext_count(),
+    ///     lwe_ciphertext_count
+    /// );
+    ///
+    /// // Extracts the internal container
+    /// let h_raw_input_ciphertext_vector: Vec<u64> =
+    ///     default_engine.consume_retrieve_lwe_ciphertext_vector(h_ciphertext_vector)?;
+    /// let h_raw_output_ciphertext_vector: &[u64] =
+    ///     default_engine.consume_retrieve_lwe_ciphertext_vector(h_view_output_ciphertext_vector)?;
+    /// assert_eq!(
+    ///     h_raw_input_ciphertext_vector,
+    ///     h_raw_output_ciphertext_vector.to_vec()
+    /// );
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_convert_lwe_ciphertext_vector(
+        &mut self,
+        output: &mut LweCiphertextVectorMutView64,
+        input: &CudaLweCiphertextVector64,
+    ) -> Result<(), LweCiphertextVectorDiscardingConversionError<CudaError>> {
+        unsafe { self.discard_convert_lwe_ciphertext_vector_unchecked(output, input) };
+        Ok(())
+    }
+
+    unsafe fn discard_convert_lwe_ciphertext_vector_unchecked(
+        &mut self,
+        output: &mut LweCiphertextVectorMutView64,
+        input: &CudaLweCiphertextVector64,
+    ) {
+        discard_copy_lwe_ciphertext_vector_from_gpu_to_cpu::<u64>(
+            &mut output.0,
+            self.get_cuda_streams(),
+            &input.0,
+            self.get_number_of_gpus(),
+        );
+    }
+}

--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/mod.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/mod.rs
@@ -92,5 +92,6 @@ mod lwe_ciphertext_discarding_conversion;
 mod lwe_ciphertext_discarding_keyswitch;
 mod lwe_ciphertext_vector_conversion;
 mod lwe_ciphertext_vector_discarding_bootstrap;
+mod lwe_ciphertext_vector_discarding_conversion;
 mod lwe_ciphertext_vector_discarding_keyswitch;
 mod lwe_keyswitch_key_conversion;


### PR DESCRIPTION
### Resolves: https://github.com/zama-ai/concrete-core-internal/issues/324

### Description
This PR adds conversions between Cuda LWE ciphertext vectors & views on the CPU.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
