### PR TITLE
Add extract bits feature in concrete-cuda

### DIFF
--- a/concrete-core/src/backends/cuda/private/wopbs/test.rs
+++ b/concrete-core/src/backends/cuda/private/wopbs/test.rs
@@ -1,17 +1,25 @@
 use crate::backends::cuda::private::device::{CudaStream, GpuIndex};
+use crate::commons::crypto::bootstrap::StandardBootstrapKey;
 use crate::commons::crypto::encoding::{Plaintext, PlaintextList};
 use crate::commons::crypto::ggsw::StandardGgswCiphertext;
 use crate::commons::crypto::glwe::GlweCiphertext;
+use crate::commons::crypto::lwe::{LweCiphertext, LweKeyswitchKey, LweList};
 use crate::commons::crypto::secret::generators::{
     EncryptionRandomGenerator, SecretRandomGenerator,
 };
-use crate::commons::crypto::secret::GlweSecretKey;
+use crate::commons::crypto::secret::{GlweSecretKey, LweSecretKey};
+use crate::commons::math::decomposition::SignedDecomposer;
 use crate::commons::math::polynomial::PolynomialList;
 use crate::commons::math::tensor::{AsMutTensor, AsRefSlice, AsRefTensor};
+use crate::commons::test_tools;
 use crate::prelude::*;
 use concrete_csprng::generators::SoftwareRandomGenerator;
 use concrete_csprng::seeders::UnixSeeder;
-use concrete_cuda::cuda_bind::cuda_cmux_tree_64;
+use concrete_cuda::cuda_bind::{
+    cuda_cmux_tree_64, cuda_convert_lwe_bootstrap_key_64, cuda_extract_bits_64,
+    cuda_initialize_twiddles, cuda_synchronize_device,
+};
+use std::os::raw::c_void;
 
 #[test]
 pub fn test_cuda_cmux_tree() {
@@ -166,4 +174,220 @@ pub fn test_cuda_cmux_tree() {
     // );
     println!("Done!");
     assert_eq!(lut_number as u64, witness % (1 << (64 - delta_log)))
+}
+
+#[test]
+pub fn test_cuda_extract_bits() {
+    // Define settings for an insecure toy example
+    let polynomial_size = PolynomialSize(1024);
+    let rlwe_dimension = GlweDimension(1);
+    let lwe_dimension = LweDimension(585);
+
+    let level_bsk = DecompositionLevelCount(2);
+    let base_log_bsk = DecompositionBaseLog(7);
+
+    let level_ksk = DecompositionLevelCount(2);
+    let base_log_ksk = DecompositionBaseLog(11);
+
+    let std = LogStandardDev::from_log_standard_dev(-60.);
+
+    let number_of_bits_of_message_including_padding = 5_usize;
+    // Tests take about 2-3 seconds on a laptop with this number
+    let number_of_test_runs = 1;
+
+    const UNSAFE_SECRET: u128 = 0;
+    let mut seeder = UnixSeeder::new(UNSAFE_SECRET);
+
+    let mut secret_generator = SecretRandomGenerator::<SoftwareRandomGenerator>::new(seeder.seed());
+    let mut encryption_generator =
+        EncryptionRandomGenerator::<SoftwareRandomGenerator>::new(seeder.seed(), &mut seeder);
+
+    // allocation and generation of the key in coef domain:
+    let rlwe_sk: GlweSecretKey<_, Vec<u64>> =
+        GlweSecretKey::generate_binary(rlwe_dimension, polynomial_size, &mut secret_generator);
+    let lwe_small_sk: LweSecretKey<_, Vec<u64>> =
+        LweSecretKey::generate_binary(lwe_dimension, &mut secret_generator);
+
+    let mut coef_bsk = StandardBootstrapKey::allocate(
+        0_u64,
+        rlwe_dimension.to_glwe_size(),
+        polynomial_size,
+        level_bsk,
+        base_log_bsk,
+        lwe_dimension,
+    );
+    coef_bsk.fill_with_new_key(&lwe_small_sk, &rlwe_sk, std, &mut encryption_generator);
+
+    /*
+    // allocation for the bootstrapping key
+    let mut fourier_bsk: FourierBootstrapKey<_, u64> = FourierBootstrapKey::allocate(
+        Complex64::new(0., 0.),
+        rlwe_dimension.to_glwe_size(),
+        polynomial_size,
+        level_bsk,
+        base_log_bsk,
+        lwe_dimension,
+    );
+    */
+
+    let mut h_coef_bsk: Vec<u64> = vec![];
+    let mut h_ksk: Vec<u64> = vec![];
+    h_coef_bsk.append(&mut coef_bsk.tensor.as_slice().to_vec());
+    let gpu_index = GpuIndex(0);
+    let stream = CudaStream::new(gpu_index).unwrap();
+
+    let bsksize = (rlwe_dimension.0 + 1)
+        * (rlwe_dimension.0 + 1)
+        * polynomial_size.0
+        * level_bsk.0
+        * lwe_dimension.0;
+    let ksksize = level_ksk.0 * polynomial_size.0 * (lwe_dimension.0 + 1);
+
+    let mut h_lut_vector_indexes = vec![0 as u32; 1];
+
+    let mut d_lwe_out = stream.malloc::<u64>(
+        (lwe_dimension.0 as u32 + 1) * (number_of_bits_of_message_including_padding) as u32,
+    );
+    let mut d_lwe_in = stream.malloc::<u64>((polynomial_size.0 + 1) as u32);
+    let mut d_lwe_in_buffer = stream.malloc::<u64>((polynomial_size.0 + 1) as u32);
+    let mut d_lwe_in_shifted_buffer = stream.malloc::<u64>((polynomial_size.0 + 1) as u32);
+    let mut d_lwe_out_ks_buffer = stream.malloc::<u64>((lwe_dimension.0 + 1) as u32);
+    let mut d_lwe_out_pbs_buffer = stream.malloc::<u64>((polynomial_size.0 + 1) as u32);
+    let mut d_lut_pbs = stream.malloc::<u64>((2 * polynomial_size.0) as u32);
+    let mut d_lut_vector_indexes = stream.malloc::<u32>(1);
+    let mut d_ksk = stream.malloc::<u64>(ksksize as u32);
+    let mut d_bsk_fourier = stream.malloc::<f64>(bsksize as u32);
+    //decomp_size.0 * (output_size.0 + 1) * input_size.0
+    unsafe {
+        cuda_initialize_twiddles(polynomial_size.0 as u32, gpu_index.0 as u32);
+        cuda_convert_lwe_bootstrap_key_64(
+            d_bsk_fourier.as_mut_c_ptr(),
+            h_coef_bsk.as_ptr() as *mut c_void,
+            stream.stream_handle().0,
+            gpu_index.0 as u32,
+            lwe_dimension.0 as u32,
+            rlwe_dimension.0 as u32,
+            level_bsk.0 as u32,
+            polynomial_size.0 as u32,
+        );
+        stream.copy_to_gpu::<u32>(&mut d_lut_vector_indexes, &mut h_lut_vector_indexes);
+    }
+    //let mut buffers = FourierBuffers::new(fourier_bsk.polynomial_size(),
+    // fourier_bsk.glwe_size()); fourier_bsk.fill_with_forward_fourier(&coef_bsk, &mut buffers);
+
+    let lwe_big_sk = LweSecretKey::binary_from_container(rlwe_sk.as_tensor().as_slice());
+    let mut ksk_lwe_big_to_small = LweKeyswitchKey::allocate(
+        0_u64,
+        level_ksk,
+        base_log_ksk,
+        lwe_big_sk.key_size(),
+        lwe_small_sk.key_size(),
+    );
+    ksk_lwe_big_to_small.fill_with_keyswitch_key(
+        &lwe_big_sk,
+        &lwe_small_sk,
+        std,
+        &mut encryption_generator,
+    );
+
+    let delta_log = DeltaLog(64 - number_of_bits_of_message_including_padding);
+    // Decomposer to manage the rounding after decrypting the extracted bit
+
+    let decomposer = SignedDecomposer::new(DecompositionBaseLog(1), DecompositionLevelCount(1));
+
+    h_ksk.clone_from(&ksk_lwe_big_to_small.into_container());
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    for _ in 0..number_of_test_runs {
+        // Generate a random plaintext in [0; 2^{number_of_bits_of_message_including_padding}[
+        let val = test_tools::random_uint_between(
+            0..2u64.pow(number_of_bits_of_message_including_padding as u32),
+        );
+
+        // Encryption
+        let message = Plaintext(val << delta_log.0);
+        println!("{:?}", message);
+        let mut lwe_in = LweCiphertext::allocate(0u64, LweSize(polynomial_size.0 + 1));
+        lwe_big_sk.encrypt_lwe(&mut lwe_in, &message, std, &mut encryption_generator);
+
+        // Bit extraction
+        // Extract all the bits
+        let number_values_to_extract = ExtractedBitsCount(64 - delta_log.0);
+
+        let mut _lwe_out_list = LweList::allocate(
+            0u64,
+            lwe_dimension.to_lwe_size(),
+            CiphertextCount(number_values_to_extract.0),
+        );
+        /*
+        extract_bits(
+            delta_log,
+            &mut lwe_out_list,
+            &lwe_in,
+            &ksk_lwe_big_to_small,
+            &fourier_bsk,
+            &mut buffers,
+            number_values_to_extract,
+        );
+        */
+
+        unsafe {
+            stream.copy_to_gpu::<u64>(&mut d_ksk, &mut h_ksk);
+            //println!("rust_lwe_in: {:?}", lwe_in);
+            stream.copy_to_gpu::<u64>(&mut d_lwe_in, &mut lwe_in.tensor.as_slice());
+
+            cuda_extract_bits_64(
+                stream.stream_handle().0,
+                d_lwe_out.as_mut_c_ptr(),
+                d_lwe_in.as_c_ptr(),
+                d_lwe_in_buffer.as_mut_c_ptr(),
+                d_lwe_in_shifted_buffer.as_mut_c_ptr(),
+                d_lwe_out_ks_buffer.as_mut_c_ptr(),
+                d_lwe_out_pbs_buffer.as_mut_c_ptr(),
+                d_lut_pbs.as_mut_c_ptr(),
+                d_lut_vector_indexes.as_mut_c_ptr(),
+                d_ksk.as_c_ptr(),
+                d_bsk_fourier.as_c_ptr(),
+                number_values_to_extract.0 as u32,
+                delta_log.0 as u32,
+                polynomial_size.0 as u32,
+                lwe_dimension.0 as u32,
+                base_log_bsk.0 as u32,
+                level_bsk.0 as u32,
+                base_log_ksk.0 as u32,
+                level_ksk.0 as u32,
+            );
+
+            let mut h_result = vec![0u64; (lwe_dimension.0 + 1) * number_values_to_extract.0];
+            stream.copy_to_cpu::<u64>(&mut h_result, &d_lwe_out);
+
+            cuda_synchronize_device(gpu_index.0 as u32);
+
+            let mut i = 0;
+            for result_h in h_result.chunks(lwe_dimension.0 + 1).rev() {
+                let result_ct = LweCiphertext::from_container(result_h);
+                let mut decrypted_message = Plaintext(0_u64);
+                lwe_small_sk.decrypt_lwe(&mut decrypted_message, &result_ct);
+                // Round after decryption using decomposer
+                let decrypted_rounded = decomposer.closest_representable(decrypted_message.0);
+                // Bring back the extracted bit found in the MSB in the LSB
+                let decrypted_extract_bit = decrypted_rounded >> 63;
+                println!("extracted bit : {:?}", decrypted_extract_bit);
+                println!("{:?}", decrypted_message);
+
+                // TODO decomposition algorithm should be changed for keyswitch and amortized pbs.
+
+                assert_eq!(
+                    ((message.0 >> delta_log.0) >> i) & 1,
+                    decrypted_extract_bit,
+                    "Bit #{}, for plaintext {:#066b}",
+                    delta_log.0 + i,
+                    message.0
+                );
+
+                i += 1;
+            }
+        }
+    }
 }

--- a/concrete-cuda/cuda/include/bootstrap.h
+++ b/concrete-cuda/cuda/include/bootstrap.h
@@ -102,7 +102,55 @@ void cuda_cmux_tree_64(
         uint32_t l_gadget,
         uint32_t r,
         uint32_t max_shared_memory);
+
+
+
+void cuda_extract_bits_32(
+    void *v_stream,
+    void *list_lwe_out,
+    void *lwe_in,
+    void *lwe_in_buffer,
+    void *lwe_in_shifted_buffer,
+    void *lwe_out_ks_buffer,
+    void *lwe_out_pbs_buffer,
+    void *lut_pbs,
+    void *lut_vector_indexes,
+    void *ksk,
+    void *fourier_bsk,
+    uint32_t number_of_bits,
+    uint32_t delta_log,
+    uint32_t lwe_dimension_before,
+    uint32_t lwe_dimension_after,
+    uint32_t base_log_bsk,
+    uint32_t l_gadget_bsk,
+    uint32_t base_log_ksk,
+    uint32_t l_gadget_ksk);
+
+
+void cuda_extract_bits_64(
+        void *v_stream,
+        void *list_lwe_out,
+        void *lwe_in,
+        void *lwe_in_buffer,
+        void *lwe_in_shifted_buffer,
+        void *lwe_out_ks_buffer,
+        void *lwe_out_pbs_buffer,
+        void *lut_pbs,
+        void *lut_vector_indexes,
+        void *ksk,
+        void *fourier_bsk,
+        uint32_t number_of_bits,
+        uint32_t delta_log,
+        uint32_t lwe_dimension_before,
+        uint32_t lwe_dimension_after,
+        uint32_t base_log_bsk,
+        uint32_t l_gadget_bsk,
+        uint32_t base_log_ksk,
+        uint32_t l_gadget_ksk);
+
+
 };
+
 
 
 __device__ inline int get_start_ith_ggsw(int i, uint32_t polynomial_size,

--- a/concrete-cuda/cuda/src/bootstrap_wop.cu
+++ b/concrete-cuda/cuda/src/bootstrap_wop.cu
@@ -101,3 +101,124 @@ void cuda_cmux_tree_64(
             break;
     }
 }
+
+
+void cuda_extract_bits_32(
+    void *v_stream,
+    void *list_lwe_out,
+    void *lwe_in,
+    void *lwe_in_buffer,
+    void *lwe_in_shifted_buffer,
+    void *lwe_out_ks_buffer,
+    void *lwe_out_pbs_buffer,
+    void *lut_pbs,
+    void *lut_vector_indexes,
+    void *ksk,
+    void *fourier_bsk,
+    uint32_t number_of_bits,
+    uint32_t delta_log,
+    uint32_t lwe_dimension_before,
+    uint32_t lwe_dimension_after,
+    uint32_t base_log_bsk,
+    uint32_t l_gadget_bsk,
+    uint32_t base_log_ksk,
+    uint32_t l_gadget_ksk)
+{
+  switch (lwe_dimension_before) {
+  case 512:
+    host_extract_bits<uint32_t, Degree<512>>(
+        v_stream, (uint32_t *)list_lwe_out, (uint32_t *)lwe_in,
+        (uint32_t *)lwe_in_buffer, (uint32_t *)lwe_in_shifted_buffer,
+        (uint32_t *)lwe_out_ks_buffer, (uint32_t *)lwe_out_pbs_buffer,
+        (uint32_t *)lut_pbs, (uint32_t *)lut_vector_indexes, (uint32_t *)ksk,
+        (double2 *)fourier_bsk, number_of_bits, delta_log,
+        lwe_dimension_before, lwe_dimension_after, base_log_bsk, l_gadget_bsk,
+        base_log_ksk, l_gadget_ksk);
+    break;
+  case 1024:
+    host_extract_bits<uint32_t, Degree<1024>>(
+        v_stream, (uint32_t *)list_lwe_out, (uint32_t *)lwe_in,
+        (uint32_t *)lwe_in_buffer, (uint32_t *)lwe_in_shifted_buffer,
+        (uint32_t *)lwe_out_ks_buffer, (uint32_t *)lwe_out_pbs_buffer,
+        (uint32_t *)lut_pbs, (uint32_t *)lut_vector_indexes, (uint32_t *)ksk,
+        (double2 *)fourier_bsk, number_of_bits, delta_log,
+        lwe_dimension_before, lwe_dimension_after, base_log_bsk, l_gadget_bsk,
+        base_log_ksk, l_gadget_ksk);
+    break;
+  case 2048:
+    host_extract_bits<uint32_t, Degree<2048>>(
+        v_stream, (uint32_t *)list_lwe_out, (uint32_t *)lwe_in,
+        (uint32_t *)lwe_in_buffer, (uint32_t *)lwe_in_shifted_buffer,
+        (uint32_t *)lwe_out_ks_buffer, (uint32_t *)lwe_out_pbs_buffer,
+        (uint32_t *)lut_pbs, (uint32_t *)lut_vector_indexes, (uint32_t *)ksk,
+        (double2 *)fourier_bsk, number_of_bits, delta_log,
+        lwe_dimension_before, lwe_dimension_after, base_log_bsk, l_gadget_bsk,
+        base_log_ksk, l_gadget_ksk);
+    break;
+  default:
+    break;
+  }
+
+}
+
+
+
+void cuda_extract_bits_64(
+    void *v_stream,
+    void *list_lwe_out,
+    void *lwe_in,
+    void *lwe_in_buffer,
+    void *lwe_in_shifted_buffer,
+    void *lwe_out_ks_buffer,
+    void *lwe_out_pbs_buffer,
+    void *lut_pbs,
+    void *lut_vector_indexes,
+    void *ksk,
+    void *fourier_bsk,
+    uint32_t number_of_bits,
+    uint32_t delta_log,
+    uint32_t lwe_dimension_before,
+    uint32_t lwe_dimension_after,
+    uint32_t base_log_bsk,
+    uint32_t l_gadget_bsk,
+    uint32_t base_log_ksk,
+    uint32_t l_gadget_ksk)
+{
+  switch (lwe_dimension_before) {
+  case 512:
+    host_extract_bits<uint64_t, Degree<512>>(
+        v_stream, (uint64_t *)list_lwe_out, (uint64_t *)lwe_in,
+        (uint64_t *)lwe_in_buffer, (uint64_t *)lwe_in_shifted_buffer,
+        (uint64_t *)lwe_out_ks_buffer, (uint64_t *)lwe_out_pbs_buffer,
+        (uint64_t *)lut_pbs, (uint32_t *)lut_vector_indexes, (uint64_t *)ksk,
+        (double2 *)fourier_bsk, number_of_bits, delta_log,
+        lwe_dimension_before, lwe_dimension_after, base_log_bsk, l_gadget_bsk,
+        base_log_ksk, l_gadget_ksk);
+    break;
+  case 1024:
+    host_extract_bits<uint64_t, Degree<1024>>(
+        v_stream, (uint64_t *)list_lwe_out, (uint64_t *)lwe_in,
+        (uint64_t *)lwe_in_buffer, (uint64_t *)lwe_in_shifted_buffer,
+        (uint64_t *)lwe_out_ks_buffer, (uint64_t *)lwe_out_pbs_buffer,
+        (uint64_t *)lut_pbs, (uint32_t *)lut_vector_indexes, (uint64_t *)ksk,
+        (double2 *)fourier_bsk, number_of_bits, delta_log,
+        lwe_dimension_before, lwe_dimension_after, base_log_bsk, l_gadget_bsk,
+        base_log_ksk, l_gadget_ksk);
+    break;
+  case 2048:
+    host_extract_bits<uint64_t, Degree<2048>>(
+        v_stream, (uint64_t *)list_lwe_out, (uint64_t *)lwe_in,
+        (uint64_t *)lwe_in_buffer, (uint64_t *)lwe_in_shifted_buffer,
+        (uint64_t *)lwe_out_ks_buffer, (uint64_t *)lwe_out_pbs_buffer,
+        (uint64_t *)lut_pbs, (uint32_t *)lut_vector_indexes, (uint64_t *)ksk,
+        (double2 *)fourier_bsk, number_of_bits, delta_log,
+        lwe_dimension_before, lwe_dimension_after, base_log_bsk, l_gadget_bsk,
+        base_log_ksk, l_gadget_ksk);
+    break;
+  default:
+    break;
+  }
+
+}
+
+

--- a/concrete-cuda/cuda/src/bootstrap_wop.cuh
+++ b/concrete-cuda/cuda/src/bootstrap_wop.cuh
@@ -6,9 +6,7 @@
 #include "../include/helper_cuda.h"
 #include "bootstrap.h"
 #include "complex/operations.cuh"
-#include "crypto/gadget.cuh"
 #include "crypto/torus.cuh"
-#include "crypto/ggsw.cuh"
 #include "fft/bnsmfft.cuh"
 #include "fft/smfft.cuh"
 #include "fft/twiddles.cuh"
@@ -18,6 +16,9 @@
 #include "polynomial/polynomial_math.cuh"
 #include "utils/memory.cuh"
 #include "utils/timer.cuh"
+#include "keyswitch.cuh"
+#include "bootstrap_low_latency.cuh"
+#include "crypto/ggsw.cuh"
 
 template <typename T, class params>
 __device__ void fft(double2 *output, T *input){
@@ -399,4 +400,189 @@ void host_cmux_tree(
        checkCudaErrors(cudaFree(d_mem));
 
 }
+
+
+
+// only works for big lwe for ks+bs case
+// state_lwe_buffer is copied from big lwe input
+// shifted_lwe_buffer is scalar multiplication of lwe input
+template <typename Torus, class params>
+__global__ void copy_and_shift_lwe(Torus *dst_copy, Torus *dst_shift,
+                                        Torus *src, Torus value)
+{
+    int tid = threadIdx.x;
+#pragma unroll
+    for (int i = 0; i < params::opt; i++) {
+      dst_copy[tid] = src[tid];
+      dst_shift[tid] = src[tid] * value;
+      tid += params::degree / params::opt;
+    }
+
+    if (threadIdx.x == params::degree / params::opt - 1) {
+      dst_copy[params::degree] = src[params::degree];
+      dst_shift[params::degree] = src[params::degree] * value;
+    }
+}
+
+
+// only works for small lwe in ks+bs case
+// function copies lwe when length is not a power of two
+template <typename Torus>
+__global__ void copy_small_lwe(Torus *dst, Torus *src, uint32_t small_lwe_size,
+                               uint32_t lwe_id)
+{
+    size_t threads_per_block = blockDim.x;
+    size_t opt = small_lwe_size / threads_per_block;
+    size_t rem = small_lwe_size & (threads_per_block - 1);
+
+    Torus *cur_dst = &dst[lwe_id * small_lwe_size];
+
+    size_t tid = threadIdx.x;
+    for (int i = 0; i < opt; i++) {
+        cur_dst[tid] = src[tid];
+        tid += threads_per_block;
+    }
+
+    if (threadIdx.x < rem)
+      cur_dst[tid] = src[tid];
+
+
+}
+
+
+// only used in extract bits for one ciphertext
+// should be called with one block and one thread
+// NOTE: check if putting this functionality in copy_small_lwe or
+// fill_pbs_lut vector is faster
+template <typename Torus>
+__global__ void add_to_body(Torus *lwe, size_t lwe_dimension,
+                                    Torus value) {
+    lwe[lwe_dimension] += value;
+
+}
+
+
+
+// Fill lut(only body) for the current bit (equivalent to trivial encryption as
+// mask is 0s)
+// The LUT is filled with -alpha in each coefficient where alpha = delta*2^{bit_idx-1}
+template <typename Torus, class params>
+__global__ void fill_lut_body_for_current_bit(Torus *lut, Torus value)
+{
+    Torus *cur_poly = &lut[params::degree];
+    size_t tid = threadIdx.x;
+#pragma unroll
+    for (int i = 0; i < params::opt; i++) {
+        cur_poly[tid] = value;
+        tid += params::degree / params::opt;
+    }
+}
+
+
+
+// Add alpha where alpha = delta*2^{bit_idx-1} to end up with an encryption of 0 if the
+// extracted bit was 0 and 1 in the other case
+//
+// Remove the extracted bit from the state LWE to get a 0 at the extracted bit
+// location.
+//
+// Shift on padding bit for next iteration, that's why
+// alpha= 1ll << (ciphertext_n_bits - delta_log - bit_idx - 2) is used
+// instead of alpha= 1ll << (ciphertext_n_bits - delta_log - bit_idx - 1)
+template <typename Torus, class params>
+__global__ void add_sub_and_mul_lwe(Torus *shifted_lwe, Torus *state_lwe,
+                                    Torus *pbs_lwe_out, Torus add_value,
+                                    Torus mul_value)
+{
+  size_t tid = threadIdx.x;
+
+#pragma unroll
+  for (int i = 0; i < params::opt; i++) {
+    shifted_lwe[tid] = state_lwe[tid] -= pbs_lwe_out[tid];
+    shifted_lwe[tid] *= mul_value;
+    tid += params::degree / params::opt;
+  }
+
+  if (threadIdx.x == params::degree / params::opt - 1) {
+    shifted_lwe[params::degree] = state_lwe[params::degree] -=
+        (pbs_lwe_out[params::degree] + add_value);
+    shifted_lwe[params::degree] *= mul_value;
+  }
+}
+
+
+template <typename Torus, class params>
+__host__ void host_extract_bits(
+    void *v_stream,
+    Torus *list_lwe_out,
+    Torus *lwe_in,
+    Torus *lwe_in_buffer,
+    Torus *lwe_in_shifted_buffer,
+    Torus *lwe_out_ks_buffer,
+    Torus *lwe_out_pbs_buffer,
+    Torus *lut_pbs,
+    uint32_t *lut_vector_indexes,
+    Torus *ksk,
+    double2 *fourier_bsk,
+    uint32_t number_of_bits,
+    uint32_t delta_log,
+    uint32_t lwe_dimension_before,
+    uint32_t lwe_dimension_after,
+    uint32_t base_log_bsk,
+    uint32_t l_gadget_bsk,
+    uint32_t base_log_ksk,
+    uint32_t l_gadget_ksk)
+{
+    auto stream = static_cast<cudaStream_t *>(v_stream);
+    uint32_t ciphertext_n_bits = sizeof(Torus) * 8;
+
+    int blocks = 1;
+    int threads = params::degree / params::opt;
+
+    copy_and_shift_lwe<Torus, params><<<blocks, threads, 0, *stream>>>
+        (lwe_in_buffer, lwe_in_shifted_buffer, lwe_in,
+         1ll << (ciphertext_n_bits - delta_log - 1));
+
+    for (int bit_idx = 0; bit_idx < number_of_bits; bit_idx++) {
+        cuda_keyswitch_lwe_ciphertext_vector(v_stream, lwe_out_ks_buffer,
+                                             lwe_in_shifted_buffer, ksk,
+                                             lwe_dimension_before,
+                                             lwe_dimension_after, base_log_ksk,
+                                             l_gadget_ksk, 1);
+
+        copy_small_lwe<<<1, 256, 0, *stream>>>(list_lwe_out,
+                                               lwe_out_ks_buffer,
+                                               lwe_dimension_after + 1,
+                                               number_of_bits - bit_idx - 1);
+
+        if (bit_idx == number_of_bits - 1) {
+          break;
+        }
+
+        add_to_body<Torus><<<1, 1, 0, *stream>>>(lwe_out_ks_buffer,
+                                          lwe_dimension_after,
+                                          1ll << (ciphertext_n_bits - 2));
+
+
+        fill_lut_body_for_current_bit<Torus, params>
+            <<<blocks, threads, 0,*stream>>> (lut_pbs, 0ll - 1ll << (
+                                                           delta_log - 1 +
+                                                           bit_idx));
+
+        host_bootstrap_low_latency<Torus, params>(v_stream, lwe_out_pbs_buffer,
+                                   lut_pbs, lut_vector_indexes,
+                                   lwe_out_ks_buffer, fourier_bsk,
+                                   lwe_dimension_after, lwe_dimension_before,
+                                   base_log_bsk, l_gadget_bsk, 1, 1);
+
+        add_sub_and_mul_lwe<Torus, params><<<1, threads, 0, *stream>>>(
+            lwe_in_shifted_buffer, lwe_in_buffer, lwe_out_pbs_buffer,
+            1ll << (delta_log - 1 + bit_idx),
+            1ll << (ciphertext_n_bits - delta_log - bit_idx - 2) );
+
+    }
+
+}
+
+
 #endif //WO_PBS_H

--- a/concrete-cuda/cuda/src/crypto/gadget.cuh
+++ b/concrete-cuda/cuda/src/crypto/gadget.cuh
@@ -4,6 +4,7 @@
 #include "polynomial/polynomial.cuh"
 #include <cstdint>
 
+#pragma once
 template <typename T, class params> class GadgetMatrix {
 private:
   uint32_t l_gadget;

--- a/concrete-cuda/cuda/src/keyswitch.cuh
+++ b/concrete-cuda/cuda/src/keyswitch.cuh
@@ -17,6 +17,18 @@ __device__ Torus *get_ith_block(Torus *ksk, int i, int level,
     return ptr;
 }
 
+template <typename Torus>
+__device__ Torus decompose_one(Torus &state, Torus  mod_b_mask,
+                               int base_log) {
+    Torus res = state & mod_b_mask;
+    state >>= base_log;
+    Torus carry = ((res - 1ll) | state) & res;
+    carry >>= base_log - 1;
+    state += carry;
+    res -= carry << base_log;
+    return res;
+}
+
 /*
  * keyswitch kernel
  * Each thread handles a piece of the following equation:
@@ -76,9 +88,15 @@ __global__ void keyswitch(Torus *lwe_out, Torus *lwe_in,
     Torus a_i = round_to_closest_multiple(block_lwe_in[i], base_log,
                                           l_gadget);
 
+    Torus state = a_i >> (sizeof(Torus) * 8 - base_log * l_gadget);
+    Torus mod_b_mask = (1ll << base_log) - 1ll;
+
     for (int j = 0; j < l_gadget; j++) {
-      auto ksk_block = get_ith_block(ksk, i, j, lwe_dimension_after, l_gadget);
-      Torus decomposed = gadget.decompose_one_level_single(a_i, (uint32_t)j);
+      auto ksk_block = get_ith_block(ksk, i, l_gadget - j - 1,
+                                     lwe_dimension_after,
+                                     l_gadget);
+      Torus decomposed = decompose_one<Torus>(state, mod_b_mask,
+                                                base_log);
       for (int k = 0; k < lwe_part_per_thd; k++) {
         int idx = tid + k * blockDim.x;
         local_lwe_out[idx] -= (Torus)ksk_block[idx] * decomposed;

--- a/concrete-cuda/src/cuda_bind.rs
+++ b/concrete-cuda/src/cuda_bind.rs
@@ -176,4 +176,48 @@ extern "C" {
         r: u32,
         max_shared_memory: u32,
     );
+
+    pub fn cuda_extract_bits_32(
+        v_stream: *const c_void,
+        list_lwe_out: *mut c_void,
+        lwe_in: *const c_void,
+        lwe_in_buffer: *mut c_void,
+        lwe_in_shifted_buffer: *mut c_void,
+        lwe_out_ks_buffer: *mut c_void,
+        lwe_out_pbs_buffer: *mut c_void,
+        lut_pbs: *mut c_void,
+        lut_vector_indexes: *const c_void,
+        ksk: *const c_void,
+        fourier_bsk: *const c_void,
+        number_of_bits: u32,
+        delta_log: u32,
+        lwe_dimension_before: u32,
+        lwe_dimension_after: u32,
+        base_log_bsk: u32,
+        l_gadget_bsk: u32,
+        base_log_ksk: u32,
+        l_gadget_ksk: u32,
+    );
+
+    pub fn cuda_extract_bits_64(
+        v_stream: *const c_void,
+        list_lwe_out: *mut c_void,
+        lwe_in: *const c_void,
+        lwe_in_buffer: *mut c_void,
+        lwe_in_shifted_buffer: *mut c_void,
+        lwe_out_ks_buffer: *mut c_void,
+        lwe_out_pbs_buffer: *mut c_void,
+        lut_pbs: *mut c_void,
+        lut_vector_indexes: *const c_void,
+        ksk: *const c_void,
+        fourier_bsk: *const c_void,
+        number_of_bits: u32,
+        delta_log: u32,
+        lwe_dimension_before: u32,
+        lwe_dimension_after: u32,
+        base_log_bsk: u32,
+        l_gadget_bsk: u32,
+        base_log_ksk: u32,
+        l_gadget_ksk: u32,
+    );
 }


### PR DESCRIPTION
### Resolves: `https://github.com/zama-ai/concrete-core-internal/issues/276`

### Description
  implementation of extract bits functionality in concrete-cuda

  update of decomposition algorithm for cuda keyswitch 


### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<https://github.com/zama-ai/concrete-core-internal/issues/276>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
