### PR TITLE
feat(cuda): Implements vertical packing's blind rotation and sample extraction on the CUDA backend

### DIFF
--- a/concrete-core/Cargo.toml
+++ b/concrete-core/Cargo.toml
@@ -72,7 +72,7 @@ backend_default_generator_aarch64_aes = [
 backend_default_serialization = ["bincode", "__commons_serialization"]
 
 # A GPU backend, relying on Cuda acceleration
-backend_cuda = ["concrete-cuda"]
+backend_cuda = ["concrete-cuda", "backend_fft"]
 
 # Private features
 __profiling = []

--- a/concrete-core/src/backends/cuda/private/wopbs/mod.rs
+++ b/concrete-core/src/backends/cuda/private/wopbs/mod.rs
@@ -1,2 +1,300 @@
+use crate::backends::cuda::private::device::{CudaStream, GpuIndex};
+use crate::backends::fft::private::crypto::bootstrap::FourierLweBootstrapKeyView;
+use crate::backends::fft::private::crypto::wop_pbs::{
+    circuit_bootstrap_boolean, FourierGgswCiphertextListMutView,
+};
+use crate::backends::fft::private::math::fft::FftView;
+use crate::commons::crypto::ggsw::StandardGgswCiphertext;
+use crate::commons::crypto::glwe::LwePrivateFunctionalPackingKeyswitchKeyList;
+use crate::commons::crypto::lwe::{LweCiphertext, LweList};
+use crate::commons::math::polynomial::PolynomialList;
+use crate::commons::math::tensor::{AsRefSlice, AsRefTensor};
+use crate::commons::utils::izip;
+use crate::prelude::{
+    DecompositionBaseLog, DecompositionLevelCount, DeltaLog, GgswCiphertext64,
+    GgswCiphertextEntity, LweCiphertext64, LweDimension, PolynomialCount,
+};
+use aligned_vec::CACHELINE_ALIGN;
+use concrete_cuda::cuda_bind::{cuda_blind_rotate_and_sample_extraction_64, cuda_cmux_tree_64};
+use concrete_fft::c64;
+use dyn_stack::{DynStack, ReborrowMut};
+
 #[cfg(test)]
 mod test;
+
+// GGSW ciphertexts are stored from the msb (vec_ggsw[0]) to the lsb (vec_ggsw[last])
+pub fn cuda_vertical_packing(
+    tree_lut: &[Vec<u64>],
+    vec_ggsw: &[GgswCiphertext64],
+    level: DecompositionLevelCount,
+    base_log: DecompositionBaseLog,
+    r: usize,
+) -> LweCiphertext64 {
+    let polynomial_size = vec_ggsw[0].polynomial_size();
+    let glwe_dimension = vec_ggsw[0].glwe_dimension();
+    let glwe_size = glwe_dimension.to_glwe_size().0 * polynomial_size.0;
+
+    println!("vec_ggsw size: {}", vec_ggsw.len());
+
+    let gpu_index = GpuIndex(0);
+    let stream = CudaStream::new(gpu_index).unwrap();
+
+    // LUTs
+    let mut h_concatenated_luts_glwe = vec![];
+    for h_lut in tree_lut.iter() {
+        let mut h_lut = h_lut.clone();
+        h_concatenated_luts_glwe.append(&mut h_lut);
+    }
+    let mut d_concatenated_luts_glwe = stream.malloc::<u64>(h_concatenated_luts_glwe.len() as u32);
+    unsafe {
+        stream.copy_to_gpu::<u64>(
+            &mut d_concatenated_luts_glwe,
+            h_concatenated_luts_glwe.as_slice(),
+        );
+    }
+
+    let mut d_result_br = stream.malloc::<u64>(glwe_size as u32);
+
+    if tree_lut.len() == (1 << r) {
+        assert_eq!(h_concatenated_luts_glwe.len(), (1 << r) * glwe_size);
+        let mut d_result_cmux = stream.malloc::<u64>(glwe_size as u32);
+
+        // split the vec of GGSW in two, the msb GGSW is for the CMux tree and the lsb GGSW is for
+        // the last blind rotation.
+        let (cmux_ggsw, br_ggsw) = vec_ggsw.split_at(r);
+
+        // mbr GGSWs
+        let mut h_concatenated_br_ggsw = vec![];
+        for ggsw in br_ggsw.iter() {
+            let ggsw_slice = ggsw.0.as_tensor().as_slice();
+            h_concatenated_br_ggsw.append(&mut ggsw_slice.to_vec());
+        }
+        let mut d_concatenated_br_ggsw = stream.malloc::<u64>(h_concatenated_br_ggsw.len() as u32);
+        unsafe {
+            stream.copy_to_gpu::<u64>(
+                &mut d_concatenated_br_ggsw,
+                h_concatenated_br_ggsw.as_slice(),
+            );
+        }
+
+        // mtree GGSWs
+        let mut h_concatenated_cmux_ggsw = vec![];
+        for ggsw in cmux_ggsw.iter() {
+            let ggsw_slice = ggsw.0.as_tensor().as_slice();
+            h_concatenated_cmux_ggsw.append(&mut ggsw_slice.to_vec());
+        }
+        let mut d_concatenated_cmux_ggsw =
+            stream.malloc::<u64>(h_concatenated_cmux_ggsw.len() as u32);
+        unsafe {
+            stream.copy_to_gpu::<u64>(
+                &mut d_concatenated_cmux_ggsw,
+                h_concatenated_cmux_ggsw.as_slice(),
+            );
+        }
+
+        // CMUX Tree
+        unsafe {
+            cuda_cmux_tree_64(
+                stream.stream_handle().0,
+                d_result_cmux.as_mut_c_ptr(),
+                d_concatenated_cmux_ggsw.as_c_ptr(),
+                d_concatenated_luts_glwe.as_c_ptr(),
+                glwe_dimension.0 as u32,
+                polynomial_size.0 as u32,
+                base_log.0 as u32,
+                level.0 as u32,
+                cmux_ggsw.len() as u32,
+                stream.get_max_shared_memory().unwrap() as u32,
+            );
+        }
+        // Blind rotation + sample extraction
+        unsafe {
+            cuda_blind_rotate_and_sample_extraction_64(
+                stream.stream_handle().0,
+                d_result_br.as_mut_c_ptr(),
+                d_concatenated_br_ggsw.as_c_ptr(),
+                d_result_cmux.as_c_ptr(),
+                br_ggsw.len() as u32,
+                1u32, // tau
+                glwe_dimension.0 as u32,
+                polynomial_size.0 as u32,
+                base_log.0 as u32,
+                level.0 as u32,
+                stream.get_max_shared_memory().unwrap() as u32,
+            );
+        }
+    } else {
+        assert_eq!(glwe_size, h_concatenated_luts_glwe.as_slice().len());
+
+        // mbr GGSWs
+        let mut h_concatenated_br_ggsw = vec![];
+        for ggsw in vec_ggsw.iter() {
+            let ggsw_slice = ggsw.0.as_tensor().as_slice();
+            h_concatenated_br_ggsw.append(&mut ggsw_slice.to_vec());
+        }
+        let mut d_concatenated_br_ggsw = stream.malloc::<u64>(h_concatenated_br_ggsw.len() as u32);
+        unsafe {
+            stream.copy_to_gpu::<u64>(
+                &mut d_concatenated_br_ggsw,
+                h_concatenated_br_ggsw.as_slice(),
+            );
+        }
+
+        // Blind rotation + sample extraction
+        unsafe {
+            cuda_blind_rotate_and_sample_extraction_64(
+                stream.stream_handle().0,
+                d_result_br.as_mut_c_ptr(),
+                d_concatenated_br_ggsw.as_c_ptr(),
+                d_concatenated_luts_glwe.as_c_ptr(),
+                vec_ggsw.len() as u32,
+                1u32, // tau
+                glwe_dimension.0 as u32,
+                polynomial_size.0 as u32,
+                base_log.0 as u32,
+                level.0 as u32,
+                stream.get_max_shared_memory().unwrap() as u32,
+            );
+        }
+    }
+
+    // Check the result
+    let lwe_dimension = LweDimension(polynomial_size.0 * glwe_dimension.0);
+    // sample extract of the RLWE of the Vertical packing
+    let mut h_result = vec![41u64; lwe_dimension.to_lwe_size().0];
+    unsafe {
+        stream.copy_to_cpu::<u64>(&mut h_result, &d_result_br);
+    }
+
+    LweCiphertext64(LweCiphertext::from_container(h_result))
+}
+
+/// Perform a circuit bootstrap followed by a vertical packing on ciphertexts encrypting boolean
+/// messages.
+///
+/// The circuit bootstrapping uses the private functional packing key switch.
+///
+/// This is supposed to be used only with boolean (1 bit of message) LWE ciphertexts.
+#[allow(clippy::too_many_arguments)]
+pub fn circuit_bootstrap_boolean_cuda_vertical_packing(
+    big_lut_as_polynomial_list: PolynomialList<&[u64]>,
+    fourier_bsk: FourierLweBootstrapKeyView<'_>,
+    mut lwe_list_out: LweList<&mut [u64]>,
+    lwe_list_in: LweList<&[u64]>,
+    fpksk_list: LwePrivateFunctionalPackingKeyswitchKeyList<&[u64]>,
+    level_cbs: DecompositionLevelCount,
+    base_log_cbs: DecompositionBaseLog,
+    fft: FftView<'_>,
+    stack: DynStack<'_>,
+) {
+    let glwe_size = fpksk_list.output_glwe_key_dimension().to_glwe_size();
+    let (mut ggsw_list_data, stack) = stack.make_aligned_with(
+        lwe_list_in.count().0 * fpksk_list.output_polynomial_size().0 / 2
+            * glwe_size.0
+            * glwe_size.0
+            * level_cbs.0,
+        CACHELINE_ALIGN,
+        |_| c64::default(),
+    );
+    let (mut ggsw_res_data, mut stack) = stack.make_aligned_with(
+        fpksk_list.output_polynomial_size().0 * glwe_size.0 * glwe_size.0 * level_cbs.0,
+        CACHELINE_ALIGN,
+        |_| 0u64,
+    );
+
+    let mut alt_ggsw_vec = vec![];
+
+    let mut ggsw_list = FourierGgswCiphertextListMutView::new(
+        &mut ggsw_list_data,
+        lwe_list_in.count().0,
+        fpksk_list.output_polynomial_size(),
+        glwe_size,
+        base_log_cbs,
+        level_cbs,
+    );
+
+    let mut ggsw_res = StandardGgswCiphertext::from_container(
+        &mut *ggsw_res_data,
+        glwe_size,
+        fpksk_list.output_polynomial_size(),
+        base_log_cbs,
+    );
+
+    // let mut fft_engine = FftEngine::new(()).unwrap();
+    for (lwe_in, ggsw) in izip!(
+        lwe_list_in.ciphertext_iter(),
+        ggsw_list.as_mut_view().into_ggsw_iter(),
+    ) {
+        circuit_bootstrap_boolean(
+            fourier_bsk,
+            lwe_in,
+            ggsw_res.as_mut_view(),
+            DeltaLog(64 - 1),
+            fpksk_list,
+            fft,
+            stack.rb_mut(),
+        );
+
+        let ggsw_alt = GgswCiphertext64(StandardGgswCiphertext::from_container(
+            ggsw_res.as_mut_view().into_container().to_vec(),
+            glwe_size,
+            fpksk_list.output_polynomial_size(),
+            base_log_cbs,
+        ));
+        alt_ggsw_vec.push(ggsw_alt);
+
+        ggsw.fill_with_forward_fourier(ggsw_res.as_view(), fft, stack.rb_mut());
+    }
+
+    // We deduce the number of luts in the vec_lut from the number of cipherxtexts in lwe_list_out
+    let number_of_luts = lwe_list_out.count().0;
+
+    let small_lut_size =
+        PolynomialCount(big_lut_as_polynomial_list.polynomial_count().0 / number_of_luts);
+
+    // Convert fourier GGSWs back to standard GGSWs
+    // let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(0))).unwrap();
+
+    // let input = 42_u64;
+    // let plaintext: Plaintext64 = default_engine.create_plaintext_from(&input).unwrap();
+
+    println!("number_of_luts size: {}", number_of_luts);
+    println!(
+        "big_lut_as_polynomial_list size: {}",
+        big_lut_as_polynomial_list.polynomial_count().0
+    );
+    println!("ggsw_list size: {}", ggsw_list.count());
+
+    for (lut, mut lwe_out) in izip!(
+        big_lut_as_polynomial_list.sublist_iter(small_lut_size),
+        lwe_list_out.ciphertext_iter_mut(),
+    ) {
+        let mut h_luts = vec![];
+        for polynomial in lut.polynomial_iter() {
+            let mut poly = polynomial.as_tensor().as_slice().to_vec();
+            let mut h_zeroes = vec![0_u64; fpksk_list.output_polynomial_size().0];
+
+            let mut h_lut = vec![];
+            // Mask is zero
+            h_lut.append(&mut h_zeroes);
+            // Body is something else
+            h_lut.append(&mut poly);
+
+            h_luts.push(h_lut);
+        }
+
+        // let mut lwe_out_cpu = LweCiphertext
+        // vertical_packing(lut, lwe_out.as_mut_view(), ggsw_list.as_view(), fft, stack.rb_mut());
+
+        let mut result = cuda_vertical_packing(
+            &h_luts,
+            &alt_ggsw_vec,
+            level_cbs,
+            base_log_cbs,
+            number_of_luts,
+        );
+        // assert_eq!(result.0.as_mut_view().into_container(),
+        // lwe_out.as_mut_view().into_container());
+        lwe_out.update_with_add(&result.0.as_mut_view());
+    }
+}

--- a/concrete-core/src/backends/cuda/private/wopbs/test.rs
+++ b/concrete-core/src/backends/cuda/private/wopbs/test.rs
@@ -1,8 +1,18 @@
 use crate::backends::cuda::private::device::{CudaStream, GpuIndex};
+use crate::backends::cuda::private::wopbs::{
+    circuit_bootstrap_boolean_cuda_vertical_packing, cuda_vertical_packing,
+};
+use crate::backends::fft::private::crypto::bootstrap::{
+    fill_with_forward_fourier_scratch, FourierLweBootstrapKey,
+};
+use crate::backends::fft::private::crypto::wop_pbs::{
+    circuit_bootstrap_boolean_vertical_packing_scratch, extract_bits, extract_bits_scratch,
+};
+use crate::backends::fft::private::math::fft::Fft;
 use crate::commons::crypto::bootstrap::StandardBootstrapKey;
 use crate::commons::crypto::encoding::{Plaintext, PlaintextList};
 use crate::commons::crypto::ggsw::StandardGgswCiphertext;
-use crate::commons::crypto::glwe::GlweCiphertext;
+use crate::commons::crypto::glwe::{GlweCiphertext, LwePrivateFunctionalPackingKeyswitchKeyList};
 use crate::commons::crypto::lwe::{LweCiphertext, LweKeyswitchKey, LweList};
 use crate::commons::crypto::secret::generators::{
     EncryptionRandomGenerator, SecretRandomGenerator,
@@ -19,6 +29,8 @@ use concrete_cuda::cuda_bind::{
     cuda_cmux_tree_64, cuda_convert_lwe_bootstrap_key_64, cuda_extract_bits_64,
     cuda_initialize_twiddles, cuda_synchronize_device,
 };
+use concrete_fft::c64;
+use dyn_stack::{DynStack, GlobalMemBuffer};
 use std::os::raw::c_void;
 
 #[test]
@@ -404,4 +416,279 @@ pub fn test_cuda_extract_bits() {
     println!("number of tests: {}", number_of_test_runs);
     println!("total_time: {:?}", elapsed);
     println!("average  time {:?}", elapsed / number_of_test_runs);
+}
+
+// Circuit bootstrap + vecrtical packing applying an identity lut
+#[test]
+pub fn test_extract_bit_circuit_bootstrapping_cuda_vertical_packing() {
+    // define settings
+    let polynomial_size = PolynomialSize(1024);
+    let glwe_dimension = GlweDimension(1);
+    let lwe_dimension = LweDimension(481);
+
+    let level_bsk = DecompositionLevelCount(9);
+    let base_log_bsk = DecompositionBaseLog(4);
+
+    let level_pksk = DecompositionLevelCount(9);
+    let base_log_pksk = DecompositionBaseLog(4);
+
+    let level_ksk = DecompositionLevelCount(9);
+    let base_log_ksk = DecompositionBaseLog(1);
+
+    let level_cbs = DecompositionLevelCount(4);
+    let base_log_cbs = DecompositionBaseLog(6);
+    //decomp_size.0 * (output_size.0 + 1) * input_size.0
+    unsafe {
+        cuda_initialize_twiddles(polynomial_size.0 as u32, 0u32);
+    }
+
+    // Value was 0.000_000_000_000_000_221_486_881_160_055_68_513645324585951
+    // But rust indicates it gets truncated anyways to
+    // 0.000_000_000_000_000_221_486_881_160_055_68
+    let std_small = StandardDev::from_standard_dev(0.000_000_000_000_000_221_486_881_160_055_68);
+    // Value was 0.000_061_200_133_780_220_371_345
+    // But rust indicates it gets truncated anyways to
+    // 0.000_061_200_133_780_220_36
+    let std_big = StandardDev::from_standard_dev(0.000_061_200_133_780_220_36);
+
+    const UNSAFE_SECRET: u128 = 0;
+    let mut seeder = UnixSeeder::new(UNSAFE_SECRET);
+
+    let mut secret_generator = SecretRandomGenerator::<SoftwareRandomGenerator>::new(seeder.seed());
+    let mut encryption_generator =
+        EncryptionRandomGenerator::<SoftwareRandomGenerator>::new(seeder.seed(), &mut seeder);
+
+    //create GLWE and LWE secret key
+    let glwe_sk: GlweSecretKey<_, Vec<u64>> =
+        GlweSecretKey::generate_binary(glwe_dimension, polynomial_size, &mut secret_generator);
+    let lwe_small_sk: LweSecretKey<_, Vec<u64>> =
+        LweSecretKey::generate_binary(lwe_dimension, &mut secret_generator);
+
+    let lwe_big_sk = LweSecretKey::binary_from_container(glwe_sk.as_tensor().as_slice());
+
+    // allocation and generation of the key in coef domain:
+    let mut coef_bsk = StandardBootstrapKey::allocate(
+        0u64,
+        glwe_dimension.to_glwe_size(),
+        polynomial_size,
+        level_bsk,
+        base_log_bsk,
+        lwe_dimension,
+    );
+    coef_bsk.fill_with_new_key(
+        &lwe_small_sk,
+        &glwe_sk,
+        Variance(std_small.get_variance()),
+        &mut encryption_generator,
+    );
+    // allocation for the bootstrapping key
+    let mut fourier_bsk = FourierLweBootstrapKey::new(
+        vec![
+            c64::default();
+            lwe_dimension.0 * polynomial_size.0 / 2
+                * level_bsk.0
+                * glwe_dimension.to_glwe_size().0
+                * glwe_dimension.to_glwe_size().0
+        ],
+        lwe_dimension,
+        polynomial_size,
+        glwe_dimension.to_glwe_size(),
+        base_log_bsk,
+        level_bsk,
+    );
+
+    let fft = Fft::new(polynomial_size);
+    let fft = fft.as_view();
+
+    let mut mem = GlobalMemBuffer::new(fill_with_forward_fourier_scratch(fft).unwrap());
+    fourier_bsk.as_mut_view().fill_with_forward_fourier(
+        coef_bsk.as_view(),
+        fft,
+        DynStack::new(&mut mem),
+    );
+
+    let mut ksk_lwe_big_to_small = LweKeyswitchKey::allocate(
+        0u64,
+        level_ksk,
+        base_log_ksk,
+        lwe_big_sk.key_size(),
+        lwe_small_sk.key_size(),
+    );
+    ksk_lwe_big_to_small.fill_with_keyswitch_key(
+        &lwe_big_sk,
+        &lwe_small_sk,
+        Variance(std_big.get_variance()),
+        &mut encryption_generator,
+    );
+
+    // Creation of all the pfksk for the circuit bootstrapping
+    let mut vec_fpksk = LwePrivateFunctionalPackingKeyswitchKeyList::allocate(
+        0u64,
+        level_pksk,
+        base_log_pksk,
+        lwe_big_sk.key_size(),
+        glwe_sk.key_size(),
+        glwe_sk.polynomial_size(),
+        FunctionalPackingKeyswitchKeyCount(glwe_dimension.to_glwe_size().0),
+    );
+
+    vec_fpksk.par_fill_with_fpksk_for_circuit_bootstrap(
+        &lwe_big_sk,
+        &glwe_sk,
+        std_small,
+        &mut encryption_generator,
+    );
+
+    let number_of_bits_in_input_lwe = 10;
+    let number_of_values_to_extract = ExtractedBitsCount(number_of_bits_in_input_lwe);
+
+    let decomposer = SignedDecomposer::new(DecompositionBaseLog(10), DecompositionLevelCount(1));
+
+    // Here even thought the deltas have the same value, they can differ between ciphertexts and lut
+    // so keeping both separate
+    let delta_log = DeltaLog(64 - number_of_values_to_extract.0);
+    let delta_lut = DeltaLog(64 - number_of_values_to_extract.0);
+
+    let number_of_test_runs = 1;
+
+    for run_number in 0..number_of_test_runs {
+        let cleartext =
+            test_tools::random_uint_between(0..2u64.pow(number_of_bits_in_input_lwe as u32));
+
+        println!("{}", cleartext);
+
+        let message = Plaintext(cleartext << delta_log.0);
+        let mut lwe_in =
+            LweCiphertext::allocate(0u64, LweSize(glwe_dimension.0 * polynomial_size.0 + 1));
+        lwe_big_sk.encrypt_lwe(
+            &mut lwe_in,
+            &message,
+            Variance(std_big.get_variance()),
+            &mut encryption_generator,
+        );
+        let mut extracted_bits_lwe_list = LweList::allocate(
+            0u64,
+            ksk_lwe_big_to_small.lwe_size(),
+            CiphertextCount(number_of_values_to_extract.0),
+        );
+
+        let mut mem = GlobalMemBuffer::new(
+            extract_bits_scratch::<u64>(
+                lwe_dimension,
+                ksk_lwe_big_to_small.after_key_size(),
+                fourier_bsk.glwe_size(),
+                polynomial_size,
+                fft,
+            )
+            .unwrap(),
+        );
+        extract_bits(
+            extracted_bits_lwe_list.as_mut_view(),
+            lwe_in.as_view(),
+            ksk_lwe_big_to_small.as_view(),
+            fourier_bsk.as_view(),
+            delta_log,
+            number_of_values_to_extract,
+            fft,
+            DynStack::new(&mut mem),
+        );
+
+        // Decrypt all extracted bit for checking purposes in case of problems
+        for ct in extracted_bits_lwe_list.ciphertext_iter() {
+            let mut decrypted_message = Plaintext(0u64);
+            lwe_small_sk.decrypt_lwe(&mut decrypted_message, &ct);
+            let extract_bit_result =
+                (((decrypted_message.0 as f64) / (1u64 << (63)) as f64).round()) as u64;
+            println!("{:?}", extract_bit_result);
+            println!("{:?}", decrypted_message);
+        }
+
+        // LUT creation
+        let number_of_luts_and_output_vp_ciphertexts = 1;
+        let mut lut_size = polynomial_size.0;
+
+        let lut_poly_list = if run_number % 2 == 0 {
+            // Test with a small lut, only triggering a blind rotate
+            if lut_size < (1 << extracted_bits_lwe_list.count().0) {
+                lut_size = 1 << extracted_bits_lwe_list.count().0;
+            }
+            let mut lut = Vec::with_capacity(lut_size);
+
+            for i in 0..lut_size {
+                lut.push((i as u64 % (1 << (64 - delta_log.0))) << delta_lut.0);
+            }
+
+            // Here we have a single lut, so store it directly in the polynomial list
+            PolynomialList::from_container(lut, PolynomialSize(lut_size))
+        } else {
+            // Test with a big lut, triggering an actual cmux tree
+            let mut lut_poly_list = PolynomialList::allocate(
+                0u64,
+                PolynomialCount(1 << number_of_bits_in_input_lwe),
+                polynomial_size,
+            );
+            for (i, mut polynomial) in lut_poly_list.polynomial_iter_mut().enumerate() {
+                polynomial
+                    .as_mut_tensor()
+                    .fill_with_element((i as u64 % (1 << (64 - delta_log.0))) << delta_lut.0);
+            }
+            lut_poly_list
+        };
+
+        // We need as many output ciphertexts as we have input luts
+        let mut vertical_packing_lwe_list_out = LweList::allocate(
+            0u64,
+            LweDimension(polynomial_size.0 * glwe_dimension.0).to_lwe_size(),
+            CiphertextCount(number_of_luts_and_output_vp_ciphertexts),
+        );
+
+        // Perform circuit bootstrap + vertical packing
+        let mut mem = GlobalMemBuffer::new(
+            circuit_bootstrap_boolean_vertical_packing_scratch::<u64>(
+                extracted_bits_lwe_list.count(),
+                vertical_packing_lwe_list_out.count(),
+                extracted_bits_lwe_list.lwe_size(),
+                lut_poly_list.polynomial_count(),
+                fourier_bsk.output_lwe_dimension().to_lwe_size(),
+                vec_fpksk.output_polynomial_size(),
+                fourier_bsk.glwe_size(),
+                level_cbs,
+                fft,
+            )
+            .unwrap(),
+        );
+        circuit_bootstrap_boolean_cuda_vertical_packing(
+            lut_poly_list.as_view(),
+            fourier_bsk.as_view(),
+            vertical_packing_lwe_list_out.as_mut_view(),
+            extracted_bits_lwe_list.as_view(),
+            vec_fpksk.as_view(),
+            level_cbs,
+            base_log_cbs,
+            fft,
+            DynStack::new(&mut mem),
+        );
+
+        // We have a single output ct
+        let result_ct = vertical_packing_lwe_list_out
+            .ciphertext_iter()
+            .next()
+            .unwrap();
+
+        // decrypt result
+        let mut decrypted_message = Plaintext(0u64);
+        let lwe_sk = LweSecretKey::binary_from_container(glwe_sk.as_tensor().as_slice());
+        lwe_sk.decrypt_lwe(&mut decrypted_message, &result_ct);
+        let decoded_message = decomposer.closest_representable(decrypted_message.0) >> delta_log.0;
+
+        // print information if the result is wrong
+        if decoded_message != cleartext {
+            panic!(
+                "decoded_message ({:?}) != cleartext ({:?})\n\
+                decrypted_message: {:?}, decoded_message: {:?}",
+                decoded_message, cleartext, decrypted_message, decoded_message
+            );
+        }
+        println!("{:?}", decoded_message);
+    }
 }

--- a/concrete-cuda/cuda/include/bootstrap.h
+++ b/concrete-cuda/cuda/include/bootstrap.h
@@ -59,6 +59,12 @@ void cuda_cmux_tree_64(void *v_stream, void *glwe_array_out, void *ggsw_in,
                        uint32_t level_count, uint32_t r,
                        uint32_t max_shared_memory);
 
+void cuda_blind_rotate_and_sample_extraction_64(
+    void *v_stream, void *lwe_out, void *ggsw_in, void *lut_vector,
+    uint32_t mbr_size, uint32_t tau, uint32_t glwe_dimension,
+    uint32_t polynomial_size, uint32_t base_log, uint32_t l_gadget,
+    uint32_t max_shared_memory);
+
 void cuda_extract_bits_32(
     void *v_stream, void *list_lwe_array_out, void *lwe_array_in,
     void *lwe_array_in_buffer, void *lwe_array_in_shifted_buffer,

--- a/concrete-cuda/cuda/src/bootstrap_wop.cu
+++ b/concrete-cuda/cuda/src/bootstrap_wop.cu
@@ -251,3 +251,43 @@ void cuda_extract_bits_64(
     break;
   }
 }
+
+void cuda_blind_rotate_and_sample_extraction_64(
+    void *v_stream, void *lwe_out, void *ggsw_in, void *lut_vector,
+    uint32_t mbr_size, uint32_t tau, uint32_t glwe_dimension,
+    uint32_t polynomial_size, uint32_t base_log, uint32_t l_gadget,
+    uint32_t max_shared_memory) {
+
+  switch (polynomial_size) {
+  case 512:
+    host_blind_rotate_and_sample_extraction<uint64_t, int64_t, Degree<512>>(
+        v_stream, (uint64_t *)lwe_out, (uint64_t *)ggsw_in,
+        (uint64_t *)lut_vector, mbr_size, tau, glwe_dimension, polynomial_size,
+        base_log, l_gadget, max_shared_memory);
+    break;
+  case 1024:
+    host_blind_rotate_and_sample_extraction<uint64_t, int64_t, Degree<1024>>(
+        v_stream, (uint64_t *)lwe_out, (uint64_t *)ggsw_in,
+        (uint64_t *)lut_vector, mbr_size, tau, glwe_dimension, polynomial_size,
+        base_log, l_gadget, max_shared_memory);
+    break;
+  case 2048:
+    host_blind_rotate_and_sample_extraction<uint64_t, int64_t, Degree<2048>>(
+        v_stream, (uint64_t *)lwe_out, (uint64_t *)ggsw_in,
+        (uint64_t *)lut_vector, mbr_size, tau, glwe_dimension, polynomial_size,
+        base_log, l_gadget, max_shared_memory);
+    break;
+  case 4096:
+    host_blind_rotate_and_sample_extraction<uint64_t, int64_t, Degree<4096>>(
+        v_stream, (uint64_t *)lwe_out, (uint64_t *)ggsw_in,
+        (uint64_t *)lut_vector, mbr_size, tau, glwe_dimension, polynomial_size,
+        base_log, l_gadget, max_shared_memory);
+    break;
+  case 8192:
+    host_blind_rotate_and_sample_extraction<uint64_t, int64_t, Degree<8192>>(
+        v_stream, (uint64_t *)lwe_out, (uint64_t *)ggsw_in,
+        (uint64_t *)lut_vector, mbr_size, tau, glwe_dimension, polynomial_size,
+        base_log, l_gadget, max_shared_memory);
+    break;
+  }
+}

--- a/concrete-cuda/cuda/src/crypto/ggsw.cuh
+++ b/concrete-cuda/cuda/src/crypto/ggsw.cuh
@@ -12,6 +12,7 @@ __global__ void batch_fft_ggsw_vectors(double2 *dest, T *src) {
   int offset = blockIdx.x * blockDim.x;
   int tid = threadIdx.x;
   int log_2_opt = params::opt >> 1;
+
 #pragma unroll
   for (int i = 0; i < log_2_opt; i++) {
     ST x = src[(2 * tid) + params::opt * offset];
@@ -31,6 +32,7 @@ __global__ void batch_fft_ggsw_vectors(double2 *dest, T *src) {
 
   // Write the output to global memory
   tid = threadIdx.x;
+#pragma unroll
   for (int j = 0; j < log_2_opt; j++) {
     dest[tid + (params::opt >> 1) * offset] = shared_output[tid];
     tid += params::degree / params::opt;
@@ -50,8 +52,8 @@ void batch_fft_ggsw_vector(void *v_stream, double2 *dest, T *src, uint32_t r,
 
   int shared_memory_size = sizeof(double) * polynomial_size;
 
-  int total_polynomials = r * (glwe_dim + 1) * (glwe_dim + 1) * level_count;
-  int gridSize = total_polynomials;
+  int gridSize = r * (glwe_dim + 1) * (glwe_dim + 1) * level_count;
+  ;
   int blockSize = polynomial_size / params::opt;
 
   batch_fft_ggsw_vectors<T, ST, params>

--- a/concrete-cuda/src/cuda_bind.rs
+++ b/concrete-cuda/src/cuda_bind.rs
@@ -181,6 +181,20 @@ extern "C" {
         max_shared_memory: u32,
     );
 
+    pub fn cuda_blind_rotate_and_sample_extraction_64(
+        v_stream: *const c_void,
+        lwe_out: *mut c_void,
+        ggsw_in: *const c_void,
+        lut_vector: *const c_void,
+        mbr_size: u32,
+        tau: u32,
+        glwe_dimension: u32,
+        polynomial_size: u32,
+        base_log: u32,
+        l_gadget: u32,
+        max_shared_memory: u32,
+    );
+
     pub fn cuda_extract_bits_32(
         v_stream: *const c_void,
         list_lwe_array_out: *mut c_void,


### PR DESCRIPTION
### Resolves: https://github.com/zama-ai/concrete-core-internal/issues/225

### Description
This PR implements the missing parts for the vertical packing on the CUDA backend. It also contains a private test that verifies if it works.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
