### PR TITLE
fix(ci): Replaces the command used to test CUDA 11.1 in the CI.

### DIFF
--- a/.github/workflows/aws_tests_gpu_slab_beta.yml
+++ b/.github/workflows/aws_tests_gpu_slab_beta.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Test concrete-core with cuda backend with CUDA 11.1
         run: |
-          cargo test --release -p concrete-core --features=backend_cuda -- backends::cuda --test-threads 1
+          cargo xtask test_cuda
 
       - name: Slack Notification
         if: ${{ always() }}


### PR DESCRIPTION
### Resolves: 

### Description
We should be using `cargo xtask test_cuda` for that.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
