### PR TITLE
feat(cuda): Refactor all host functions in concrete-cuda to use asynchronous allocation

### DIFF
--- a/concrete-cuda/cuda/include/device.h
+++ b/concrete-cuda/cuda/include/device.h
@@ -7,6 +7,8 @@ int cuda_destroy_stream(void *v_stream, uint32_t gpu_index);
 
 void *cuda_malloc(uint64_t size, uint32_t gpu_index);
 
+void *cuda_malloc_async(uint64_t size, void *v_stream);
+
 int cuda_check_valid_malloc(uint64_t size, uint32_t gpu_index);
 
 int cuda_memcpy_to_cpu(void *dest, const void *src, uint64_t size,
@@ -25,6 +27,8 @@ int cuda_get_number_of_gpus();
 int cuda_synchronize_device(uint32_t gpu_index);
 
 int cuda_drop(void *ptr, uint32_t gpu_index);
+
+int cuda_drop_async(void *ptr, void *v_stream);
 
 int cuda_get_max_shared_memory(uint32_t gpu_index);
 }

--- a/concrete-cuda/cuda/include/device.h
+++ b/concrete-cuda/cuda/include/device.h
@@ -7,7 +7,7 @@ int cuda_destroy_stream(void *v_stream, uint32_t gpu_index);
 
 void *cuda_malloc(uint64_t size, uint32_t gpu_index);
 
-void *cuda_malloc_async(uint64_t size, void *v_stream);
+void *cuda_malloc_async(uint64_t size, cudaStream_t stream);
 
 int cuda_check_valid_malloc(uint64_t size, uint32_t gpu_index);
 
@@ -28,7 +28,7 @@ int cuda_synchronize_device(uint32_t gpu_index);
 
 int cuda_drop(void *ptr, uint32_t gpu_index);
 
-int cuda_drop_async(void *ptr, void *v_stream);
+int cuda_drop_async(void *ptr, cudaStream_t stream);
 
 int cuda_get_max_shared_memory(uint32_t gpu_index);
 }

--- a/concrete-cuda/cuda/src/bootstrap_amortized.cuh
+++ b/concrete-cuda/cuda/src/bootstrap_amortized.cuh
@@ -338,7 +338,7 @@ __host__ void host_bootstrap_amortized(
   // from one of three templates (no use, partial use or full use
   // of shared memory)
   if (max_shared_memory < SM_PART) {
-    d_mem = (char*) cuda_malloc_async(DM_FULL * input_lwe_ciphertext_count, v_stream);
+    d_mem = (char*) cuda_malloc_async(DM_FULL * input_lwe_ciphertext_count, *stream);
     device_bootstrap_amortized<Torus, params, NOSM><<<grid, thds, 0, *stream>>>(
         lwe_array_out, lut_vector, lut_vector_indexes, lwe_array_in,
         bootstrapping_key, d_mem, input_lwe_dimension, polynomial_size,
@@ -348,7 +348,7 @@ __host__ void host_bootstrap_amortized(
                          cudaFuncAttributeMaxDynamicSharedMemorySize, SM_PART);
     cudaFuncSetCacheConfig(device_bootstrap_amortized<Torus, params, PARTIALSM>,
                            cudaFuncCachePreferShared);
-    d_mem = (char*) cuda_malloc_async(DM_PART * input_lwe_ciphertext_count, v_stream);
+    d_mem = (char*) cuda_malloc_async(DM_PART * input_lwe_ciphertext_count, *stream);
     device_bootstrap_amortized<Torus, params, PARTIALSM>
         <<<grid, thds, SM_PART, *stream>>>(
             lwe_array_out, lut_vector, lut_vector_indexes, lwe_array_in,
@@ -366,7 +366,7 @@ __host__ void host_bootstrap_amortized(
     checkCudaErrors(cudaFuncSetCacheConfig(
         device_bootstrap_amortized<Torus, params, FULLSM>,
         cudaFuncCachePreferShared));
-    d_mem = (char*) cuda_malloc_async(0, v_stream);
+    d_mem = (char*) cuda_malloc_async(0, *stream);
 
     device_bootstrap_amortized<Torus, params, FULLSM>
         <<<grid, thds, SM_FULL, *stream>>>(
@@ -377,7 +377,7 @@ __host__ void host_bootstrap_amortized(
   // Synchronize the streams before copying the result to lwe_array_out at the
   // right place
   cudaStreamSynchronize(*stream);
-  cuda_drop_async(d_mem, v_stream);
+  cuda_drop_async(d_mem, *stream);
 }
 
 template <typename Torus, class params>

--- a/concrete-cuda/cuda/src/bootstrap_low_latency.cuh
+++ b/concrete-cuda/cuda/src/bootstrap_low_latency.cuh
@@ -10,6 +10,7 @@
 #include "cooperative_groups.h"
 
 #include "../include/helper_cuda.h"
+#include "device.h"
 #include "bootstrap.h"
 #include "complex/operations.cuh"
 #include "crypto/gadget.cuh"
@@ -261,10 +262,8 @@ host_bootstrap_low_latency(void *v_stream, Torus *lwe_array_out,
 
   int buffer_size_per_gpu =
       level_count * num_samples * polynomial_size / 2 * sizeof(double2);
-  double2 *mask_buffer_fft;
-  double2 *body_buffer_fft;
-  checkCudaErrors(cudaMalloc((void **)&mask_buffer_fft, buffer_size_per_gpu));
-  checkCudaErrors(cudaMalloc((void **)&body_buffer_fft, buffer_size_per_gpu));
+  double2 *mask_buffer_fft = (double2*) cuda_malloc_async(buffer_size_per_gpu, *stream);
+  double2 *body_buffer_fft = (double2*) cuda_malloc_async(buffer_size_per_gpu, *stream);
 
   int bytes_needed = sizeof(int16_t) * polynomial_size + // accumulator_decomp
                      sizeof(Torus) * polynomial_size +   // accumulator
@@ -298,8 +297,8 @@ host_bootstrap_low_latency(void *v_stream, Torus *lwe_array_out,
   // Synchronize the streams before copying the result to lwe_array_out at the
   // right place
   cudaStreamSynchronize(*stream);
-  cudaFree(mask_buffer_fft);
-  cudaFree(body_buffer_fft);
+  cuda_drop_async(mask_buffer_fft, *stream);
+  cuda_drop_async(body_buffer_fft, *stream);
 }
 
 #endif // LOWLAT_PBS_H

--- a/concrete-cuda/cuda/src/device.cu
+++ b/concrete-cuda/cuda/src/device.cu
@@ -31,15 +31,14 @@ void *cuda_malloc(uint64_t size, uint32_t gpu_index) {
   return ptr;
 }
 
-///
-void *cuda_malloc_async(uint64_t size, void *v_stream) {
+/// Allocates a size-byte array at the device memory. Tries to do it asynchronously.
+void *cuda_malloc_async(uint64_t size, cudaStream_t stream) {
   void *ptr;
 
   #if (CUDART_VERSION < 11020)
   checkCudaErrors(cudaMalloc((void **)&ptr, size));
   #else
-  auto stream = static_cast<cudaStream_t *>(v_stream);
-  checkCudaErrors(cudaMallocAsync((void **)&ptr, size, *stream));
+  checkCudaErrors(cudaMallocAsync((void **)&ptr, size, stream));
   #endif
   return ptr;
 }
@@ -153,10 +152,14 @@ int cuda_drop(void *ptr, uint32_t gpu_index) {
   return 0;
 }
 
-/// Drop a cuda array
-int cuda_drop_async(void *ptr, void *v_stream) {
-  auto stream = static_cast<cudaStream_t *>(v_stream);
-  checkCudaErrors(cudaFreeAsync(ptr, *stream));
+/// Drop a cuda array. Tries to do it asynchronously
+int cuda_drop_async(void *ptr, cudaStream_t stream) {
+
+  #if (CUDART_VERSION < 11020)
+  checkCudaErrors(cudaFree(ptr));
+  #else
+  checkCudaErrors(cudaFreeAsync(ptr, stream));
+  #endif
   return 0;
 }
 

--- a/concrete-cuda/cuda/src/device.cu
+++ b/concrete-cuda/cuda/src/device.cu
@@ -31,6 +31,19 @@ void *cuda_malloc(uint64_t size, uint32_t gpu_index) {
   return ptr;
 }
 
+///
+void *cuda_malloc_async(uint64_t size, void *v_stream) {
+  void *ptr;
+
+  #if (CUDART_VERSION < 11020)
+  checkCudaErrors(cudaMalloc((void **)&ptr, size));
+  #else
+  auto stream = static_cast<cudaStream_t *>(v_stream);
+  checkCudaErrors(cudaMallocAsync((void **)&ptr, size, *stream));
+  #endif
+  return ptr;
+}
+
 /// Checks that allocation is valid
 /// 0: valid
 /// -1: invalid, not enough memory in device
@@ -137,6 +150,13 @@ int cuda_drop(void *ptr, uint32_t gpu_index) {
   }
   cudaSetDevice(gpu_index);
   checkCudaErrors(cudaFree(ptr));
+  return 0;
+}
+
+/// Drop a cuda array
+int cuda_drop_async(void *ptr, void *v_stream) {
+  auto stream = static_cast<cudaStream_t *>(v_stream);
+  checkCudaErrors(cudaFreeAsync(ptr, *stream));
   return 0;
 }
 


### PR DESCRIPTION
### Resolves: https://github.com/zama-ai/concrete-core-internal/issues/430

### Description
Two functions are implemented to encapsulate the asynchronous allocation and freeing of device memory. If the installed toolkit version is less than 11.2, use synchronous.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
