### PR TITLE
chore(cuda): remove cuda_script file

### DIFF
--- a/concrete-cuda/cuda/CMakeLists.txt
+++ b/concrete-cuda/cuda/CMakeLists.txt
@@ -27,6 +27,7 @@ execute_process(COMMAND nvcc -lcuda ${CUDAFILE} -o ${OUTPUTFILE})
 execute_process(COMMAND ${OUTPUTFILE}
         RESULT_VARIABLE CUDA_RETURN_CODE
         OUTPUT_VARIABLE ARCH)
+file(REMOVE ${OUTPUTFILE})
 
 if (${CUDA_RETURN_CODE} EQUAL 0)
     set(CUDA_SUCCESS "TRUE")


### PR DESCRIPTION
### Resolves: https://github.com/zama-ai/concrete-core-internal/issues/300
### Description
The cuda_script is now removed after it's used in the CMakelists.txt file.
### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
