### PR TITLE
fix(cuda): Remove extra ; in bootstrap header file that lead to warnings

### DIFF
--- a/concrete-cuda/cuda/include/bootstrap.h
+++ b/concrete-cuda/cuda/include/bootstrap.h
@@ -78,7 +78,7 @@ void cuda_extract_bits_64(
     uint32_t lwe_dimension_out, uint32_t glwe_dimension, uint32_t base_log_bsk,
     uint32_t level_count_bsk, uint32_t base_log_ksk, uint32_t level_count_ksk,
     uint32_t number_of_samples);
-};
+}
 
 #ifdef __CUDACC__
 __device__ inline int get_start_ith_ggsw(int i, uint32_t polynomial_size,


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX187GxdY8scLwWG7PlcFDpQSdW65xjpJC4%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=8bUHVLR)
