### PR TITLE
chore(ci): set scheduled benchmarks with results sent to ci bot

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,7 +17,6 @@ env:
 
 jobs:
   start-runner:
-    if: "contains(github.event.label.name, 'aws_test')"
     name: Start EC2 runner
     runs-on: ubuntu-20.04
     outputs:
@@ -52,10 +51,6 @@ jobs:
             echo "AMI: ${{ github.event.inputs.instance_image_id }}"
             echo "Type: ${{ github.event.inputs.instance_type }}"
 
-      - name: Set up home
-        run: |
-          echo "HOME=/home/ubuntu" >> "${GITHUB_ENV}"
-
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -68,7 +63,8 @@ jobs:
 
       - name: Parse results
         run: |
-          python3 ./ci/benchmark_parser.py "./${RESULTS_FILENAME}" --series-tags "{\"commit_hash\": \"${{ github.sha }}\"}"
+          python3 ./ci/benchmark_parser.py "./${RESULTS_FILENAME}" \
+          --series-tags '{"commit_hash": "${{ github.sha }}", "backend": "cpu"}'
         shell: bash
 
       - name: Upload results artifacts

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,127 @@
+# Run benchmarks on an AWS instance and return parsed results to Slab CI bot.
+name: Performance benchmarks
+
+on:
+  workflow_dispatch:
+  # Have a weekly benchmark run on main branch to be available on Monday morning (Paris time)
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # At 1:00 every Monday
+    # Timezone is UTC, so Paris time is +2 during the summer and +1 during winter
+    - cron: '0 1 * * MON'
+
+env:
+  CARGO_TERM_COLOR: always
+  ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  RESULTS_FILENAME: parsed_benchmark_results_${{ github.sha }}.json
+
+jobs:
+  start-runner:
+    if: "contains(github.event.label.name, 'aws_test')"
+    name: Start EC2 runner
+    runs-on: ubuntu-20.04
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_IAM_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_IAM_KEY }}
+          aws-region: eu-west-3
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: start
+          github-token: ${{ secrets.CONCRETE_ACTIONS_TOKEN }}
+          ec2-image-id: ami-0dae0bbbc42a4664a
+          ec2-instance-type: m6i.metal  # Bare metal instance but very costly.
+          subnet-id: subnet-da319dd4
+          security-group-id: sg-064a7184f24469c76
+
+  run-benchmarks:
+    name: Execute benchmarks in EC2
+    needs: start-runner
+    runs-on: ${{ needs.start-runner.outputs.label }}
+    steps:
+      - name: EC2 instance configuration used
+        run: |
+            echo "IDs: ${{ github.event.inputs.instance_id }}"
+            echo "AMI: ${{ github.event.inputs.instance_image_id }}"
+            echo "Type: ${{ github.event.inputs.instance_type }}"
+
+      - name: Set up home
+        run: |
+          echo "HOME=/home/ubuntu" >> "${GITHUB_ENV}"
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - uses: actions/checkout@v3
+      - name: Run concrete benchmarks
+        run: cargo run concrete-core-bench
+
+      - name: Parse results
+        run: |
+          python3 ./ci/benchmark_parser.py "./${RESULTS_FILENAME}" --series-tags "{\"commit_hash\": \"${{ github.sha }}\"}"
+        shell: bash
+
+      - name: Upload results artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.sha }}
+          path: ${RESULTS_FILENAME}
+
+      - uses: actions/checkout@v3
+      - name: Send data to Slab
+        shell: bash
+        run: |
+          echo "Computing HMac on downloaded artifact"
+          SIGNATURE="$(./ci/hmac_calculator.sh ./${RESULTS_FILENAME} '${{ secrets.JOB_SECRET }}')"
+          echo "Sending results to Slab..."
+          curl -v -k \
+          -H "Content-Type: application/json" \
+          -H "X-Slab-Repository: ${{ github.repository }}" \
+          -H "X-Slab-Command: plot_data" \
+          -H "X-Hub-Signature-256: sha256=${SIGNATURE}" \
+          -d @${RESULTS_FILENAME} \
+          ${{ secrets.SLAB_URL }}
+
+      - name: Slack Notification
+        if: ${{ always() }}
+        continue-on-error: true
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7
+        env:
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+          SLACK_ICON: https://pbs.twimg.com/profile_images/1274014582265298945/OjBKP9kn_400x400.png
+          SLACK_MESSAGE: "(Slab ci-bot) AWS benchmarks CPU finished with status ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  stop-runner:
+    name: Stop EC2 runner
+    needs:
+      - start-runner
+      - run-benchmarks
+    runs-on: ubuntu-20.04
+    if: ${{ always() && (needs.start-runner.result != 'skipped') }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_IAM_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_IAM_KEY }}
+          aws-region: eu-west-3
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          github-token: ${{ secrets.CONCRETE_ACTIONS_TOKEN }}
+          label: ${{ needs.start-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
+          mode: stop

--- a/ci/benchmark_parser.py
+++ b/ci/benchmark_parser.py
@@ -1,0 +1,100 @@
+import argparse
+import pathlib
+import json
+
+RESULTS_DIRECTORY = "target/criterion"
+EXCLUDED_DIRECTORIES = ["child_generate", "fork", "parent_generate", "report"]
+
+parser = argparse.ArgumentParser()
+parser.add_argument('output-file', help='File storing parsed results')
+parser.add_argument('-d', '--results-directory',
+                    dest='results_dir', default=RESULTS_DIRECTORY,
+                    help='Location of raw benchmark results')
+parser.add_argument('-n', '--series-name', dest='series_name',
+                    default="concrete_core_benchmark_timing",
+                    help='Name of the data series (as stored in Prometheus)')
+parser.add_argument('-e', '--series-help', dest='series_help',
+                    default="Timings of crypto operator with various parameters.",
+                    help='Description of the data series (as stored in Prometheus)')
+parser.add_argument('-t', '--series-tags', dest='series_tags',
+                    type=json.loads, default={},
+                    help='Tags to apply to all the points in the data series')
+
+
+def parse_results():
+    result_values = list()
+    for directory in RESULTS_DIRECTORY.iterdir():
+        if directory.name in EXCLUDED_DIRECTORIES or not(directory.is_dir()):
+            continue
+        for subdir in directory.iterdir():
+            if subdir.name == "report":
+                continue
+            results_dir = subdir.joinpath("new")
+            tags = parse_benchmark_file(results_dir)
+            for timing in parse_estimate_file(results_dir):
+                data_point = dict()
+                data_point["value"] = timing.pop("value")
+                timing.update(tags)
+                data_point["tags"] = tags
+                result_values.append(data_point)
+
+    return result_values
+
+
+def dump_results(results, target_directory, filename, series_name,
+                 series_help="", series_tags=None):
+    dump_file = target_directory.joinpath(filename)
+    series = [
+        {"series_name": series_name,
+         "series_help": series_help,
+         "series_tags": series_tags or dict(),
+         "points": results},
+    ]
+    dump_file.write_text(json.dumps(series))
+
+
+def parse_benchmark_file(directory):
+    raw_results = _parse_file_to_json(directory, "benchmark.json")
+    tags = dict()
+    operator, _, raw_config = raw_results["group_id"].partition("Fixture")
+    tags["operator"] = operator
+
+    parsed_config = raw_config.strip('<>').split(", ")
+    tags["precision"] = parsed_config[0].lstrip("Precision")
+    tags["engine"] = parsed_config[1]
+    tags["data_flavor"] = parsed_config[2].strip(")")  # FIXME There is an unneeded parenthesis at the end of the data flavor in concrete-core
+
+    tags["parameters"] = raw_results["value_str"].lstrip(operator + "Parameters ")
+    return tags
+
+
+def parse_estimate_file(directory):
+    raw_results = _parse_file_to_json(directory, "estimates.json")
+    timings = list()
+    for stat_name in ("mean", "median", "std_dev"):
+        if raw_results[stat_name] is None:
+            # Slope might not be filled.
+            continue
+
+        timings.append(
+            {"value": raw_results[stat_name]["point_estimate"],
+             "stat": stat_name}
+        )
+
+    return timings
+
+
+def _parse_file_to_json(directory, filename):
+    result_file = directory.joinpath(filename)
+    return json.loads(result_file.read_text())
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    print("Parsing benchmark results...")
+    dump_results(parse_results(), pathlib.Path(args.results_dir),
+                 args.output_file, args.series_name,
+                 series_help=args.series_help, series_tags=args.series_tags)
+
+    print("Results parsed.")


### PR DESCRIPTION
### Resolves: zama-ai/products#291

### Description

A new scheduled workflow is created to run concrete benchmarks using only CPU backend on a weekly basis. The results are then parsed before being sent to Slab ci-bot.
After that Slab handles transformation of these results into Prometheus metrics in order to be displayed in visualization system which is currently a Grafana instance.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
* [ ] ~~Docs have been added / updated (for bug fixes / features)~~
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] ~~The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)~~
* [ ] ~~The draft release description has been updated~~
* [ ] ~~Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]~~

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
