### PR TITLE
fix(cuda): include cuda_runtime.h in device.h to include the definition of cudaStream_t

### DIFF
--- a/concrete-cuda/cuda/include/device.h
+++ b/concrete-cuda/cuda/include/device.h
@@ -1,4 +1,5 @@
 #include <cstdint>
+#include <cuda_runtime.h>
 
 extern "C" {
 void *cuda_create_stream(uint32_t gpu_index);


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX17VqT1msf9jeWbdweGXmUJAtJhZqqBkc%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=fVhILCF)

Without this include the Compiler cannot find cudaStream_t at link time.
