### PR TITLE
chore(ffi): disable avx/avx2 instructions on x86 macs

### DIFF
--- a/.github/workflows/ffi_github_release.yml
+++ b/.github/workflows/ffi_github_release.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build libconcrete_core_ffi
         env:
-          RUSTFLAGS: "-Ctarget-feature=+aes,+sse2,+avx,+avx2"
+          RUSTFLAGS: "-Ctarget-feature=+aes,+sse2"
         run: |
           TMP_DIR="$(mktemp -d)"
 


### PR DESCRIPTION
### Resolves:

### Description

- github actions runner fail to run with those instructions enabled

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
