### PR TITLE
fix(cuda): Add a conditional macro check to remove CUDA-specific definitions when not needed

### DIFF
--- a/concrete-cuda/cuda/include/bootstrap.h
+++ b/concrete-cuda/cuda/include/bootstrap.h
@@ -104,7 +104,7 @@ void cuda_cmux_tree_64(
         uint32_t max_shared_memory);
 };
 
-
+#ifdef __CUDACC__
 __device__ inline int get_start_ith_ggsw(int i, uint32_t polynomial_size,
                                          int glwe_dimension,
                                          uint32_t l_gadget);
@@ -118,4 +118,6 @@ template <typename T>
 __device__ T*
 get_ith_body_kth_block(T *ptr, int i, int k, int level, uint32_t polynomial_size,
                        int glwe_dimension, uint32_t l_gadget);
+#endif
+
 #endif // CUDA_BOOTSTRAP_H


### PR DESCRIPTION
### Resolves:  https://github.com/zama-ai/concrete-core-internal/issues/434

### Description
This PR solves an issue that may happen if headers in concrete-cuda are included in code compiled using a standard C/C++ compiler. 

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
