### PR TITLE
Fix Cuda amortized bootstrap bug with N=8192

### DIFF
--- a/concrete-core/src/backends/cuda/implementation/entities/plaintext_vector.rs
+++ b/concrete-core/src/backends/cuda/implementation/entities/plaintext_vector.rs
@@ -2,8 +2,6 @@ use crate::backends::cuda::private::crypto::plaintext::list::CudaPlaintextList;
 use crate::prelude::PlaintextCount;
 use crate::specification::entities::markers::PlaintextVectorKind;
 use crate::specification::entities::{AbstractEntity, PlaintextVectorEntity};
-#[cfg(feature = "backend_default_serialization")]
-use serde::{Deserialize, Serialize};
 
 /// A structure representing a vector of plaintexts with 32 bits of precision.
 #[derive(Debug)]

--- a/concrete-core/src/backends/cuda/private/crypto/bootstrap/test.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/bootstrap/test.rs
@@ -4,7 +4,6 @@ mod cuda_unit_test_pbs {
     use crate::commons::test_tools::new_random_generator;
     use crate::prelude::*;
     use std::error::Error;
-    use std::ffi::c_void;
 
     fn generate_accumulator_with_engine<F>(
         engine: &mut DefaultEngine,

--- a/concrete-core/src/backends/cuda/private/crypto/bootstrap/test.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/bootstrap/test.rs
@@ -58,12 +58,17 @@ mod cuda_unit_test_pbs {
     }
 
     #[test]
-    fn cuda_test_pbs() -> Result<(), Box<dyn Error>> {
+    fn cuda_test_amortized_pbs() -> Result<(), Box<dyn Error>> {
         println!("cuda_test_pbs");
         // Shortint 2_2 params
-        let lwe_dimension = LweDimension(742);
+        let lwe_dimension = LweDimension(500);
         let glwe_dimension = GlweDimension(1);
-        let polynomial_size = PolynomialSize(2048);
+        let polynomial_sizes = vec![
+            PolynomialSize(1024),
+            PolynomialSize(2048),
+            PolynomialSize(4096),
+            PolynomialSize(8192),
+        ];
         let lwe_modular_std_dev = StandardDev(0.000007069849454709433);
         let glwe_modular_std_dev = StandardDev(0.00000000000000029403601535432533);
         let pbs_base_log = DecompositionBaseLog(23);
@@ -92,206 +97,453 @@ mod cuda_unit_test_pbs {
         let mut error_sample_vec = Vec::<u64>::with_capacity(repetitions * samples);
 
         let mut generator = new_random_generator();
+        for &polynomial_size in polynomial_sizes.iter() {
+            for _ in 0..repetitions {
+                // Generate client-side keys
 
-        for _ in 0..repetitions {
-            // Generate client-side keys
+                // generate the lwe secret key
+                let small_lwe_secret_key: LweSecretKey64 =
+                    default_engine.generate_new_lwe_secret_key(lwe_dimension)?;
 
-            // generate the lwe secret key
-            let small_lwe_secret_key: LweSecretKey64 =
-                default_engine.generate_new_lwe_secret_key(lwe_dimension)?;
+                // generate the rlwe secret key
+                let glwe_secret_key: GlweSecretKey64 =
+                    default_engine.generate_new_glwe_secret_key(glwe_dimension, polynomial_size)?;
 
-            // generate the rlwe secret key
-            let glwe_secret_key: GlweSecretKey64 =
-                default_engine.generate_new_glwe_secret_key(glwe_dimension, polynomial_size)?;
+                let large_lwe_secret_key = default_engine
+                    .transform_glwe_secret_key_to_lwe_secret_key(glwe_secret_key.clone())?;
 
-            let large_lwe_secret_key = default_engine
-                .transform_glwe_secret_key_to_lwe_secret_key(glwe_secret_key.clone())?;
+                // Convert into a variance for rlwe context
+                let var_rlwe = Variance(glwe_modular_std_dev.get_variance());
 
-            // Convert into a variance for rlwe context
-            let var_rlwe = Variance(glwe_modular_std_dev.get_variance());
+                let bootstrap_key: LweBootstrapKey64 = default_parallel_engine
+                    .generate_new_lwe_bootstrap_key(
+                        &small_lwe_secret_key,
+                        &glwe_secret_key,
+                        pbs_base_log,
+                        pbs_level,
+                        var_rlwe,
+                    )?;
 
-            let bootstrap_key: LweBootstrapKey64 = default_parallel_engine
-                .generate_new_lwe_bootstrap_key(
-                    &small_lwe_secret_key,
-                    &glwe_secret_key,
-                    pbs_base_log,
-                    pbs_level,
-                    var_rlwe,
-                )?;
+                // Creation of the bootstrapping key in the Fourier domain
 
-            // Creation of the bootstrapping key in the Fourier domain
+                // cuda
+                let mut h_coef_bsk: Vec<u64> = vec![];
+                h_coef_bsk.append(&mut bootstrap_key.0.tensor.as_slice().to_vec());
 
-            // cuda
-            let mut h_coef_bsk: Vec<u64> = vec![];
-            h_coef_bsk.append(&mut bootstrap_key.0.tensor.as_slice().to_vec());
+                let gpu_index = crate::backends::cuda::private::device::GpuIndex(0);
+                let stream =
+                    crate::backends::cuda::private::device::CudaStream::new(gpu_index).unwrap();
 
-            let gpu_index = crate::backends::cuda::private::device::GpuIndex(0);
-            let stream =
-                crate::backends::cuda::private::device::CudaStream::new(gpu_index).unwrap();
+                let mut h_lut_vector_indexes = vec![0 as u32; 1];
+                let mut d_lut_vector_indexes = stream.malloc::<u32>(1);
+                let mut d_lut_pbs = stream.malloc::<u64>((2 * polynomial_size.0) as u32);
+                let mut d_lwe_in = stream.malloc::<u64>((lwe_dimension.0 + 1) as u32);
+                let mut d_lwe_out = stream.malloc::<u64>((polynomial_size.0 + 1) as u32);
 
-            let mut h_lut_vector_indexes = vec![0 as u32; 1];
-            let mut d_lut_vector_indexes = stream.malloc::<u32>(1);
-            let mut d_lut_pbs = stream.malloc::<u64>((2 * polynomial_size.0) as u32);
-            let mut d_lwe_in = stream.malloc::<u64>((lwe_dimension.0 + 1) as u32);
-            let mut d_lwe_out = stream.malloc::<u64>((polynomial_size.0 + 1) as u32);
+                let bsk_size = (glwe_dimension.0 + 1)
+                    * (glwe_dimension.0 + 1)
+                    * polynomial_size.0
+                    * pbs_level.0
+                    * lwe_dimension.0;
 
-            let bsk_size = (glwe_dimension.0 + 1)
-                * (glwe_dimension.0 + 1)
-                * polynomial_size.0
-                * pbs_level.0
-                * lwe_dimension.0;
-
-            let mut d_bsk_fourier = stream.malloc::<f64>(bsk_size as u32);
-
-            unsafe {
-                concrete_cuda::cuda_bind::cuda_initialize_twiddles(
-                    polynomial_size.0 as u32,
-                    gpu_index.0 as u32,
-                );
-                concrete_cuda::cuda_bind::cuda_convert_lwe_bootstrap_key_64(
-                    d_bsk_fourier.as_mut_c_ptr(),
-                    h_coef_bsk.as_ptr() as *mut std::os::raw::c_void,
-                    stream.stream_handle().0,
-                    gpu_index.0 as u32,
-                    lwe_dimension.0 as u32,
-                    glwe_dimension.0 as u32,
-                    pbs_level.0 as u32,
-                    polynomial_size.0 as u32,
-                );
-                stream.copy_to_gpu::<u32>(&mut d_lut_vector_indexes, &mut h_lut_vector_indexes);
-            }
-
-            let fourier_bsk: FftFourierLweBootstrapKey64 =
-                fft_engine.convert_lwe_bootstrap_key(&bootstrap_key)?;
-
-            let accumulator = generate_accumulator_with_engine(
-                &mut default_engine,
-                &fourier_bsk,
-                message_modulus,
-                carry_modulus,
-                |x| x,
-            )?;
-
-            unsafe {
-                stream.copy_to_gpu::<u64>(
-                    &mut d_lut_pbs,
-                    &mut accumulator.0.tensor.as_slice().to_vec(),
-                );
-            }
-
-            // convert into a variance
-            let var_lwe = Variance(lwe_modular_std_dev.get_variance());
-
-            for _ in 0..samples {
-                let input_plaintext: u64 =
-                    (generator.random_uniform::<u64>() % payload_modulus) << delta;
-
-                let plaintext = default_engine.create_plaintext_from(&input_plaintext)?;
-                let input = default_engine.encrypt_lwe_ciphertext(
-                    &small_lwe_secret_key,
-                    &plaintext,
-                    var_lwe,
-                )?;
-
-                let mut output =
-                    default_engine.zero_encrypt_lwe_ciphertext(&large_lwe_secret_key, var_lwe)?;
+                let mut d_bsk_fourier = stream.malloc::<f64>(bsk_size as u32);
 
                 unsafe {
-                    stream
-                        .copy_to_gpu::<u64>(&mut d_lwe_in, &mut input.0.tensor.as_slice().to_vec());
-                }
-
-                unsafe {
-                    concrete_cuda::cuda_bind::cuda_bootstrap_amortized_lwe_ciphertext_vector_64(
+                    concrete_cuda::cuda_bind::cuda_initialize_twiddles(
+                        polynomial_size.0 as u32,
+                        gpu_index.0 as u32,
+                    );
+                    concrete_cuda::cuda_bind::cuda_convert_lwe_bootstrap_key_64(
+                        d_bsk_fourier.as_mut_c_ptr(),
+                        h_coef_bsk.as_ptr() as *mut std::os::raw::c_void,
                         stream.stream_handle().0,
                         gpu_index.0 as u32,
-                        d_lwe_out.as_mut_c_ptr(),
-                        d_lut_pbs.as_c_ptr(),
-                        d_lut_vector_indexes.as_c_ptr(),
-                        d_lwe_in.as_c_ptr(),
-                        d_bsk_fourier.as_c_ptr(),
                         lwe_dimension.0 as u32,
                         glwe_dimension.0 as u32,
-                        polynomial_size.0 as u32,
-                        pbs_base_log.0 as u32,
                         pbs_level.0 as u32,
-                        1,
-                        1,
-                        0,
-                        stream.get_max_shared_memory().unwrap() as u32,
+                        polynomial_size.0 as u32,
+                    );
+                    stream.copy_to_gpu::<u32>(&mut d_lut_vector_indexes, &mut h_lut_vector_indexes);
+                }
+
+                let fourier_bsk: FftFourierLweBootstrapKey64 =
+                    fft_engine.convert_lwe_bootstrap_key(&bootstrap_key)?;
+
+                let accumulator = generate_accumulator_with_engine(
+                    &mut default_engine,
+                    &fourier_bsk,
+                    message_modulus,
+                    carry_modulus,
+                    |x| x,
+                )?;
+
+                unsafe {
+                    stream.copy_to_gpu::<u64>(
+                        &mut d_lut_pbs,
+                        &mut accumulator.0.tensor.as_slice().to_vec(),
                     );
                 }
-                println!("h_test_vector: {:?}", accumulator.0.get_body().tensor);
-                fft_engine.discard_bootstrap_lwe_ciphertext(
-                    &mut output,
-                    &input,
-                    &accumulator,
-                    &fourier_bsk,
-                )?;
-                println!("h_lwe_out: {:?}", output.0.tensor);
-                let mut h_output: Vec<u64> = vec![0; polynomial_size.0 + 1];
-                unsafe {
-                    stream.copy_to_cpu::<u64>(&mut h_output, &mut d_lwe_out);
+
+                // convert into a variance
+                let var_lwe = Variance(lwe_modular_std_dev.get_variance());
+
+                for _ in 0..samples {
+                    let input_plaintext: u64 =
+                        (generator.random_uniform::<u64>() % payload_modulus) << delta;
+
+                    let plaintext = default_engine.create_plaintext_from(&input_plaintext)?;
+                    let input = default_engine.encrypt_lwe_ciphertext(
+                        &small_lwe_secret_key,
+                        &plaintext,
+                        var_lwe,
+                    )?;
+
+                    let mut output = default_engine
+                        .zero_encrypt_lwe_ciphertext(&large_lwe_secret_key, var_lwe)?;
+
+                    unsafe {
+                        stream.copy_to_gpu::<u64>(
+                            &mut d_lwe_in,
+                            &mut input.0.tensor.as_slice().to_vec(),
+                        );
+                    }
+
+                    unsafe {
+                        concrete_cuda::cuda_bind::cuda_bootstrap_amortized_lwe_ciphertext_vector_64(
+                            stream.stream_handle().0,
+                            gpu_index.0 as u32,
+                            d_lwe_out.as_mut_c_ptr(),
+                            d_lut_pbs.as_c_ptr(),
+                            d_lut_vector_indexes.as_c_ptr(),
+                            d_lwe_in.as_c_ptr(),
+                            d_bsk_fourier.as_c_ptr(),
+                            lwe_dimension.0 as u32,
+                            glwe_dimension.0 as u32,
+                            polynomial_size.0 as u32,
+                            pbs_base_log.0 as u32,
+                            pbs_level.0 as u32,
+                            1,
+                            1,
+                            0,
+                            stream.get_max_shared_memory().unwrap() as u32,
+                        );
+                    }
+                    //println!("h_test_vector: {:?}", accumulator.0.get_body().tensor);
+                    //fft_engine.discard_bootstrap_lwe_ciphertext(
+                    //    &mut output,
+                    //    &input,
+                    //    &accumulator,
+                    //    &fourier_bsk,
+                    //)?;
+                    //println!("h_lwe_out: {:?}", output.0.tensor);
+                    let mut h_output: Vec<u64> = vec![0; polynomial_size.0 + 1];
+                    unsafe {
+                        stream.copy_to_cpu::<u64>(&mut h_output, &mut d_lwe_out);
+                    }
+                    output.0.tensor.as_mut_container().clone_from(&h_output);
+                    //println!("h_output: {:?}", output);
+                    // decryption
+                    let decrypted =
+                        default_engine.decrypt_lwe_ciphertext(&large_lwe_secret_key, &output)?;
+
+                    if decrypted == plaintext {
+                        panic!("Equal {decrypted:?}, {plaintext:?}");
+                    }
+
+                    let mut decrypted_u64: u64 = 0;
+                    default_engine.discard_retrieve_plaintext(&mut decrypted_u64, &decrypted)?;
+
+                    // let err = if decrypted_u64 >= input_plaintext {
+                    //     decrypted_u64 - input_plaintext
+                    // } else {
+                    //     input_plaintext - decrypted_u64
+                    // };
+
+                    let err = {
+                        let d0 = decrypted_u64.wrapping_sub(input_plaintext);
+                        let d1 = input_plaintext.wrapping_sub(decrypted_u64);
+                        std::cmp::min(d0, d1)
+                    };
+
+                    // let err = torus_modular_distance(input_plaintext, decrypted_u64);
+
+                    error_sample_vec.push(err);
+
+                    //The bit before the message
+                    let rounding_bit = delta >> 1;
+
+                    //compute the rounding bit
+                    let rounding = (decrypted_u64 & rounding_bit) << 1;
+
+                    let decoded = (decrypted_u64.wrapping_add(rounding)) / delta;
+
+                    assert_eq!(decoded, input_plaintext / delta);
                 }
-                output.0.tensor.as_mut_container().clone_from(&h_output);
-                println!("h_output: {:?}", output);
-                // decryption
-                let decrypted =
-                    default_engine.decrypt_lwe_ciphertext(&large_lwe_secret_key, &output)?;
-
-                if decrypted == plaintext {
-                    panic!("Equal {decrypted:?}, {plaintext:?}");
-                }
-
-                let mut decrypted_u64: u64 = 0;
-                default_engine.discard_retrieve_plaintext(&mut decrypted_u64, &decrypted)?;
-
-                // let err = if decrypted_u64 >= input_plaintext {
-                //     decrypted_u64 - input_plaintext
-                // } else {
-                //     input_plaintext - decrypted_u64
-                // };
-
-                let err = {
-                    let d0 = decrypted_u64.wrapping_sub(input_plaintext);
-                    let d1 = input_plaintext.wrapping_sub(decrypted_u64);
-                    std::cmp::min(d0, d1)
-                };
-
-                // let err = torus_modular_distance(input_plaintext, decrypted_u64);
-
-                error_sample_vec.push(err);
-
-                //The bit before the message
-                let rounding_bit = delta >> 1;
-
-                //compute the rounding bit
-                let rounding = (decrypted_u64 & rounding_bit) << 1;
-
-                let decoded = (decrypted_u64.wrapping_add(rounding)) / delta;
-
-                assert_eq!(decoded, input_plaintext / delta);
             }
+
+            error_sample_vec.sort();
+
+            let bit_errors: Vec<_> = error_sample_vec
+                .iter()
+                .map(|&x| if x != 0 { 63 - x.leading_zeros() } else { 0 })
+                .collect();
+
+            let mean_bit_errors: u32 = bit_errors.iter().sum::<u32>() / bit_errors.len() as u32;
+            let mean_bit_errors_f64: f64 =
+                bit_errors.iter().map(|&x| x as f64).sum::<f64>() / bit_errors.len() as f64;
+
+            for (idx, (&val, &bit_error)) in
+                error_sample_vec.iter().zip(bit_errors.iter()).enumerate()
+            {
+                println!("#{idx}: Error {val}, bit_error {bit_error}");
+            }
+
+            println!("Mean bit error: {mean_bit_errors}");
+            println!("Mean bit error f64: {mean_bit_errors_f64}");
         }
 
-        error_sample_vec.sort();
+        Ok(())
+    }
 
-        let bit_errors: Vec<_> = error_sample_vec
-            .iter()
-            .map(|&x| if x != 0 { 63 - x.leading_zeros() } else { 0 })
-            .collect();
+    #[test]
+    fn cuda_test_low_lat_pbs() -> Result<(), Box<dyn Error>> {
+        println!("cuda_test_pbs");
+        // Shortint 2_2 params
+        let lwe_dimension = LweDimension(742);
+        let glwe_dimension = GlweDimension(1);
+        let polynomial_sizes = vec![PolynomialSize(1024), PolynomialSize(2048)];
+        let lwe_modular_std_dev = StandardDev(0.000007069849454709433);
+        let glwe_modular_std_dev = StandardDev(0.00000000000000029403601535432533);
+        let pbs_base_log = DecompositionBaseLog(23);
+        let pbs_level = DecompositionLevelCount(2);
+        let message_modulus: usize = 4;
+        let carry_modulus: usize = 4;
 
-        let mean_bit_errors: u32 = bit_errors.iter().sum::<u32>() / bit_errors.len() as u32;
-        let mean_bit_errors_f64: f64 =
-            bit_errors.iter().map(|&x| x as f64).sum::<f64>() / bit_errors.len() as f64;
+        let payload_modulus = (message_modulus * carry_modulus) as u64;
 
-        for (idx, (&val, &bit_error)) in error_sample_vec.iter().zip(bit_errors.iter()).enumerate()
-        {
-            println!("#{idx}: Error {val}, bit_error {bit_error}");
+        // Value of the shift we multiply our messages by
+        let delta = (1_u64 << 63) / payload_modulus;
+
+        // Unix seeder must be given a secret input.
+        // Here we just give it 0, which is totally unsafe.
+        const UNSAFE_SECRET: u128 = 0;
+
+        let mut default_engine = DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+        let mut fft_engine = FftEngine::new(())?;
+
+        let mut default_parallel_engine =
+            DefaultParallelEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET)))?;
+
+        let repetitions = 1;
+        let samples = 1;
+
+        let mut error_sample_vec = Vec::<u64>::with_capacity(repetitions * samples);
+
+        let mut generator = new_random_generator();
+        for &polynomial_size in polynomial_sizes.iter() {
+            for _ in 0..repetitions {
+                // Generate client-side keys
+
+                // generate the lwe secret key
+                let small_lwe_secret_key: LweSecretKey64 =
+                    default_engine.generate_new_lwe_secret_key(lwe_dimension)?;
+
+                // generate the rlwe secret key
+                let glwe_secret_key: GlweSecretKey64 =
+                    default_engine.generate_new_glwe_secret_key(glwe_dimension, polynomial_size)?;
+
+                let large_lwe_secret_key = default_engine
+                    .transform_glwe_secret_key_to_lwe_secret_key(glwe_secret_key.clone())?;
+
+                // Convert into a variance for rlwe context
+                let var_rlwe = Variance(glwe_modular_std_dev.get_variance());
+
+                let bootstrap_key: LweBootstrapKey64 = default_parallel_engine
+                    .generate_new_lwe_bootstrap_key(
+                        &small_lwe_secret_key,
+                        &glwe_secret_key,
+                        pbs_base_log,
+                        pbs_level,
+                        var_rlwe,
+                    )?;
+
+                // Creation of the bootstrapping key in the Fourier domain
+
+                // cuda
+                let mut h_coef_bsk: Vec<u64> = vec![];
+                h_coef_bsk.append(&mut bootstrap_key.0.tensor.as_slice().to_vec());
+
+                let gpu_index = crate::backends::cuda::private::device::GpuIndex(0);
+                let stream =
+                    crate::backends::cuda::private::device::CudaStream::new(gpu_index).unwrap();
+
+                let mut h_lut_vector_indexes = vec![0 as u32; 1];
+                let mut d_lut_vector_indexes = stream.malloc::<u32>(1);
+                let mut d_lut_pbs = stream.malloc::<u64>((2 * polynomial_size.0) as u32);
+                let mut d_lwe_in = stream.malloc::<u64>((lwe_dimension.0 + 1) as u32);
+                let mut d_lwe_out = stream.malloc::<u64>((polynomial_size.0 + 1) as u32);
+
+                let bsk_size = (glwe_dimension.0 + 1)
+                    * (glwe_dimension.0 + 1)
+                    * polynomial_size.0
+                    * pbs_level.0
+                    * lwe_dimension.0;
+
+                let mut d_bsk_fourier = stream.malloc::<f64>(bsk_size as u32);
+
+                unsafe {
+                    concrete_cuda::cuda_bind::cuda_initialize_twiddles(
+                        polynomial_size.0 as u32,
+                        gpu_index.0 as u32,
+                    );
+                    concrete_cuda::cuda_bind::cuda_convert_lwe_bootstrap_key_64(
+                        d_bsk_fourier.as_mut_c_ptr(),
+                        h_coef_bsk.as_ptr() as *mut std::os::raw::c_void,
+                        stream.stream_handle().0,
+                        gpu_index.0 as u32,
+                        lwe_dimension.0 as u32,
+                        glwe_dimension.0 as u32,
+                        pbs_level.0 as u32,
+                        polynomial_size.0 as u32,
+                    );
+                    stream.copy_to_gpu::<u32>(&mut d_lut_vector_indexes, &mut h_lut_vector_indexes);
+                }
+
+                let fourier_bsk: FftFourierLweBootstrapKey64 =
+                    fft_engine.convert_lwe_bootstrap_key(&bootstrap_key)?;
+
+                let accumulator = generate_accumulator_with_engine(
+                    &mut default_engine,
+                    &fourier_bsk,
+                    message_modulus,
+                    carry_modulus,
+                    |x| x,
+                )?;
+
+                unsafe {
+                    stream.copy_to_gpu::<u64>(
+                        &mut d_lut_pbs,
+                        &mut accumulator.0.tensor.as_slice().to_vec(),
+                    );
+                }
+
+                // convert into a variance
+                let var_lwe = Variance(lwe_modular_std_dev.get_variance());
+
+                for _ in 0..samples {
+                    let input_plaintext: u64 =
+                        (generator.random_uniform::<u64>() % payload_modulus) << delta;
+
+                    let plaintext = default_engine.create_plaintext_from(&input_plaintext)?;
+                    let input = default_engine.encrypt_lwe_ciphertext(
+                        &small_lwe_secret_key,
+                        &plaintext,
+                        var_lwe,
+                    )?;
+
+                    let mut output = default_engine
+                        .zero_encrypt_lwe_ciphertext(&large_lwe_secret_key, var_lwe)?;
+
+                    unsafe {
+                        stream.copy_to_gpu::<u64>(
+                            &mut d_lwe_in,
+                            &mut input.0.tensor.as_slice().to_vec(),
+                        );
+                    }
+
+                    unsafe {
+                        concrete_cuda::cuda_bind::cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
+                            stream.stream_handle().0,
+                            gpu_index.0 as u32,
+                            d_lwe_out.as_mut_c_ptr(),
+                            d_lut_pbs.as_c_ptr(),
+                            d_lut_vector_indexes.as_c_ptr(),
+                            d_lwe_in.as_c_ptr(),
+                            d_bsk_fourier.as_c_ptr(),
+                            lwe_dimension.0 as u32,
+                            glwe_dimension.0 as u32,
+                            polynomial_size.0 as u32,
+                            pbs_base_log.0 as u32,
+                            pbs_level.0 as u32,
+                            1,
+                            1,
+                            0,
+                            stream.get_max_shared_memory().unwrap() as u32,
+                        );
+                    }
+                    //println!("h_test_vector: {:?}", accumulator.0.get_body().tensor);
+                    //fft_engine.discard_bootstrap_lwe_ciphertext(
+                    //    &mut output,
+                    //    &input,
+                    //    &accumulator,
+                    //    &fourier_bsk,
+                    //)?;
+                    //println!("h_lwe_out: {:?}", output.0.tensor);
+                    let mut h_output: Vec<u64> = vec![0; polynomial_size.0 + 1];
+                    unsafe {
+                        stream.copy_to_cpu::<u64>(&mut h_output, &mut d_lwe_out);
+                    }
+                    output.0.tensor.as_mut_container().clone_from(&h_output);
+                    //println!("h_output: {:?}", output);
+                    // decryption
+                    let decrypted =
+                        default_engine.decrypt_lwe_ciphertext(&large_lwe_secret_key, &output)?;
+
+                    if decrypted == plaintext {
+                        panic!("Equal {decrypted:?}, {plaintext:?}");
+                    }
+
+                    let mut decrypted_u64: u64 = 0;
+                    default_engine.discard_retrieve_plaintext(&mut decrypted_u64, &decrypted)?;
+
+                    // let err = if decrypted_u64 >= input_plaintext {
+                    //     decrypted_u64 - input_plaintext
+                    // } else {
+                    //     input_plaintext - decrypted_u64
+                    // };
+
+                    let err = {
+                        let d0 = decrypted_u64.wrapping_sub(input_plaintext);
+                        let d1 = input_plaintext.wrapping_sub(decrypted_u64);
+                        std::cmp::min(d0, d1)
+                    };
+
+                    // let err = torus_modular_distance(input_plaintext, decrypted_u64);
+
+                    error_sample_vec.push(err);
+
+                    //The bit before the message
+                    let rounding_bit = delta >> 1;
+
+                    //compute the rounding bit
+                    let rounding = (decrypted_u64 & rounding_bit) << 1;
+
+                    let decoded = (decrypted_u64.wrapping_add(rounding)) / delta;
+
+                    assert_eq!(decoded, input_plaintext / delta);
+                }
+            }
+
+            error_sample_vec.sort();
+
+            let bit_errors: Vec<_> = error_sample_vec
+                .iter()
+                .map(|&x| if x != 0 { 63 - x.leading_zeros() } else { 0 })
+                .collect();
+
+            let mean_bit_errors: u32 = bit_errors.iter().sum::<u32>() / bit_errors.len() as u32;
+            let mean_bit_errors_f64: f64 =
+                bit_errors.iter().map(|&x| x as f64).sum::<f64>() / bit_errors.len() as f64;
+
+            for (idx, (&val, &bit_error)) in
+                error_sample_vec.iter().zip(bit_errors.iter()).enumerate()
+            {
+                println!("#{idx}: Error {val}, bit_error {bit_error}");
+            }
+
+            println!("Mean bit error: {mean_bit_errors}");
+            println!("Mean bit error f64: {mean_bit_errors_f64}");
         }
-
-        println!("Mean bit error: {mean_bit_errors}");
-        println!("Mean bit error f64: {mean_bit_errors_f64}");
 
         Ok(())
     }

--- a/concrete-core/src/backends/cuda/private/wopbs/test.rs
+++ b/concrete-core/src/backends/cuda/private/wopbs/test.rs
@@ -1,7 +1,5 @@
 use crate::backends::cuda::private::device::{CudaStream, GpuIndex};
-use crate::backends::cuda::private::wopbs::{
-    circuit_bootstrap_boolean_cuda_vertical_packing, cuda_vertical_packing,
-};
+use crate::backends::cuda::private::wopbs::circuit_bootstrap_boolean_cuda_vertical_packing;
 use crate::backends::fft::private::crypto::bootstrap::{
     fill_with_forward_fourier_scratch, FourierLweBootstrapKey,
 };

--- a/concrete-cuda/cuda/src/crypto/bootstrapping_key.cuh
+++ b/concrete-cuda/cuda/src/crypto/bootstrapping_key.cuh
@@ -118,6 +118,12 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
   case 512:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      checkCudaErrors(cudaFuncSetAttribute(
+          batch_NSMFFT<FFTDegree<Degree<512>, ForwardFFT>, FULLSM>,
+          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
+      checkCudaErrors(cudaFuncSetCacheConfig(
+          batch_NSMFFT<FFTDegree<Degree<512>, ForwardFFT>, FULLSM>,
+          cudaFuncCachePreferShared));
       batch_NSMFFT<FFTDegree<Degree<512>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
@@ -131,6 +137,12 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
   case 1024:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      checkCudaErrors(cudaFuncSetAttribute(
+          batch_NSMFFT<FFTDegree<Degree<1024>, ForwardFFT>, FULLSM>,
+          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
+      checkCudaErrors(cudaFuncSetCacheConfig(
+          batch_NSMFFT<FFTDegree<Degree<1024>, ForwardFFT>, FULLSM>,
+          cudaFuncCachePreferShared));
       batch_NSMFFT<FFTDegree<Degree<1024>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
@@ -144,6 +156,12 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
   case 2048:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      checkCudaErrors(cudaFuncSetAttribute(
+          batch_NSMFFT<FFTDegree<Degree<2048>, ForwardFFT>, FULLSM>,
+          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
+      checkCudaErrors(cudaFuncSetCacheConfig(
+          batch_NSMFFT<FFTDegree<Degree<2048>, ForwardFFT>, FULLSM>,
+          cudaFuncCachePreferShared));
       batch_NSMFFT<FFTDegree<Degree<2048>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
@@ -157,6 +175,12 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
   case 4096:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      checkCudaErrors(cudaFuncSetAttribute(
+          batch_NSMFFT<FFTDegree<Degree<4096>, ForwardFFT>, FULLSM>,
+          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
+      checkCudaErrors(cudaFuncSetCacheConfig(
+          batch_NSMFFT<FFTDegree<Degree<4096>, ForwardFFT>, FULLSM>,
+          cudaFuncCachePreferShared));
       batch_NSMFFT<FFTDegree<Degree<4096>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
@@ -170,6 +194,12 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
   case 8192:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      checkCudaErrors(cudaFuncSetAttribute(
+          batch_NSMFFT<FFTDegree<Degree<8192>, ForwardFFT>, FULLSM>,
+          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
+      checkCudaErrors(cudaFuncSetCacheConfig(
+          batch_NSMFFT<FFTDegree<Degree<8192>, ForwardFFT>, FULLSM>,
+          cudaFuncCachePreferShared));
       batch_NSMFFT<FFTDegree<Degree<8192>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);

--- a/concrete-cuda/cuda/src/fft/bnsmfft.cuh
+++ b/concrete-cuda/cuda/src/fft/bnsmfft.cuh
@@ -46,6 +46,7 @@ template <int degree> __device__ double2 negacyclic_twiddle(int j) {
     break;
   case 8192:
     twid = negTwids13[j];
+    break;
   default:
     twid.x = 0;
     twid.y = 0;
@@ -721,12 +722,9 @@ __device__ void correction_inverse_fft_inplace(double2 *x) {
 template <class params, sharedMemDegree SMD>
 __global__ void batch_NSMFFT(double2 *d_input, double2 *d_output,
                              double2 *buffer) {
-  double2 *fft = &buffer[blockIdx.x * params::degree / 2];
-  if constexpr (SMD != NOSM) {
-    extern __shared__ double2 sharedMemoryFFT[];
-    fft = sharedMemoryFFT;
-  }
-
+  extern __shared__ double2 sharedMemoryFFT[];
+  double2 *fft = (SMD == NOSM) ? &buffer[blockIdx.x * params::degree / 2]
+                               : sharedMemoryFFT;
   int tid = threadIdx.x;
 
 #pragma unroll

--- a/concrete-tasks/src/test.rs
+++ b/concrete-tasks/src/test.rs
@@ -67,7 +67,7 @@ pub fn cuda_test() -> Result<(), Error> {
 pub fn cuda_core_test() -> Result<(), Error> {
     cmd!(<ENV_TARGET_NATIVE>
         &format!("cargo test --profile release-debug-asserts -p concrete-core \
-        --features=backend_cuda --features {} -- backends::cuda",
+        --features=backend_cuda --features {} -- backends::cuda --test-threads 1",
         get_target_arch_feature_for_core()?
     ))
 }


### PR DESCRIPTION
### Resolves: [#480](https://github.com/zama-ai/concrete-core-internal/issues/480)

### Description
 - Fix 8192 polynomial size pbs bug
 - Modify private unit test to work on multiple polynomial sizes
 - Removes some (legacy) warnings
 - Fix memory leak in pbs/wopbd private tests
 
### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires:  [#480](https://github.com/zama-ai/concrete-core-internal/issues/480)

-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
