### PR TITLE
fix(cuda): Checks the cudaDevAttrMemoryPoolsSupported property to ensure that asynchronous allocation is supported

### DIFF
--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/glwe_ciphertext_vector_conversion.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/glwe_ciphertext_vector_conversion.rs
@@ -604,7 +604,7 @@ impl
         input: &GlweCiphertextVectorMutView32,
     ) -> CudaGlweCiphertextVector32 {
         // Copy the entire input vector over all GPUs
-        let mut vecs = Vec::with_capacity(self.get_number_of_gpus().0 as usize);
+        let mut vecs = Vec::with_capacity(self.get_number_of_gpus().0);
         let data_per_gpu = input.glwe_ciphertext_count().0
             * input.glwe_dimension().to_glwe_size().0
             * input.polynomial_size().0;
@@ -712,7 +712,7 @@ impl
         input: &GlweCiphertextVectorMutView64,
     ) -> CudaGlweCiphertextVector64 {
         // Copy the entire input vector over all GPUs
-        let mut vecs = Vec::with_capacity(self.get_number_of_gpus().0 as usize);
+        let mut vecs = Vec::with_capacity(self.get_number_of_gpus().0);
         let data_per_gpu = input.glwe_ciphertext_count().0
             * input.glwe_dimension().to_glwe_size().0
             * input.polynomial_size().0;

--- a/concrete-cuda/cuda/include/device.h
+++ b/concrete-cuda/cuda/include/device.h
@@ -7,7 +7,7 @@ int cuda_destroy_stream(void *v_stream, uint32_t gpu_index);
 
 void *cuda_malloc(uint64_t size, uint32_t gpu_index);
 
-void *cuda_malloc_async(uint64_t size, cudaStream_t stream);
+void *cuda_malloc_async(uint64_t size, cudaStream_t stream, uint32_t gpu_index);
 
 int cuda_check_valid_malloc(uint64_t size, uint32_t gpu_index);
 
@@ -28,7 +28,7 @@ int cuda_synchronize_device(uint32_t gpu_index);
 
 int cuda_drop(void *ptr, uint32_t gpu_index);
 
-int cuda_drop_async(void *ptr, cudaStream_t stream);
+int cuda_drop_async(void *ptr, cudaStream_t stream, uint32_t gpu_index);
 
 int cuda_get_max_shared_memory(uint32_t gpu_index);
 }

--- a/concrete-cuda/cuda/src/bootstrap_low_latency.cuh
+++ b/concrete-cuda/cuda/src/bootstrap_low_latency.cuh
@@ -258,14 +258,16 @@ host_bootstrap_low_latency(void *v_stream, Torus *lwe_array_out,
                            uint32_t base_log, uint32_t level_count,
                            uint32_t num_samples, uint32_t num_lut_vectors) {
 
+  uint32_t gpu_index = 0;
+
   auto stream = static_cast<cudaStream_t *>(v_stream);
 
   int buffer_size_per_gpu =
       level_count * num_samples * polynomial_size / 2 * sizeof(double2);
   double2 *mask_buffer_fft =
-      (double2 *)cuda_malloc_async(buffer_size_per_gpu, *stream);
+      (double2 *)cuda_malloc_async(buffer_size_per_gpu, *stream, gpu_index);
   double2 *body_buffer_fft =
-      (double2 *)cuda_malloc_async(buffer_size_per_gpu, *stream);
+      (double2 *)cuda_malloc_async(buffer_size_per_gpu, *stream, gpu_index);
 
   int bytes_needed = sizeof(int16_t) * polynomial_size + // accumulator_decomp
                      sizeof(Torus) * polynomial_size +   // accumulator
@@ -299,8 +301,8 @@ host_bootstrap_low_latency(void *v_stream, Torus *lwe_array_out,
   // Synchronize the streams before copying the result to lwe_array_out at the
   // right place
   cudaStreamSynchronize(*stream);
-  cuda_drop_async(mask_buffer_fft, *stream);
-  cuda_drop_async(body_buffer_fft, *stream);
+  cuda_drop_async(mask_buffer_fft, *stream, gpu_index);
+  cuda_drop_async(body_buffer_fft, *stream, gpu_index);
 }
 
 #endif // LOWLAT_PBS_H

--- a/concrete-cuda/cuda/src/bootstrap_wop.cuh
+++ b/concrete-cuda/cuda/src/bootstrap_wop.cuh
@@ -302,8 +302,8 @@ void host_cmux_tree(void *v_stream, Torus *glwe_array_out, Torus *ggsw_in,
   int ggsw_size = r * polynomial_size * (glwe_dimension + 1) *
                   (glwe_dimension + 1) * level_count;
 
-  double2 *d_ggsw_fft_in =
-      (double2 *)cuda_malloc_async(ggsw_size * sizeof(double), *stream, gpu_index);
+  double2 *d_ggsw_fft_in = (double2 *)cuda_malloc_async(
+      ggsw_size * sizeof(double), *stream, gpu_index);
 
   batch_fft_ggsw_vector<Torus, STorus, params>(v_stream, d_ggsw_fft_in, ggsw_in,
                                                r, glwe_dimension,
@@ -328,10 +328,10 @@ void host_cmux_tree(void *v_stream, Torus *glwe_array_out, Torus *ggsw_in,
   // Allocate buffers
   int glwe_size = (glwe_dimension + 1) * polynomial_size;
 
-  Torus *d_buffer1 =
-      (Torus *)cuda_malloc_async(num_lut * glwe_size * sizeof(Torus), *stream, gpu_index);
-  Torus *d_buffer2 =
-      (Torus *)cuda_malloc_async(num_lut * glwe_size * sizeof(Torus), *stream, gpu_index);
+  Torus *d_buffer1 = (Torus *)cuda_malloc_async(
+      num_lut * glwe_size * sizeof(Torus), *stream, gpu_index);
+  Torus *d_buffer2 = (Torus *)cuda_malloc_async(
+      num_lut * glwe_size * sizeof(Torus), *stream, gpu_index);
 
   checkCudaErrors(cudaMemcpyAsync(d_buffer1, lut_vector,
                                   num_lut * glwe_size * sizeof(Torus),

--- a/concrete-cuda/cuda/src/device.cu
+++ b/concrete-cuda/cuda/src/device.cu
@@ -33,14 +33,15 @@ void *cuda_malloc(uint64_t size, uint32_t gpu_index) {
 
 /// Allocates a size-byte array at the device memory. Tries to do it
 /// asynchronously.
-void *cuda_malloc_async(uint64_t size, cudaStream_t stream, uint32_t gpu_index) {
+void *cuda_malloc_async(uint64_t size, cudaStream_t stream,
+                        uint32_t gpu_index) {
   void *ptr;
 
   int support_async_alloc;
-  checkCudaErrors(cudaDeviceGetAttribute(&support_async_alloc, cudaDevAttrMemoryPoolsSupported,
-                                         gpu_index));
+  checkCudaErrors(cudaDeviceGetAttribute(
+      &support_async_alloc, cudaDevAttrMemoryPoolsSupported, gpu_index));
 
-  if(support_async_alloc)
+  if (support_async_alloc)
     checkCudaErrors(cudaMallocAsync((void **)&ptr, size, stream));
   else
     checkCudaErrors(cudaMalloc((void **)&ptr, size));
@@ -160,10 +161,10 @@ int cuda_drop(void *ptr, uint32_t gpu_index) {
 int cuda_drop_async(void *ptr, cudaStream_t stream, uint32_t gpu_index) {
 
   int support_async_alloc;
-  checkCudaErrors(cudaDeviceGetAttribute(&support_async_alloc, cudaDevAttrMemoryPoolsSupported,
-                                         gpu_index));
+  checkCudaErrors(cudaDeviceGetAttribute(
+      &support_async_alloc, cudaDevAttrMemoryPoolsSupported, gpu_index));
 
-  if(support_async_alloc)
+  if (support_async_alloc)
     checkCudaErrors(cudaFreeAsync(ptr, stream));
   else
     checkCudaErrors(cudaFree(ptr));


### PR DESCRIPTION

### Resolves: https://github.com/zama-ai/concrete-core-internal/issues/473

### Description
We need to check for the cuda version during compilation to ensure the async functions will compile but we also need to check for that property on runtime. 

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
