### PR TITLE
fix(concrete_core_wasm): fix pruning of wrongly detected parameter arg

### DIFF
--- a/concrete-core-representation/src/ccr/mod.rs
+++ b/concrete-core-representation/src/ccr/mod.rs
@@ -56,7 +56,7 @@ pub fn load_ccr<P: AsRef<Path>>(path: P) -> ConcreteCore {
 
 // TODO: Once reintegrated into concrete-core, those parameters should be parsed from the sources as
 // well.
-const PARAMETERS_IDENTS: [&str; 25] = [
+const PARAMETERS_IDENTS: [&str; 26] = [
     "PlaintextCount",
     "EncoderCount",
     "CleartextCount",
@@ -82,6 +82,7 @@ const PARAMETERS_IDENTS: [&str; 25] = [
     "ModulusSwitchOffset",
     "DeltaLog",
     "ExtractedBitsCount",
+    "LwePublicKeyZeroEncryptionCount",
 ];
 
 const DISPERSION_IDENTS: [&str; 3] = ["LogStandardDev", "StandardDev", "Variance"];

--- a/concrete-core-wasm/Cargo.toml
+++ b/concrete-core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concrete-core-wasm"
-version = "0.2.0"
+version = "1.0.0-rc2"
 authors = ["Zama team"]
 edition = "2021"
 license = "BSD-3-Clause-Clear"

--- a/concrete-core-wasm/src/lib.rs
+++ b/concrete-core-wasm/src/lib.rs
@@ -86,7 +86,8 @@ mod commons {
         (GlweCiphertextCount, GlweCiphertextCount, usize),
         (PolynomialSize, PolynomialSize, usize),
         (DeltaLog, DeltaLog, usize),
-        (ExtractedBitsCount, ExtractedBitsCount, usize)
+        (ExtractedBitsCount, ExtractedBitsCount, usize),
+        (LwePublicKeyZeroEncryptionCount, LwePublicKeyZeroEncryptionCount, usize)
     }
 }
 pub use commons::*;


### PR DESCRIPTION
### Description

The `LwePublicKeyGenerationEngine` signature contained a new `LwePublicKeyZeroEncryptionCount` parameter type, that was not recognized by the `concrete-core-representation` tool. That lead to the argument being parsed as `Unknown` and pruned from the `ccr` before the binding was generated. 

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
