### PR TITLE
feat(cuda): implement Send and Sync for cuda ksk and bsk

### DIFF
--- a/concrete-core/src/backends/cuda/private/crypto/bootstrap/mod.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/bootstrap/mod.rs
@@ -32,6 +32,9 @@ pub(crate) struct CudaBootstrapKey<T: UnsignedInteger> {
     pub(crate) _phantom: PhantomData<T>,
 }
 
+unsafe impl<T> Send for CudaBootstrapKey<T> where T: Send + UnsignedInteger {}
+unsafe impl<T> Sync for CudaBootstrapKey<T> where T: Sync + UnsignedInteger {}
+
 pub(crate) unsafe fn convert_lwe_bootstrap_key_from_cpu_to_gpu<T: UnsignedInteger, Cont>(
     streams: &[CudaStream],
     input: &StandardBootstrapKey<Cont>,

--- a/concrete-core/src/backends/cuda/private/crypto/keyswitch/mod.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/keyswitch/mod.rs
@@ -22,6 +22,9 @@ pub(crate) struct CudaLweKeyswitchKey<T: UnsignedInteger> {
     pub(crate) decomp_base_log: DecompositionBaseLog,
 }
 
+unsafe impl<T> Send for CudaLweKeyswitchKey<T> where T: Send + UnsignedInteger {}
+unsafe impl<T> Sync for CudaLweKeyswitchKey<T> where T: Sync + UnsignedInteger {}
+
 pub(crate) unsafe fn execute_lwe_ciphertext_vector_keyswitch_on_gpu<T: UnsignedInteger>(
     streams: &[CudaStream],
     output: &mut CudaLweList<T>,


### PR DESCRIPTION
### Resolves: https://github.com/zama-ai/concrete-core-internal/issues/400

### Description

Adds implementation of Send Sync for cuda bsk and ksk.

I don't know the internals of the cuda implementation in details,
but for this change to be valid, the CudaVec's internal pointer (that is the ksk and bsk in our case)
should point to data that don't have interior mutability, which would otherwise lead to data races.
(So the ksk and bsk on the cuda side must not have buffers stored in them, or any ref count).

On a test using concrete-boolean, I got a noticable (but quickly bounded) speedup by using multiple thread + cuda
while still having correct results.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
