### PR TITLE
feat(core): add circuit bootstrap & vertical packing to fft backend

### DIFF
--- a/concrete-core-bench/src/fft.rs
+++ b/concrete-core-bench/src/fft.rs
@@ -40,5 +40,8 @@ bench! {
     ((BinaryKeyDistribution), GlweCiphertextsGgswCiphertextFusingCmuxFixture, (GlweCiphertext,
         GlweCiphertext, FftFourierGgswCiphertext)),
     ((BinaryKeyDistribution, BinaryKeyDistribution), LweCiphertextDiscardingBitExtractFixture,
-        (FftFourierLweBootstrapKey, LweKeyswitchKey, LweCiphertext, LweCiphertextVector))
+        (FftFourierLweBootstrapKey, LweKeyswitchKey, LweCiphertext, LweCiphertextVector)),
+    ((BinaryKeyDistribution, BinaryKeyDistribution), LweCiphertextVectorDiscardingCircuitBootstrapBooleanVerticalPackingFixture,
+        (FftFourierLweBootstrapKey, LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys,
+        PlaintextVector, Cleartext, LweCiphertextVectorView, LweCiphertextVectorMutView))
 }

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_circuit_bootstrap_boolean_vertical_packing.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_circuit_bootstrap_boolean_vertical_packing.rs
@@ -86,9 +86,9 @@ const fn get_parameters_for_raw_precision<Precision: IntegerPrecision>(
     if Precision::Raw::BITS == 32 {
         [
             LweCiphertextVectorDiscardingCircuitBootstrapBooleanVerticalPackingParameters {
-                // Offline evaluation 2.0f64.powf(-90.) is
-                // 0.0000000000000000000000000008077935669463161f64
-                noise: Variance(0.0000000000000000000000000008077935669463161f64),
+                // Offline evaluation 2.0f64.powf(-120.) is
+                // 0.000000000000000000000000000000000000752316384526264
+                noise: Variance(0.000000000000000000000000000000000000752316384526264f64),
                 lwe_dimension: LweDimension(10),
                 glwe_dimension: GlweDimension(1),
                 polynomial_size: PolynomialSize(512),
@@ -106,9 +106,9 @@ const fn get_parameters_for_raw_precision<Precision: IntegerPrecision>(
     } else if Precision::Raw::BITS == 64 {
         [
             LweCiphertextVectorDiscardingCircuitBootstrapBooleanVerticalPackingParameters {
-                // Offline evaluation 2.0f64.powf(-80.) is
-                // 0.0000000000000000000000008271806125530277f64
-                noise: Variance(0.0000000000000000000000008271806125530277f64),
+                // Offline evaluation 2.0f64.powf(-120.) is
+                // 0.000000000000000000000000000000000000752316384526264
+                noise: Variance(0.000000000000000000000000000000000000752316384526264f64),
                 lwe_dimension: LweDimension(10),
                 glwe_dimension: GlweDimension(1),
                 polynomial_size: PolynomialSize(512),

--- a/concrete-core-test/src/fft.rs
+++ b/concrete-core-test/src/fft.rs
@@ -39,5 +39,8 @@ test! {
     ((BinaryKeyDistribution), GlweCiphertextsGgswCiphertextFusingCmuxFixture, (GlweCiphertext,
         GlweCiphertext, FftFourierGgswCiphertext)),
     ((BinaryKeyDistribution, BinaryKeyDistribution), LweCiphertextDiscardingBitExtractFixture,
-        (FftFourierLweBootstrapKey, LweKeyswitchKey, LweCiphertext, LweCiphertextVector))
+        (FftFourierLweBootstrapKey, LweKeyswitchKey, LweCiphertext, LweCiphertextVector)),
+    ((BinaryKeyDistribution, BinaryKeyDistribution), LweCiphertextVectorDiscardingCircuitBootstrapBooleanVerticalPackingFixture,
+        (FftFourierLweBootstrapKey, LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys,
+        PlaintextVector, Cleartext, LweCiphertextVectorView, LweCiphertextVectorMutView))
 }

--- a/concrete-core/src/backends/fft/implementation/engines/fft_engine/lwe_ciphertext_discarding_circuit_bootstrap_boolean.rs
+++ b/concrete-core/src/backends/fft/implementation/engines/fft_engine/lwe_ciphertext_discarding_circuit_bootstrap_boolean.rs
@@ -1,0 +1,324 @@
+use crate::backends::default::entities::{
+    GgswCiphertext32, GgswCiphertext64, LweCiphertext32, LweCiphertext64,
+    LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys32,
+    LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys64,
+};
+use crate::backends::fft::engines::{FftEngine, FftError};
+use crate::backends::fft::entities::{FftFourierLweBootstrapKey32, FftFourierLweBootstrapKey64};
+use crate::backends::fft::private::crypto::wop_pbs::{
+    circuit_bootstrap_boolean, circuit_bootstrap_boolean_scratch,
+};
+use crate::backends::fft::private::math::fft::Fft;
+use crate::prelude::LweCiphertextEntity;
+use crate::specification::engines::{
+    LweCiphertextDiscardingCircuitBootstrapBooleanEngine,
+    LweCiphertextDiscardingCircuitBootstrapBooleanError,
+};
+use crate::specification::entities::LweBootstrapKeyEntity;
+use crate::specification::parameters::DeltaLog;
+
+impl From<FftError> for LweCiphertextDiscardingCircuitBootstrapBooleanError<FftError> {
+    fn from(err: FftError) -> Self {
+        Self::Engine(err)
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextDiscardingCircuitBootstrapBooleanEngine`] for [`FftEngine`]
+/// that operates on 32 bits integers.
+impl
+    LweCiphertextDiscardingCircuitBootstrapBooleanEngine<
+        LweCiphertext32,
+        GgswCiphertext32,
+        FftFourierLweBootstrapKey32,
+        LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys32,
+    > for FftEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // Define settings for an insecure toy example
+    /// let polynomial_size = PolynomialSize(512);
+    /// let glwe_dimension = GlweDimension(2);
+    /// let small_lwe_dimension = LweDimension(10);
+    ///
+    /// // The following sets of decomposition parameters are independant and can be adapted for
+    /// // your use case, having identical parameters for some of them here is a coincidence
+    /// let level_bsk = DecompositionLevelCount(2);
+    /// let base_log_bsk = DecompositionBaseLog(15);
+    ///
+    /// let level_pfpksk = DecompositionLevelCount(2);
+    /// let base_log_pfpksk = DecompositionBaseLog(15);
+    ///
+    /// let level_count_cbs = DecompositionLevelCount(1);
+    /// let base_log_cbs = DecompositionBaseLog(10);
+    ///
+    /// let std = LogStandardDev::from_log_standard_dev(-60.);
+    /// let noise = Variance(std.get_variance());
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut default_parallel_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    ///
+    /// let glwe_sk: GlweSecretKey32 =
+    ///     default_engine.generate_new_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let small_lwe_sk: LweSecretKey32 =
+    ///     default_engine.generate_new_lwe_secret_key(small_lwe_dimension)?;
+    /// let big_lwe_sk: LweSecretKey32 =
+    ///     default_engine.transform_glwe_secret_key_to_lwe_secret_key(glwe_sk.clone())?;
+    /// let std_bsk: LweBootstrapKey32 = default_parallel_engine.generate_new_lwe_bootstrap_key(
+    ///     &small_lwe_sk,
+    ///     &glwe_sk,
+    ///     base_log_bsk,
+    ///     level_bsk,
+    ///     noise,
+    /// )?;
+    /// let fbsk: FftFourierLweBootstrapKey32 = fft_engine.convert_lwe_bootstrap_key(&std_bsk)?;
+    /// let cbs_pfpksk: LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys32 = default_engine
+    ///     .generate_new_lwe_circuit_bootstrap_private_functional_packing_keyswitch_keys(
+    ///         &big_lwe_sk,
+    ///         &glwe_sk,
+    ///         base_log_pfpksk,
+    ///         level_pfpksk,
+    ///         noise,
+    ///     )?;
+    ///
+    /// // delta_log indicates where the information bit is stored in the input LWE ciphertext, here
+    /// // we put it in the most significant bit, which corresponds to 2 ^ 31
+    /// let delta_log = DeltaLog(31);
+    ///
+    /// let value = 1u32;
+    /// // Encryption of 'value' in an LWE ciphertext using delta_log for the encoding
+    /// let plaintext: Plaintext32 = default_engine.create_plaintext_from(&(value << delta_log.0))?;
+    /// let lwe_in: LweCiphertext32 =
+    ///     default_engine.encrypt_lwe_ciphertext(&small_lwe_sk, &plaintext, noise)?;
+    ///
+    /// // Create an empty GGSW ciphertext with a trivial encryption of 0
+    /// let zero_plaintext: Plaintext32 = default_engine.create_plaintext_from(&0u32)?;
+    /// let mut output_ggsw: GgswCiphertext32 = default_engine
+    ///     .trivially_encrypt_scalar_ggsw_ciphertext(
+    ///         polynomial_size,
+    ///         glwe_dimension.to_glwe_size(),
+    ///         level_count_cbs,
+    ///         base_log_cbs,
+    ///         &zero_plaintext,
+    ///     )?;
+    ///
+    /// fft_engine.discard_circuit_bootstrap_boolean_lwe_ciphertext(
+    ///     &mut output_ggsw,
+    ///     &lwe_in,
+    ///     delta_log,
+    ///     &fbsk,
+    ///     &cbs_pfpksk,
+    /// )?;
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_circuit_bootstrap_boolean_lwe_ciphertext(
+        &mut self,
+        output: &mut GgswCiphertext32,
+        input: &LweCiphertext32,
+        delta_log: DeltaLog,
+        bsk: &FftFourierLweBootstrapKey32,
+        cbs_pfpksk: &LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys32,
+    ) -> Result<(), LweCiphertextDiscardingCircuitBootstrapBooleanError<Self::EngineError>> {
+        FftError::perform_fft_checks(bsk.polynomial_size())?;
+        LweCiphertextDiscardingCircuitBootstrapBooleanError::perform_generic_checks(
+            input, output, bsk, cbs_pfpksk,
+        )?;
+        unsafe {
+            self.discard_circuit_bootstrap_boolean_lwe_ciphertext_unchecked(
+                output, input, delta_log, bsk, cbs_pfpksk,
+            )
+        };
+        Ok(())
+    }
+
+    unsafe fn discard_circuit_bootstrap_boolean_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut GgswCiphertext32,
+        input: &LweCiphertext32,
+        delta_log: DeltaLog,
+        bsk: &FftFourierLweBootstrapKey32,
+        cbs_pfpksk: &LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys32,
+    ) {
+        let fft = Fft::new(bsk.polynomial_size());
+        let fft = fft.as_view();
+        self.resize(
+            circuit_bootstrap_boolean_scratch::<u32>(
+                input.lwe_dimension().to_lwe_size(),
+                bsk.output_lwe_dimension().to_lwe_size(),
+                bsk.polynomial_size(),
+                bsk.glwe_dimension().to_glwe_size(),
+                fft,
+            )
+            .unwrap()
+            .unaligned_bytes_required(),
+        );
+        circuit_bootstrap_boolean(
+            bsk.0.as_view(),
+            input.0.as_view(),
+            output.0.as_mut_view(),
+            delta_log,
+            cbs_pfpksk.0.as_view(),
+            fft,
+            self.stack(),
+        );
+    }
+}
+
+/// # Description:
+/// Implementation of [`LweCiphertextDiscardingCircuitBootstrapBooleanEngine`] for [`FftEngine`]
+/// that operates on 64 bits integers.
+impl
+    LweCiphertextDiscardingCircuitBootstrapBooleanEngine<
+        LweCiphertext64,
+        GgswCiphertext64,
+        FftFourierLweBootstrapKey64,
+        LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys64,
+    > for FftEngine
+{
+    /// # Example
+    /// ```
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // Define settings for an insecure toy example
+    /// let polynomial_size = PolynomialSize(512);
+    /// let glwe_dimension = GlweDimension(2);
+    /// let small_lwe_dimension = LweDimension(10);
+    ///
+    /// // The following sets of decomposition parameters are independant and can be adapted for
+    /// // your use case, having identical parameters for some of them here is a coincidence
+    /// let level_bsk = DecompositionLevelCount(2);
+    /// let base_log_bsk = DecompositionBaseLog(15);
+    ///
+    /// let level_pfpksk = DecompositionLevelCount(2);
+    /// let base_log_pfpksk = DecompositionBaseLog(15);
+    ///
+    /// let level_count_cbs = DecompositionLevelCount(1);
+    /// let base_log_cbs = DecompositionBaseLog(10);
+    ///
+    /// let std = LogStandardDev::from_log_standard_dev(-60.);
+    /// let noise = Variance(std.get_variance());
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut default_parallel_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    ///
+    /// let glwe_sk: GlweSecretKey64 =
+    ///     default_engine.generate_new_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let small_lwe_sk: LweSecretKey64 =
+    ///     default_engine.generate_new_lwe_secret_key(small_lwe_dimension)?;
+    /// let big_lwe_sk: LweSecretKey64 =
+    ///     default_engine.transform_glwe_secret_key_to_lwe_secret_key(glwe_sk.clone())?;
+    /// let std_bsk: LweBootstrapKey64 = default_parallel_engine.generate_new_lwe_bootstrap_key(
+    ///     &small_lwe_sk,
+    ///     &glwe_sk,
+    ///     base_log_bsk,
+    ///     level_bsk,
+    ///     noise,
+    /// )?;
+    /// let fbsk: FftFourierLweBootstrapKey64 = fft_engine.convert_lwe_bootstrap_key(&std_bsk)?;
+    /// let cbs_pfpksk: LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys64 = default_engine
+    ///     .generate_new_lwe_circuit_bootstrap_private_functional_packing_keyswitch_keys(
+    ///         &big_lwe_sk,
+    ///         &glwe_sk,
+    ///         base_log_pfpksk,
+    ///         level_pfpksk,
+    ///         noise,
+    ///     )?;
+    ///
+    /// // delta_log indicates where the information bit is stored in the input LWE ciphertext, here
+    /// // we put it in the most significant bit, which corresponds to 2 ^ 63
+    /// let delta_log = DeltaLog(63);
+    ///
+    /// let value = 1u64;
+    /// // Encryption of 'value' in an LWE ciphertext using delta_log for the encoding
+    /// let plaintext: Plaintext64 = default_engine.create_plaintext_from(&(value << delta_log.0))?;
+    /// let lwe_in: LweCiphertext64 =
+    ///     default_engine.encrypt_lwe_ciphertext(&small_lwe_sk, &plaintext, noise)?;
+    ///
+    /// // Create an empty GGSW ciphertext with a trivial encryption of 0
+    /// let zero_plaintext: Plaintext64 = default_engine.create_plaintext_from(&0u64)?;
+    /// let mut output_ggsw: GgswCiphertext64 = default_engine
+    ///     .trivially_encrypt_scalar_ggsw_ciphertext(
+    ///         polynomial_size,
+    ///         glwe_dimension.to_glwe_size(),
+    ///         level_count_cbs,
+    ///         base_log_cbs,
+    ///         &zero_plaintext,
+    ///     )?;
+    ///
+    /// fft_engine.discard_circuit_bootstrap_boolean_lwe_ciphertext(
+    ///     &mut output_ggsw,
+    ///     &lwe_in,
+    ///     delta_log,
+    ///     &fbsk,
+    ///     &cbs_pfpksk,
+    /// )?;
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_circuit_bootstrap_boolean_lwe_ciphertext(
+        &mut self,
+        output: &mut GgswCiphertext64,
+        input: &LweCiphertext64,
+        delta_log: DeltaLog,
+        bsk: &FftFourierLweBootstrapKey64,
+        cbs_pfpksk: &LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys64,
+    ) -> Result<(), LweCiphertextDiscardingCircuitBootstrapBooleanError<Self::EngineError>> {
+        FftError::perform_fft_checks(bsk.polynomial_size())?;
+        LweCiphertextDiscardingCircuitBootstrapBooleanError::perform_generic_checks(
+            input, output, bsk, cbs_pfpksk,
+        )?;
+        unsafe {
+            self.discard_circuit_bootstrap_boolean_lwe_ciphertext_unchecked(
+                output, input, delta_log, bsk, cbs_pfpksk,
+            )
+        };
+        Ok(())
+    }
+
+    unsafe fn discard_circuit_bootstrap_boolean_lwe_ciphertext_unchecked(
+        &mut self,
+        output: &mut GgswCiphertext64,
+        input: &LweCiphertext64,
+        delta_log: DeltaLog,
+        bsk: &FftFourierLweBootstrapKey64,
+        cbs_pfpksk: &LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys64,
+    ) {
+        let fft = Fft::new(bsk.polynomial_size());
+        let fft = fft.as_view();
+        self.resize(
+            circuit_bootstrap_boolean_scratch::<u64>(
+                input.lwe_dimension().to_lwe_size(),
+                bsk.output_lwe_dimension().to_lwe_size(),
+                bsk.polynomial_size(),
+                bsk.glwe_dimension().to_glwe_size(),
+                fft,
+            )
+            .unwrap()
+            .unaligned_bytes_required(),
+        );
+        circuit_bootstrap_boolean(
+            bsk.0.as_view(),
+            input.0.as_view(),
+            output.0.as_mut_view(),
+            delta_log,
+            cbs_pfpksk.0.as_view(),
+            fft,
+            self.stack(),
+        );
+    }
+}

--- a/concrete-core/src/backends/fft/implementation/engines/fft_engine/lwe_ciphertext_vector_discarding_circuit_bootstrap_boolean_vertical_packing.rs
+++ b/concrete-core/src/backends/fft/implementation/engines/fft_engine/lwe_ciphertext_vector_discarding_circuit_bootstrap_boolean_vertical_packing.rs
@@ -1,0 +1,527 @@
+use crate::backends::default::entities::{
+    LweCiphertextVectorMutView32, LweCiphertextVectorMutView64, LweCiphertextVectorView32,
+    LweCiphertextVectorView64, LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys32,
+    LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys64, PlaintextVector32,
+    PlaintextVector64,
+};
+use crate::backends::fft::engines::{FftEngine, FftError};
+use crate::backends::fft::entities::{FftFourierLweBootstrapKey32, FftFourierLweBootstrapKey64};
+use crate::backends::fft::private::crypto::wop_pbs::{
+    circuit_bootstrap_boolean_vertical_packing, circuit_bootstrap_boolean_vertical_packing_scratch,
+};
+use crate::backends::fft::private::math::fft::Fft;
+use crate::commons::math::polynomial::PolynomialList;
+use crate::commons::math::tensor::{AsRefSlice, AsRefTensor};
+use crate::prelude::{
+    CiphertextCount, LweCiphertextVectorEntity,
+    LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeysEntity, PlaintextVectorEntity,
+    PolynomialCount,
+};
+use crate::specification::engines::{
+    LweCiphertextVectorDiscardingCircuitBootstrapBooleanVerticalPackingEngine,
+    LweCiphertextVectorDiscardingCircuitBootstrapBooleanVerticalPackingError,
+};
+use crate::specification::entities::LweBootstrapKeyEntity;
+use crate::specification::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+
+impl From<FftError>
+    for LweCiphertextVectorDiscardingCircuitBootstrapBooleanVerticalPackingError<FftError>
+{
+    fn from(err: FftError) -> Self {
+        Self::Engine(err)
+    }
+}
+
+impl
+    LweCiphertextVectorDiscardingCircuitBootstrapBooleanVerticalPackingEngine<
+        LweCiphertextVectorView32<'_>,
+        LweCiphertextVectorMutView32<'_>,
+        FftFourierLweBootstrapKey32,
+        PlaintextVector32,
+        LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys32,
+    > for FftEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let polynomial_size = PolynomialSize(1024);
+    /// let glwe_dimension = GlweDimension(1);
+    /// let lwe_dimension = LweDimension(481);
+    ///
+    /// let var_small = Variance::from_variance(2f64.powf(-70.0));
+    /// let var_big = Variance::from_variance(2f64.powf(-60.0));
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut default_parallel_engine =
+    ///     DefaultParallelEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    ///
+    /// let glwe_sk: GlweSecretKey32 =
+    ///     default_engine.generate_new_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let lwe_small_sk: LweSecretKey32 = default_engine.generate_new_lwe_secret_key(lwe_dimension)?;
+    /// let lwe_big_sk: LweSecretKey32 =
+    ///     default_engine.transform_glwe_secret_key_to_lwe_secret_key(glwe_sk.clone())?;
+    ///
+    /// let bsk_level_count = DecompositionLevelCount(7);
+    /// let bsk_base_log = DecompositionBaseLog(4);
+    ///
+    /// let std_bsk: LweBootstrapKey32 = default_parallel_engine.generate_new_lwe_bootstrap_key(
+    ///     &lwe_small_sk,
+    ///     &glwe_sk,
+    ///     bsk_base_log,
+    ///     bsk_level_count,
+    ///     var_small,
+    /// )?;
+    ///
+    /// let fourier_bsk: FftFourierLweBootstrapKey32 =
+    ///     fft_engine.convert_lwe_bootstrap_key(&std_bsk)?;
+    ///
+    /// let ksk_level_count = DecompositionLevelCount(9);
+    /// let ksk_base_log = DecompositionBaseLog(1);
+    ///
+    /// let ksk_big_to_small: LweKeyswitchKey32 = default_engine.generate_new_lwe_keyswitch_key(
+    ///     &lwe_big_sk,
+    ///     &lwe_small_sk,
+    ///     ksk_level_count,
+    ///     ksk_base_log,
+    ///     var_big,
+    /// )?;
+    ///
+    /// let pfpksk_level_count = DecompositionLevelCount(7);
+    /// let pfpksk_base_log = DecompositionBaseLog(4);
+    ///
+    /// let cbs_pfpksk: LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys32 = default_engine
+    ///     .generate_new_lwe_circuit_bootstrap_private_functional_packing_keyswitch_keys(
+    ///         &lwe_big_sk,
+    ///         &glwe_sk,
+    ///         pfpksk_base_log,
+    ///         pfpksk_level_count,
+    ///         var_small,
+    ///     )?;
+    ///
+    /// // We will have a message with 10 bits of information
+    /// let message_bits = 10;
+    /// let bits_to_extract = ExtractedBitsCount(message_bits);
+    ///
+    /// // The value we encrypt is 42, we will extract the bits of this value and apply the
+    /// // circuit bootstrapping followed by the vertical packing on the extracted bits.
+    /// let cleartext = 42;
+    /// let delta_log_msg = DeltaLog(32 - message_bits);
+    ///
+    /// let encoded_message = default_engine.create_plaintext_from(&(cleartext << delta_log_msg.0))?;
+    /// let lwe_in = default_engine.encrypt_lwe_ciphertext(&lwe_big_sk, &encoded_message, var_big)?;
+    ///
+    /// // Bit extraction output, use the zero_encrypt engine to allocate a ciphertext vector
+    /// let mut bit_extraction_output = default_engine.zero_encrypt_lwe_ciphertext_vector(
+    ///     &lwe_small_sk,
+    ///     var_small,
+    ///     LweCiphertextCount(bits_to_extract.0),
+    /// )?;
+    ///
+    /// fft_engine.discard_extract_bits_lwe_ciphertext(
+    ///     &mut bit_extraction_output,
+    ///     &lwe_in,
+    ///     &fourier_bsk,
+    ///     &ksk_big_to_small,
+    ///     bits_to_extract,
+    ///     delta_log_msg,
+    /// )?;
+    ///
+    /// // Though the delta log here is the same as the message delta log, in the general case they
+    /// // are different, so we create two DeltaLog parameters
+    /// let delta_log_lut = DeltaLog(32 - message_bits);
+    ///
+    /// // Create a look-up table we want to apply during vertical packing, here just the identity
+    /// // with the proper encoding.
+    /// // Note that this particular table will not trigger the cmux tree from the vertical packing,
+    /// // adapt the LUT generation to your usage.
+    /// // Here we apply a single look-up table as we output a single ciphertext.
+    /// let number_of_luts_and_output_vp_ciphertexts = 1;
+    /// let lut_size = 1 << bits_to_extract.0;
+    /// let mut lut: Vec<u32> = Vec::with_capacity(lut_size);
+    ///
+    /// for i in 0..lut_size {
+    ///     lut.push((i as u32 % (1 << message_bits)) << delta_log_lut.0);
+    /// }
+    ///
+    /// let lut_as_plaintext_vector = default_engine.create_plaintext_vector_from(lut.as_slice())?;
+    ///
+    /// // We run on views, so we need a container for the output
+    /// let mut output_cbs_vp_ct_container = vec![
+    ///     0u32;
+    ///     lwe_big_sk.lwe_dimension().to_lwe_size().0
+    ///         * number_of_luts_and_output_vp_ciphertexts
+    /// ];
+    ///
+    /// let mut output_cbs_vp_ct_mut_view: LweCiphertextVectorMutView32 = default_engine
+    ///     .create_lwe_ciphertext_vector_from(
+    ///         output_cbs_vp_ct_container.as_mut_slice(),
+    ///         lwe_big_sk.lwe_dimension().to_lwe_size(),
+    ///     )?;
+    /// // And we need to get a view on the bits extracted earlier that serve as inputs to the
+    /// // circuit bootstrap + vertical packing
+    /// let extracted_bits_lwe_size = bit_extraction_output.lwe_dimension().to_lwe_size();
+    /// let extracted_bits_container =
+    ///     default_engine.consume_retrieve_lwe_ciphertext_vector(bit_extraction_output)?;
+    /// let cbs_vp_input_vector_view: LweCiphertextVectorView32 = default_engine
+    ///     .create_lwe_ciphertext_vector_from(
+    ///         extracted_bits_container.as_slice(),
+    ///         extracted_bits_lwe_size,
+    ///     )?;
+    ///
+    /// let cbs_level_count = DecompositionLevelCount(4);
+    /// let cbs_base_log = DecompositionBaseLog(6);
+    ///
+    /// fft_engine.discard_circuit_bootstrap_boolean_vertical_packing_lwe_ciphertext_vector(
+    ///     &mut output_cbs_vp_ct_mut_view,
+    ///     &cbs_vp_input_vector_view,
+    ///     &fourier_bsk,
+    ///     &lut_as_plaintext_vector,
+    ///     cbs_level_count,
+    ///     cbs_base_log,
+    ///     &cbs_pfpksk,
+    /// )?;
+    ///
+    /// assert_eq!(output_cbs_vp_ct_mut_view.lwe_ciphertext_count().0, 1);
+    /// assert_eq!(
+    ///     output_cbs_vp_ct_mut_view.lwe_dimension(),
+    ///     LweDimension(glwe_dimension.0 * polynomial_size.0)
+    /// );
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_circuit_bootstrap_boolean_vertical_packing_lwe_ciphertext_vector(
+        &mut self,
+        output: &mut LweCiphertextVectorMutView32,
+        input: &LweCiphertextVectorView32,
+        bsk: &FftFourierLweBootstrapKey32,
+        luts: &PlaintextVector32,
+        cbs_level_count: DecompositionLevelCount,
+        cbs_base_log: DecompositionBaseLog,
+        cbs_pfpksk: &LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys32,
+    ) -> Result<
+        (),
+        LweCiphertextVectorDiscardingCircuitBootstrapBooleanVerticalPackingError<Self::EngineError>,
+    > {
+        FftError::perform_fft_checks(bsk.polynomial_size())?;
+        LweCiphertextVectorDiscardingCircuitBootstrapBooleanVerticalPackingError::
+            perform_generic_checks(
+                input,
+                output,
+                bsk,
+                luts,
+                cbs_level_count,
+                cbs_base_log,
+                cbs_pfpksk,
+                32,
+            )?;
+        unsafe {
+            self.discard_circuit_bootstrap_boolean_vertical_packing_lwe_ciphertext_vector_unchecked(
+            output,
+            input,
+            bsk,
+            luts,
+            cbs_level_count,
+            cbs_base_log,
+            cbs_pfpksk,
+        );
+        }
+        Ok(())
+    }
+
+    unsafe fn discard_circuit_bootstrap_boolean_vertical_packing_lwe_ciphertext_vector_unchecked(
+        &mut self,
+        output: &mut LweCiphertextVectorMutView32,
+        input: &LweCiphertextVectorView32,
+        bsk: &FftFourierLweBootstrapKey32,
+        luts: &PlaintextVector32,
+        cbs_level_count: DecompositionLevelCount,
+        cbs_base_log: DecompositionBaseLog,
+        cbs_pfpksk: &LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys32,
+    ) {
+        let lut_as_polynomial_list =
+            PolynomialList::from_container(luts.0.as_tensor().as_slice(), bsk.polynomial_size());
+
+        let fft = Fft::new(bsk.polynomial_size());
+        let fft = fft.as_view();
+        self.resize(
+            circuit_bootstrap_boolean_vertical_packing_scratch::<u32>(
+                CiphertextCount(input.lwe_ciphertext_count().0),
+                CiphertextCount(output.lwe_ciphertext_count().0),
+                input.lwe_dimension().to_lwe_size(),
+                PolynomialCount(luts.plaintext_count().0),
+                bsk.output_lwe_dimension().to_lwe_size(),
+                cbs_pfpksk.output_polynomial_size(),
+                bsk.glwe_dimension().to_glwe_size(),
+                cbs_level_count,
+                fft,
+            )
+            .unwrap()
+            .unaligned_bytes_required(),
+        );
+        circuit_bootstrap_boolean_vertical_packing(
+            lut_as_polynomial_list.as_view(),
+            bsk.0.as_view(),
+            output.0.as_mut_view(),
+            input.0.as_view(),
+            cbs_pfpksk.0.as_view(),
+            cbs_level_count,
+            cbs_base_log,
+            fft,
+            self.stack(),
+        )
+    }
+}
+
+impl
+    LweCiphertextVectorDiscardingCircuitBootstrapBooleanVerticalPackingEngine<
+        LweCiphertextVectorView64<'_>,
+        LweCiphertextVectorMutView64<'_>,
+        FftFourierLweBootstrapKey64,
+        PlaintextVector64,
+        LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys64,
+    > for FftEngine
+{
+    /// # Example:
+    /// ```
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let polynomial_size = PolynomialSize(1024);
+    /// let glwe_dimension = GlweDimension(1);
+    /// let lwe_dimension = LweDimension(481);
+    ///
+    /// let var_small = Variance::from_variance(2f64.powf(-80.0));
+    /// let var_big = Variance::from_variance(2f64.powf(-70.0));
+    ///
+    /// const UNSAFE_SECRET: u128 = 0;
+    /// let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut default_parallel_engine =
+    ///     DefaultParallelEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+    /// let mut fft_engine = FftEngine::new(())?;
+    ///
+    /// let glwe_sk: GlweSecretKey64 =
+    ///     default_engine.generate_new_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let lwe_small_sk: LweSecretKey64 = default_engine.generate_new_lwe_secret_key(lwe_dimension)?;
+    /// let lwe_big_sk: LweSecretKey64 =
+    ///     default_engine.transform_glwe_secret_key_to_lwe_secret_key(glwe_sk.clone())?;
+    ///
+    /// let bsk_level_count = DecompositionLevelCount(9);
+    /// let bsk_base_log = DecompositionBaseLog(4);
+    ///
+    /// let std_bsk: LweBootstrapKey64 = default_parallel_engine.generate_new_lwe_bootstrap_key(
+    ///     &lwe_small_sk,
+    ///     &glwe_sk,
+    ///     bsk_base_log,
+    ///     bsk_level_count,
+    ///     var_small,
+    /// )?;
+    ///
+    /// let fourier_bsk: FftFourierLweBootstrapKey64 =
+    ///     fft_engine.convert_lwe_bootstrap_key(&std_bsk)?;
+    ///
+    /// let ksk_level_count = DecompositionLevelCount(9);
+    /// let ksk_base_log = DecompositionBaseLog(1);
+    ///
+    /// let ksk_big_to_small: LweKeyswitchKey64 = default_engine.generate_new_lwe_keyswitch_key(
+    ///     &lwe_big_sk,
+    ///     &lwe_small_sk,
+    ///     ksk_level_count,
+    ///     ksk_base_log,
+    ///     var_big,
+    /// )?;
+    ///
+    /// let pfpksk_level_count = DecompositionLevelCount(9);
+    /// let pfpksk_base_log = DecompositionBaseLog(4);
+    ///
+    /// let cbs_pfpksk: LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys64 = default_engine
+    ///     .generate_new_lwe_circuit_bootstrap_private_functional_packing_keyswitch_keys(
+    ///         &lwe_big_sk,
+    ///         &glwe_sk,
+    ///         pfpksk_base_log,
+    ///         pfpksk_level_count,
+    ///         var_small,
+    ///     )?;
+    ///
+    /// // We will have a message with 10 bits of information
+    /// let message_bits = 10;
+    /// let bits_to_extract = ExtractedBitsCount(message_bits);
+    ///
+    /// // The value we encrypt is 42, we will extract the bits of this value and apply the
+    /// // circuit bootstrapping followed by the vertical packing on the extracted bits.
+    /// let cleartext = 42;
+    /// let delta_log_msg = DeltaLog(64 - message_bits);
+    ///
+    /// let encoded_message = default_engine.create_plaintext_from(&(cleartext << delta_log_msg.0))?;
+    /// let lwe_in = default_engine.encrypt_lwe_ciphertext(&lwe_big_sk, &encoded_message, var_big)?;
+    ///
+    /// // Bit extraction output, use the zero_encrypt engine to allocate a ciphertext vector
+    /// let mut bit_extraction_output = default_engine.zero_encrypt_lwe_ciphertext_vector(
+    ///     &lwe_small_sk,
+    ///     var_small,
+    ///     LweCiphertextCount(bits_to_extract.0),
+    /// )?;
+    ///
+    /// fft_engine.discard_extract_bits_lwe_ciphertext(
+    ///     &mut bit_extraction_output,
+    ///     &lwe_in,
+    ///     &fourier_bsk,
+    ///     &ksk_big_to_small,
+    ///     bits_to_extract,
+    ///     delta_log_msg,
+    /// )?;
+    ///
+    /// // Though the delta log here is the same as the message delta log, in the general case they
+    /// // are different, so we create two DeltaLog parameters
+    /// let delta_log_lut = DeltaLog(64 - message_bits);
+    ///
+    /// // Create a look-up table we want to apply during vertical packing, here just the identity
+    /// // with the proper encoding.
+    /// // Note that this particular table will not trigger the cmux tree from the vertical packing,
+    /// // adapt the LUT generation to your usage.
+    /// // Here we apply a single look-up table as we output a single ciphertext.
+    /// let number_of_luts_and_output_vp_ciphertexts = 1;
+    /// let lut_size = 1 << bits_to_extract.0;
+    /// let mut lut: Vec<u64> = Vec::with_capacity(lut_size);
+    ///
+    /// for i in 0..lut_size {
+    ///     lut.push((i as u64 % (1 << message_bits)) << delta_log_lut.0);
+    /// }
+    ///
+    /// let lut_as_plaintext_vector = default_engine.create_plaintext_vector_from(lut.as_slice())?;
+    ///
+    /// // We run on views, so we need a container for the output
+    /// let mut output_cbs_vp_ct_container = vec![
+    ///     0u64;
+    ///     lwe_big_sk.lwe_dimension().to_lwe_size().0
+    ///         * number_of_luts_and_output_vp_ciphertexts
+    /// ];
+    ///
+    /// let mut output_cbs_vp_ct_mut_view: LweCiphertextVectorMutView64 = default_engine
+    ///     .create_lwe_ciphertext_vector_from(
+    ///         output_cbs_vp_ct_container.as_mut_slice(),
+    ///         lwe_big_sk.lwe_dimension().to_lwe_size(),
+    ///     )?;
+    /// // And we need to get a view on the bits extracted earlier that serve as inputs to the
+    /// // circuit bootstrap + vertical packing
+    /// let extracted_bits_lwe_size = bit_extraction_output.lwe_dimension().to_lwe_size();
+    /// let extracted_bits_container =
+    ///     default_engine.consume_retrieve_lwe_ciphertext_vector(bit_extraction_output)?;
+    /// let cbs_vp_input_vector_view: LweCiphertextVectorView64 = default_engine
+    ///     .create_lwe_ciphertext_vector_from(
+    ///         extracted_bits_container.as_slice(),
+    ///         extracted_bits_lwe_size,
+    ///     )?;
+    ///
+    /// let cbs_level_count = DecompositionLevelCount(4);
+    /// let cbs_base_log = DecompositionBaseLog(6);
+    ///
+    /// fft_engine.discard_circuit_bootstrap_boolean_vertical_packing_lwe_ciphertext_vector(
+    ///     &mut output_cbs_vp_ct_mut_view,
+    ///     &cbs_vp_input_vector_view,
+    ///     &fourier_bsk,
+    ///     &lut_as_plaintext_vector,
+    ///     cbs_level_count,
+    ///     cbs_base_log,
+    ///     &cbs_pfpksk,
+    /// )?;
+    ///
+    /// assert_eq!(output_cbs_vp_ct_mut_view.lwe_ciphertext_count().0, 1);
+    /// assert_eq!(
+    ///     output_cbs_vp_ct_mut_view.lwe_dimension(),
+    ///     LweDimension(glwe_dimension.0 * polynomial_size.0)
+    /// );
+    ///
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn discard_circuit_bootstrap_boolean_vertical_packing_lwe_ciphertext_vector(
+        &mut self,
+        output: &mut LweCiphertextVectorMutView64,
+        input: &LweCiphertextVectorView64,
+        bsk: &FftFourierLweBootstrapKey64,
+        luts: &PlaintextVector64,
+        cbs_level_count: DecompositionLevelCount,
+        cbs_base_log: DecompositionBaseLog,
+        cbs_pfpksk: &LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys64,
+    ) -> Result<
+        (),
+        LweCiphertextVectorDiscardingCircuitBootstrapBooleanVerticalPackingError<Self::EngineError>,
+    > {
+        FftError::perform_fft_checks(bsk.polynomial_size())?;
+        LweCiphertextVectorDiscardingCircuitBootstrapBooleanVerticalPackingError::
+            perform_generic_checks(
+                input,
+                output,
+                bsk,
+                luts,
+                cbs_level_count,
+                cbs_base_log,
+                cbs_pfpksk,
+                64,
+            )?;
+        unsafe {
+            self.discard_circuit_bootstrap_boolean_vertical_packing_lwe_ciphertext_vector_unchecked(
+            output,
+            input,
+            bsk,
+            luts,
+            cbs_level_count,
+            cbs_base_log,
+            cbs_pfpksk,
+        );
+        }
+        Ok(())
+    }
+
+    unsafe fn discard_circuit_bootstrap_boolean_vertical_packing_lwe_ciphertext_vector_unchecked(
+        &mut self,
+        output: &mut LweCiphertextVectorMutView64,
+        input: &LweCiphertextVectorView64,
+        bsk: &FftFourierLweBootstrapKey64,
+        luts: &PlaintextVector64,
+        cbs_level_count: DecompositionLevelCount,
+        cbs_base_log: DecompositionBaseLog,
+        cbs_pfpksk: &LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys64,
+    ) {
+        let lut_as_polynomial_list =
+            PolynomialList::from_container(luts.0.as_tensor().as_slice(), bsk.polynomial_size());
+
+        let fft = Fft::new(bsk.polynomial_size());
+        let fft = fft.as_view();
+        self.resize(
+            circuit_bootstrap_boolean_vertical_packing_scratch::<u64>(
+                CiphertextCount(input.lwe_ciphertext_count().0),
+                CiphertextCount(output.lwe_ciphertext_count().0),
+                input.lwe_dimension().to_lwe_size(),
+                PolynomialCount(luts.plaintext_count().0),
+                bsk.output_lwe_dimension().to_lwe_size(),
+                cbs_pfpksk.output_polynomial_size(),
+                bsk.glwe_dimension().to_glwe_size(),
+                cbs_level_count,
+                fft,
+            )
+            .unwrap()
+            .unaligned_bytes_required(),
+        );
+        circuit_bootstrap_boolean_vertical_packing(
+            lut_as_polynomial_list.as_view(),
+            bsk.0.as_view(),
+            output.0.as_mut_view(),
+            input.0.as_view(),
+            cbs_pfpksk.0.as_view(),
+            cbs_level_count,
+            cbs_base_log,
+            fft,
+            self.stack(),
+        )
+    }
+}

--- a/concrete-core/src/backends/fft/implementation/engines/fft_engine/mod.rs
+++ b/concrete-core/src/backends/fft/implementation/engines/fft_engine/mod.rs
@@ -67,3 +67,5 @@ mod glwe_ciphertexts_ggsw_ciphertext_fusing_cmux;
 mod lwe_bootstrap_key_conversion;
 mod lwe_ciphertext_discarding_bit_extraction;
 mod lwe_ciphertext_discarding_bootstrap;
+mod lwe_ciphertext_discarding_circuit_bootstrap_boolean;
+mod lwe_ciphertext_vector_discarding_circuit_bootstrap_boolean_vertical_packing;


### PR DESCRIPTION
### Resolves: https://github.com/zama-ai/concrete-core-internal/issues/366 partially

### Description
Adds circuit bootstrap & vertical packing to the FFT backend public API

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
