### PR TITLE
chore(core): exclude docs from crate for publishing

### DIFF
--- a/concrete-core/Cargo.toml
+++ b/concrete-core/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.zama.ai/concrete-core"
 repository = "https://github.com/zama-ai/concrete-core"
 readme = "README.md"
 keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
+exclude = ["/docs/", "/katex-header.html"]
 
 [dev-dependencies]
 rand = "0.7"


### PR DESCRIPTION
### Resolves:

### Description

cargo packages everything in the concrete-core dir, and that includes some big images from our docs, let's fix that.

```
cargo package -l --allow-dirty -p concrete-core
```

shows which files get packaged

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
