### PR TITLE
fix(concrete-cuda): Do not expose cudaStream_t in public API

### DIFF
--- a/concrete-cuda/cuda/include/device.h
+++ b/concrete-cuda/cuda/include/device.h
@@ -7,7 +7,7 @@ int cuda_destroy_stream(void *v_stream, uint32_t gpu_index);
 
 void *cuda_malloc(uint64_t size, uint32_t gpu_index);
 
-void *cuda_malloc_async(uint64_t size, cudaStream_t stream, uint32_t gpu_index);
+void *cuda_malloc_async(uint64_t size, void* v_stream, uint32_t gpu_index);
 
 int cuda_check_valid_malloc(uint64_t size, uint32_t gpu_index);
 
@@ -28,7 +28,7 @@ int cuda_synchronize_device(uint32_t gpu_index);
 
 int cuda_drop(void *ptr, uint32_t gpu_index);
 
-int cuda_drop_async(void *ptr, cudaStream_t stream, uint32_t gpu_index);
+int cuda_drop_async(void *ptr, void* stream, uint32_t gpu_index);
 
 int cuda_get_max_shared_memory(uint32_t gpu_index);
 }

--- a/concrete-cuda/cuda/src/bootstrap_amortized.cuh
+++ b/concrete-cuda/cuda/src/bootstrap_amortized.cuh
@@ -317,7 +317,7 @@ __host__ void host_bootstrap_amortized(
   // of shared memory)
   if (max_shared_memory < SM_PART) {
     d_mem = (char *)cuda_malloc_async(DM_FULL * input_lwe_ciphertext_count,
-                                      *stream, gpu_index);
+                                      v_stream, gpu_index);
     device_bootstrap_amortized<Torus, params, NOSM><<<grid, thds, 0, *stream>>>(
         lwe_array_out, lut_vector, lut_vector_indexes, lwe_array_in,
         bootstrapping_key, d_mem, input_lwe_dimension, polynomial_size,
@@ -328,7 +328,7 @@ __host__ void host_bootstrap_amortized(
     cudaFuncSetCacheConfig(device_bootstrap_amortized<Torus, params, PARTIALSM>,
                            cudaFuncCachePreferShared);
     d_mem = (char *)cuda_malloc_async(DM_PART * input_lwe_ciphertext_count,
-                                      *stream, gpu_index);
+                                      v_stream, gpu_index);
     device_bootstrap_amortized<Torus, params, PARTIALSM>
         <<<grid, thds, SM_PART, *stream>>>(
             lwe_array_out, lut_vector, lut_vector_indexes, lwe_array_in,
@@ -346,7 +346,7 @@ __host__ void host_bootstrap_amortized(
     checkCudaErrors(cudaFuncSetCacheConfig(
         device_bootstrap_amortized<Torus, params, FULLSM>,
         cudaFuncCachePreferShared));
-    d_mem = (char *)cuda_malloc_async(0, *stream, gpu_index);
+    d_mem = (char *)cuda_malloc_async(0, v_stream, gpu_index);
 
     device_bootstrap_amortized<Torus, params, FULLSM>
         <<<grid, thds, SM_FULL, *stream>>>(
@@ -359,7 +359,7 @@ __host__ void host_bootstrap_amortized(
   // Synchronize the streams before copying the result to lwe_array_out at the
   // right place
   cudaStreamSynchronize(*stream);
-  cuda_drop_async(d_mem, *stream, gpu_index);
+  cuda_drop_async(d_mem, v_stream, gpu_index);
 }
 
 template <typename Torus, class params>

--- a/concrete-cuda/cuda/src/bootstrap_low_latency.cuh
+++ b/concrete-cuda/cuda/src/bootstrap_low_latency.cuh
@@ -258,9 +258,9 @@ __host__ void host_bootstrap_low_latency(
   int buffer_size_per_gpu =
       level_count * num_samples * polynomial_size / 2 * sizeof(double2);
   double2 *mask_buffer_fft =
-      (double2 *)cuda_malloc_async(buffer_size_per_gpu, *stream, gpu_index);
+      (double2 *)cuda_malloc_async(buffer_size_per_gpu, v_stream, gpu_index);
   double2 *body_buffer_fft =
-      (double2 *)cuda_malloc_async(buffer_size_per_gpu, *stream, gpu_index);
+      (double2 *)cuda_malloc_async(buffer_size_per_gpu, v_stream, gpu_index);
 
   int bytes_needed = sizeof(Torus) * polynomial_size + // accumulator_rotated
                      sizeof(Torus) * polynomial_size + // accumulator
@@ -293,9 +293,9 @@ __host__ void host_bootstrap_low_latency(
 
   // Synchronize the streams before copying the result to lwe_array_out at the
   // right place
-  cudaStreamSynchronize(*stream);
-  cuda_drop_async(mask_buffer_fft, *stream, gpu_index);
-  cuda_drop_async(body_buffer_fft, *stream, gpu_index);
+  cudaStreamSynchronize(*stream)
+  cuda_drop_async(mask_buffer_fft, v_stream, gpu_index);
+  cuda_drop_async(body_buffer_fft, v_stream, gpu_index);
 }
 
 #endif // LOWLAT_PBS_H

--- a/concrete-cuda/cuda/src/bootstrap_low_latency.cuh
+++ b/concrete-cuda/cuda/src/bootstrap_low_latency.cuh
@@ -293,7 +293,7 @@ __host__ void host_bootstrap_low_latency(
 
   // Synchronize the streams before copying the result to lwe_array_out at the
   // right place
-  cudaStreamSynchronize(*stream)
+  cudaStreamSynchronize(*stream);
   cuda_drop_async(mask_buffer_fft, v_stream, gpu_index);
   cuda_drop_async(body_buffer_fft, v_stream, gpu_index);
 }

--- a/concrete-cuda/cuda/src/crypto/bootstrapping_key.cuh
+++ b/concrete-cuda/cuda/src/crypto/bootstrapping_key.cuh
@@ -117,65 +117,65 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
   switch (polynomial_size) {
   case 512:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
-      buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      buffer = (double2 *)cuda_malloc_async(0, v_stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<512>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
-          shared_memory_size * total_polynomials, *stream, gpu_index);
+          shared_memory_size * total_polynomials, v_stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<512>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
   case 1024:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
-      buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      buffer = (double2 *)cuda_malloc_async(0, v_stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<1024>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
-          shared_memory_size * total_polynomials, *stream, gpu_index);
+          shared_memory_size * total_polynomials, v_stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<1024>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
   case 2048:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
-      buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      buffer = (double2 *)cuda_malloc_async(0, v_stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<2048>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
-          shared_memory_size * total_polynomials, *stream, gpu_index);
+          shared_memory_size * total_polynomials, v_stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<2048>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
   case 4096:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
-      buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      buffer = (double2 *)cuda_malloc_async(0, v_stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<4096>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
-          shared_memory_size * total_polynomials, *stream, gpu_index);
+          shared_memory_size * total_polynomials, v_stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<4096>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
   case 8192:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
-      buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      buffer = (double2 *)cuda_malloc_async(0, v_stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<8192>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
-          shared_memory_size * total_polynomials, *stream, gpu_index);
+          shared_memory_size * total_polynomials, v_stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<8192>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
@@ -184,8 +184,8 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
     break;
   }
 
-  cuda_drop_async(d_bsk, *stream, gpu_index);
-  cuda_drop_async(buffer, *stream, gpu_index);
+  cuda_drop_async(d_bsk, v_stream, gpu_index);
+  cuda_drop_async(buffer, v_stream, gpu_index);
   free(h_bsk);
 }
 

--- a/concrete-cuda/cuda/src/device.cu
+++ b/concrete-cuda/cuda/src/device.cu
@@ -33,8 +33,9 @@ void *cuda_malloc(uint64_t size, uint32_t gpu_index) {
 
 /// Allocates a size-byte array at the device memory. Tries to do it
 /// asynchronously.
-void *cuda_malloc_async(uint64_t size, cudaStream_t stream,
+void *cuda_malloc_async(uint64_t size, void* v_stream,
                         uint32_t gpu_index) {
+  auto stream = static_cast<cudaStream_t *>(v_stream);
   void *ptr;
 
   int support_async_alloc;
@@ -42,7 +43,7 @@ void *cuda_malloc_async(uint64_t size, cudaStream_t stream,
       &support_async_alloc, cudaDevAttrMemoryPoolsSupported, gpu_index));
 
   if (support_async_alloc)
-    checkCudaErrors(cudaMallocAsync((void **)&ptr, size, stream));
+    checkCudaErrors(cudaMallocAsync((void **)&ptr, size, *stream));
   else
     checkCudaErrors(cudaMalloc((void **)&ptr, size));
   return ptr;
@@ -158,14 +159,14 @@ int cuda_drop(void *ptr, uint32_t gpu_index) {
 }
 
 /// Drop a cuda array. Tries to do it asynchronously
-int cuda_drop_async(void *ptr, cudaStream_t stream, uint32_t gpu_index) {
-
+int cuda_drop_async(void *ptr, void* v_stream, uint32_t gpu_index) {
+  auto stream = static_cast<cudaStream_t *>(v_stream);
   int support_async_alloc;
   checkCudaErrors(cudaDeviceGetAttribute(
       &support_async_alloc, cudaDevAttrMemoryPoolsSupported, gpu_index));
 
   if (support_async_alloc)
-    checkCudaErrors(cudaFreeAsync(ptr, stream));
+    checkCudaErrors(cudaFreeAsync(ptr, *stream));
   else
     checkCudaErrors(cudaFree(ptr));
   return 0;


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1c9Ng7Cig8RkmxhEkdFxKrJJqqarskD5I%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=SnbZyQt)

The type cudaStream_t was used in device.h header file and never defined, that leads to error when the header file was include by the compiler runtime. I follow the same pattern than the other function that takes stream to avoid exposing cudaStream_t directly.
