### PR TITLE
chore(core): fix doc strings for LWE extraction

### DIFF
--- a/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_extraction.rs
+++ b/concrete-core/src/backends/default/implementation/engines/default_engine/lwe_ciphertext_discarding_extraction.rs
@@ -15,23 +15,21 @@ use crate::specification::engines::{
 impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext32, LweCiphertext32> for DefaultEngine {
     /// # Example:
     /// ```
-    /// use concrete_core::prelude::{
-    ///     GlweDimension, LweDimension, MonomialIndex, PolynomialSize, Variance, *,
-    /// };
+    /// use concrete_core::prelude::*;
     /// # use std::error::Error;
     ///
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
     /// // The target LWE dimension should be equal to the polynomial size + 1
     /// // since we're going to extract one sample from the GLWE ciphertext
-    /// let lwe_dimension = LweDimension(8);
     /// let glwe_dimension = GlweDimension(2);
     /// let polynomial_size = PolynomialSize(4);
+    /// let expected_lwe_dimension = LweDimension(glwe_dimension.0 * polynomial_size.0);
     /// // There are always polynomial_size messages encrypted in the GLWE ciphertext
     /// // We're going to extract the first one
     /// // Here a hard-set encoding is applied (shift by 20 bits)
     /// let input = vec![3_u32 << 20; polynomial_size.0];
-    /// let noise = Variance(2_f64.powf(-25.));
+    /// let noise = Variance(2_f64.powf(-75.));
     ///
     /// // Unix seeder must be given a secret input.
     /// // Here we just give it 0, which is totally unsafe.
@@ -39,7 +37,10 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext32, LweCiphertext32> 
     /// let mut engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
     /// let glwe_key: GlweSecretKey32 =
     ///     engine.generate_new_glwe_secret_key(glwe_dimension, polynomial_size)?;
-    /// let lwe_key: LweSecretKey32 = engine.generate_new_lwe_secret_key(lwe_dimension)?;
+    /// // Transform the original GLWE key to an LWE key to be able to decrypt the extracted
+    /// // ciphertext
+    /// let lwe_key: LweSecretKey32 =
+    ///     engine.transform_glwe_secret_key_to_lwe_secret_key(glwe_key.clone())?;
     /// let plaintext_vector = engine.create_plaintext_vector_from(&input)?;
     /// let glwe_ciphertext = engine.encrypt_glwe_ciphertext(&glwe_key, &plaintext_vector, noise)?;
     /// // We first create an LWE ciphertext encrypting zeros
@@ -52,7 +53,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext32, LweCiphertext32> 
     ///     MonomialIndex(0),
     /// )?;
     /// #
-    /// assert_eq!(lwe_ciphertext.lwe_dimension(), lwe_dimension);
+    /// assert_eq!(lwe_ciphertext.lwe_dimension(), expected_lwe_dimension);
     ///
     /// #
     /// # Ok(())
@@ -97,14 +98,14 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext64, LweCiphertext64> 
     /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
     /// // The target LWE dimension should be equal to the polynomial size + 1
     /// // since we're going to extract one sample from the GLWE ciphertext
-    /// let lwe_dimension = LweDimension(8);
     /// let glwe_dimension = GlweDimension(2);
     /// let polynomial_size = PolynomialSize(4);
+    /// let expected_lwe_dimension = LweDimension(glwe_dimension.0 * polynomial_size.0);
     /// // There are always polynomial_size messages encrypted in the GLWE ciphertext
     /// // We're going to extract the first one
     /// // Here a hard-set encoding is applied (shift by 50 bits)
     /// let input = vec![3_u64 << 50; polynomial_size.0];
-    /// let noise = Variance(2_f64.powf(-25.));
+    /// let noise = Variance(2_f64.powf(-75.));
     ///
     /// // Unix seeder must be given a secret input.
     /// // Here we just give it 0, which is totally unsafe.
@@ -112,7 +113,10 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext64, LweCiphertext64> 
     /// let mut engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
     /// let glwe_key: GlweSecretKey64 =
     ///     engine.generate_new_glwe_secret_key(glwe_dimension, polynomial_size)?;
-    /// let lwe_key: LweSecretKey64 = engine.generate_new_lwe_secret_key(lwe_dimension)?;
+    /// // Transform the original GLWE key to an LWE key to be able to decrypt the extracted
+    /// // ciphertext
+    /// let lwe_key: LweSecretKey64 =
+    ///     engine.transform_glwe_secret_key_to_lwe_secret_key(glwe_key.clone())?;
     /// let plaintext_vector = engine.create_plaintext_vector_from(&input)?;
     /// let glwe_ciphertext = engine.encrypt_glwe_ciphertext(&glwe_key, &plaintext_vector, noise)?;
     /// // We first create an LWE ciphertext encrypting zeros
@@ -125,7 +129,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext64, LweCiphertext64> 
     ///     MonomialIndex(0),
     /// )?;
     /// #
-    /// assert_eq!(lwe_ciphertext.lwe_dimension(), lwe_dimension);
+    /// assert_eq!(lwe_ciphertext.lwe_dimension(), expected_lwe_dimension);
     ///
     /// #
     /// # Ok(())


### PR DESCRIPTION
### Resolves:

### Description

As pointed out here https://community.zama.ai/t/extract-a-lwe-ciphertext-from-a-rlwe-ciphertext/325/3?u=icetdrinker

our doc strings for LWE sample extractions are wrong, this PR fixes it

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
