### PR TITLE
chore(core): differentiate params for pbs fixture between cpu/gpu implems

### DIFF
--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_1.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_1.rs
@@ -98,10 +98,11 @@ where
     fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
         Box::new(
             vec![
+                #[cfg(not(feature = "backend_cuda"))]
                 LweCiphertextDiscardingBootstrapParameters1 {
                     noise: Variance(LogStandardDev::from_log_standard_dev(-29.).get_variance()),
                     lwe_dimension: LweDimension(630),
-                    glwe_dimension: GlweDimension(1),
+                    glwe_dimension: GlweDimension(2),
                     poly_size: PolynomialSize(512),
                     decomp_level_count: DecompositionLevelCount(3),
                     decomp_base_log: DecompositionBaseLog(7),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_2.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_2.rs
@@ -91,14 +91,25 @@ where
 
     fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
         Box::new(
-            vec![LweCiphertextDiscardingBootstrapParameters2 {
-                noise: Variance(LogStandardDev::from_log_standard_dev(-29.).get_variance()),
-                lwe_dimension: LweDimension(630),
-                glwe_dimension: GlweDimension(1),
-                poly_size: PolynomialSize(1024),
-                decomp_level_count: DecompositionLevelCount(3),
-                decomp_base_log: DecompositionBaseLog(7),
-            }]
+            vec![
+                LweCiphertextDiscardingBootstrapParameters2 {
+                    noise: Variance(LogStandardDev::from_log_standard_dev(-29.).get_variance()),
+                    lwe_dimension: LweDimension(630),
+                    glwe_dimension: GlweDimension(1),
+                    poly_size: PolynomialSize(1024),
+                    decomp_level_count: DecompositionLevelCount(3),
+                    decomp_base_log: DecompositionBaseLog(7),
+                },
+                #[cfg(not(feature = "backend_cuda"))]
+                LweCiphertextDiscardingBootstrapParameters2 {
+                    noise: Variance(LogStandardDev::from_log_standard_dev(-29.).get_variance()),
+                    lwe_dimension: LweDimension(630),
+                    glwe_dimension: GlweDimension(2),
+                    poly_size: PolynomialSize(1024),
+                    decomp_level_count: DecompositionLevelCount(3),
+                    decomp_base_log: DecompositionBaseLog(7),
+                },
+            ]
             .into_iter(),
         )
     }

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_bootstrap_1.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_bootstrap_1.rs
@@ -112,10 +112,11 @@ where
     fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
         Box::new(
             vec![
+                #[cfg(not(feature = "backend_cuda"))]
                 LweCiphertextVectorDiscardingBootstrapParameters1 {
                     noise: Variance(LogStandardDev::from_log_standard_dev(-29.).get_variance()),
                     lwe_dimension: LweDimension(630),
-                    glwe_dimension: GlweDimension(1),
+                    glwe_dimension: GlweDimension(2),
                     poly_size: PolynomialSize(512),
                     decomp_level_count: DecompositionLevelCount(3),
                     decomp_base_log: DecompositionBaseLog(7),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_bootstrap_2.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_bootstrap_2.rs
@@ -110,10 +110,11 @@ where
     fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
         Box::new(
             vec![
+                #[cfg(not(feature = "backend_cuda"))]
                 LweCiphertextVectorDiscardingBootstrapParameters2 {
                     noise: Variance(LogStandardDev::from_log_standard_dev(-29.).get_variance()),
                     lwe_dimension: LweDimension(630),
-                    glwe_dimension: GlweDimension(1),
+                    glwe_dimension: GlweDimension(2),
                     poly_size: PolynomialSize(512),
                     decomp_level_count: DecompositionLevelCount(3),
                     decomp_base_log: DecompositionBaseLog(7),


### PR DESCRIPTION
### Resolves: `<link_your_issue_here>`

### Description
GLWE dimension can only be 1 for the GPU implementation but we should test for k > 1 for the CPU implementation.
This PRs solves this.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
