### PR TITLE
chore(ci): adapt workflows to v0.9.x of slab ci bot

### DIFF
--- a/.github/workflows/aws_tests_gpu_slab_beta.yml
+++ b/.github/workflows/aws_tests_gpu_slab_beta.yml
@@ -17,6 +17,9 @@ on:
       runner_name:
         description: "Action runner name"
         type: string
+      request_id:
+        description: 'Slab request ID'
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -49,6 +52,7 @@ jobs:
           echo "IDs: ${{ github.event.inputs.instance_id }}"
           echo "AMI: ${{ github.event.inputs.instance_image_id }}"
           echo "Type: ${{ github.event.inputs.instance_type }}"
+          echo "Request ID: ${{ github.event.inputs.request_id }}"
       - uses: actions/checkout@v2
       - name: Set up home
         run: |

--- a/.github/workflows/aws_tests_slab_beta.yml
+++ b/.github/workflows/aws_tests_slab_beta.yml
@@ -16,6 +16,9 @@ on:
       runner_name:
         description: 'Action runner name'
         type: string
+      request_id:
+        description: 'Slab request ID'
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -40,6 +43,7 @@ jobs:
           echo "IDs: ${{ github.event.inputs.instance_id }}"
           echo "AMI: ${{ github.event.inputs.instance_image_id }}"
           echo "Type: ${{ github.event.inputs.instance_type }}"
+          echo "Request ID: ${{ github.event.inputs.request_id }}"
       - uses: actions/checkout@v2
       - name: Set up home
         run: |


### PR DESCRIPTION
### Description

Last version of Slab CI bot imposes to add another input field to workflows meant to be triggered by Slab.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
* [ ] ~~Docs have been added / updated (for bug fixes / features)~~
* [ ] ~~The PR description links to the related issue (to link an issue, use '#XXX'.)~~
* [ ] ~~The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)~~
* [ ] ~~The draft release description has been updated~~
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
