### PR TITLE
chore(cuda): Refactor device.cu functions to take pointers to cudaStream_t instead of void

### DIFF
--- a/concrete-cuda/cuda/include/device.h
+++ b/concrete-cuda/cuda/include/device.h
@@ -2,13 +2,14 @@
 #include <cuda_runtime.h>
 
 extern "C" {
-void *cuda_create_stream(uint32_t gpu_index);
+cudaStream_t *cuda_create_stream(uint32_t gpu_index);
 
-int cuda_destroy_stream(void *v_stream, uint32_t gpu_index);
+int cuda_destroy_stream(cudaStream_t *stream, uint32_t gpu_index);
 
 void *cuda_malloc(uint64_t size, uint32_t gpu_index);
 
-void *cuda_malloc_async(uint64_t size, cudaStream_t stream, uint32_t gpu_index);
+void *cuda_malloc_async(uint64_t size, cudaStream_t *stream,
+                        uint32_t gpu_index);
 
 int cuda_check_valid_malloc(uint64_t size, uint32_t gpu_index);
 
@@ -16,20 +17,20 @@ int cuda_memcpy_to_cpu(void *dest, const void *src, uint64_t size,
                        uint32_t gpu_index);
 
 int cuda_memcpy_async_to_gpu(void *dest, void *src, uint64_t size,
-                             void *v_stream, uint32_t gpu_index);
+                             cudaStream_t *stream, uint32_t gpu_index);
 
 int cuda_memcpy_to_gpu(void *dest, void *src, uint64_t size,
                        uint32_t gpu_index);
 
 int cuda_memcpy_async_to_cpu(void *dest, const void *src, uint64_t size,
-                             void *v_stream, uint32_t gpu_index);
+                             cudaStream_t *stream, uint32_t gpu_index);
 int cuda_get_number_of_gpus();
 
 int cuda_synchronize_device(uint32_t gpu_index);
 
 int cuda_drop(void *ptr, uint32_t gpu_index);
 
-int cuda_drop_async(void *ptr, cudaStream_t stream, uint32_t gpu_index);
+int cuda_drop_async(void *ptr, cudaStream_t *stream, uint32_t gpu_index);
 
 int cuda_get_max_shared_memory(uint32_t gpu_index);
 }

--- a/concrete-cuda/cuda/src/bootstrap_amortized.cuh
+++ b/concrete-cuda/cuda/src/bootstrap_amortized.cuh
@@ -317,7 +317,7 @@ __host__ void host_bootstrap_amortized(
   // of shared memory)
   if (max_shared_memory < SM_PART) {
     d_mem = (char *)cuda_malloc_async(DM_FULL * input_lwe_ciphertext_count,
-                                      *stream, gpu_index);
+                                      stream, gpu_index);
     device_bootstrap_amortized<Torus, params, NOSM><<<grid, thds, 0, *stream>>>(
         lwe_array_out, lut_vector, lut_vector_indexes, lwe_array_in,
         bootstrapping_key, d_mem, input_lwe_dimension, polynomial_size,
@@ -328,7 +328,7 @@ __host__ void host_bootstrap_amortized(
     cudaFuncSetCacheConfig(device_bootstrap_amortized<Torus, params, PARTIALSM>,
                            cudaFuncCachePreferShared);
     d_mem = (char *)cuda_malloc_async(DM_PART * input_lwe_ciphertext_count,
-                                      *stream, gpu_index);
+                                      stream, gpu_index);
     device_bootstrap_amortized<Torus, params, PARTIALSM>
         <<<grid, thds, SM_PART, *stream>>>(
             lwe_array_out, lut_vector, lut_vector_indexes, lwe_array_in,
@@ -346,7 +346,7 @@ __host__ void host_bootstrap_amortized(
     checkCudaErrors(cudaFuncSetCacheConfig(
         device_bootstrap_amortized<Torus, params, FULLSM>,
         cudaFuncCachePreferShared));
-    d_mem = (char *)cuda_malloc_async(0, *stream, gpu_index);
+    d_mem = (char *)cuda_malloc_async(0, stream, gpu_index);
 
     device_bootstrap_amortized<Torus, params, FULLSM>
         <<<grid, thds, SM_FULL, *stream>>>(
@@ -359,7 +359,7 @@ __host__ void host_bootstrap_amortized(
   // Synchronize the streams before copying the result to lwe_array_out at the
   // right place
   cudaStreamSynchronize(*stream);
-  cuda_drop_async(d_mem, *stream, gpu_index);
+  cuda_drop_async(d_mem, stream, gpu_index);
 }
 
 template <typename Torus, class params>

--- a/concrete-cuda/cuda/src/bootstrap_low_latency.cuh
+++ b/concrete-cuda/cuda/src/bootstrap_low_latency.cuh
@@ -268,9 +268,9 @@ __host__ void host_bootstrap_low_latency(
   int buffer_size_per_gpu = level_count * input_lwe_ciphertext_count *
                             polynomial_size / 2 * sizeof(double2);
   double2 *mask_buffer_fft =
-      (double2 *)cuda_malloc_async(buffer_size_per_gpu, *stream, gpu_index);
+      (double2 *)cuda_malloc_async(buffer_size_per_gpu, stream, gpu_index);
   double2 *body_buffer_fft =
-      (double2 *)cuda_malloc_async(buffer_size_per_gpu, *stream, gpu_index);
+      (double2 *)cuda_malloc_async(buffer_size_per_gpu, stream, gpu_index);
 
   // With SM each block corresponds to either the mask or body, no need to
   // duplicate data for each
@@ -308,7 +308,7 @@ __host__ void host_bootstrap_low_latency(
     checkCudaErrors(cudaGetLastError());
     d_mem = (char *)cuda_malloc_async(DM_FULL * input_lwe_ciphertext_count *
                                           level_count * 2,
-                                      *stream, gpu_index);
+                                      stream, gpu_index);
     checkCudaErrors(cudaGetLastError());
     checkCudaErrors(cudaLaunchCooperativeKernel(
         (void *)device_bootstrap_low_latency<Torus, params, NOSM>, grid, thds,
@@ -317,7 +317,7 @@ __host__ void host_bootstrap_low_latency(
     kernel_args[11] = &DM_PART;
     d_mem = (char *)cuda_malloc_async(DM_PART * input_lwe_ciphertext_count *
                                           level_count * 2,
-                                      *stream, gpu_index);
+                                      stream, gpu_index);
     checkCudaErrors(cudaFuncSetAttribute(
         device_bootstrap_low_latency<Torus, params, PARTIALSM>,
         cudaFuncAttributeMaxDynamicSharedMemorySize, SM_PART));
@@ -332,7 +332,7 @@ __host__ void host_bootstrap_low_latency(
   } else {
     int DM_NONE = 0;
     kernel_args[11] = &DM_NONE;
-    d_mem = (char *)cuda_malloc_async(0, *stream, gpu_index);
+    d_mem = (char *)cuda_malloc_async(0, stream, gpu_index);
     checkCudaErrors(cudaFuncSetAttribute(
         device_bootstrap_low_latency<Torus, params, FULLSM>,
         cudaFuncAttributeMaxDynamicSharedMemorySize, SM_FULL));
@@ -347,9 +347,9 @@ __host__ void host_bootstrap_low_latency(
   // Synchronize the streams before copying the result to lwe_array_out at the
   // right place
   cudaStreamSynchronize(*stream);
-  cuda_drop_async(mask_buffer_fft, *stream, gpu_index);
-  cuda_drop_async(body_buffer_fft, *stream, gpu_index);
-  cuda_drop_async(d_mem, *stream, gpu_index);
+  cuda_drop_async(mask_buffer_fft, stream, gpu_index);
+  cuda_drop_async(body_buffer_fft, stream, gpu_index);
+  cuda_drop_async(d_mem, stream, gpu_index);
 }
 
 #endif // LOWLAT_PBS_H

--- a/concrete-cuda/cuda/src/crypto/bootstrapping_key.cuh
+++ b/concrete-cuda/cuda/src/crypto/bootstrapping_key.cuh
@@ -117,7 +117,7 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
   switch (polynomial_size) {
   case 512:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
-      buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       checkCudaErrors(cudaFuncSetAttribute(
           batch_NSMFFT<FFTDegree<Degree<512>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
@@ -129,14 +129,14 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
-          shared_memory_size * total_polynomials, *stream, gpu_index);
+          shared_memory_size * total_polynomials, stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<512>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
   case 1024:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
-      buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       checkCudaErrors(cudaFuncSetAttribute(
           batch_NSMFFT<FFTDegree<Degree<1024>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
@@ -148,14 +148,14 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
-          shared_memory_size * total_polynomials, *stream, gpu_index);
+          shared_memory_size * total_polynomials, stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<1024>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
   case 2048:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
-      buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       checkCudaErrors(cudaFuncSetAttribute(
           batch_NSMFFT<FFTDegree<Degree<2048>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
@@ -167,14 +167,14 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
-          shared_memory_size * total_polynomials, *stream, gpu_index);
+          shared_memory_size * total_polynomials, stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<2048>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
   case 4096:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
-      buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       checkCudaErrors(cudaFuncSetAttribute(
           batch_NSMFFT<FFTDegree<Degree<4096>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
@@ -186,14 +186,14 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
-          shared_memory_size * total_polynomials, *stream, gpu_index);
+          shared_memory_size * total_polynomials, stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<4096>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
   case 8192:
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
-      buffer = (double2 *)cuda_malloc_async(0, *stream, gpu_index);
+      buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       checkCudaErrors(cudaFuncSetAttribute(
           batch_NSMFFT<FFTDegree<Degree<8192>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
@@ -205,7 +205,7 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
-          shared_memory_size * total_polynomials, *stream, gpu_index);
+          shared_memory_size * total_polynomials, stream, gpu_index);
       batch_NSMFFT<FFTDegree<Degree<8192>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
@@ -214,8 +214,8 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
     break;
   }
 
-  cuda_drop_async(d_bsk, *stream, gpu_index);
-  cuda_drop_async(buffer, *stream, gpu_index);
+  cuda_drop_async(d_bsk, stream, gpu_index);
+  cuda_drop_async(buffer, stream, gpu_index);
   free(h_bsk);
 }
 

--- a/concrete-cuda/cuda/src/crypto/ggsw.cuh
+++ b/concrete-cuda/cuda/src/crypto/ggsw.cuh
@@ -49,12 +49,10 @@ __global__ void device_batch_fft_ggsw_vector(double2 *dest, T *src,
  * global memory
  */
 template <typename T, typename ST, class params>
-void batch_fft_ggsw_vector(void *v_stream, double2 *dest, T *src, uint32_t r,
-                           uint32_t glwe_dim, uint32_t polynomial_size,
-                           uint32_t level_count, uint32_t gpu_index,
-                           uint32_t max_shared_memory) {
-
-  auto stream = static_cast<cudaStream_t *>(v_stream);
+void batch_fft_ggsw_vector(cudaStream_t *stream, double2 *dest, T *src,
+                           uint32_t r, uint32_t glwe_dim,
+                           uint32_t polynomial_size, uint32_t level_count,
+                           uint32_t gpu_index, uint32_t max_shared_memory) {
 
   int shared_memory_size = sizeof(double) * polynomial_size;
 
@@ -63,11 +61,11 @@ void batch_fft_ggsw_vector(void *v_stream, double2 *dest, T *src, uint32_t r,
 
   char *d_mem;
   if (max_shared_memory < shared_memory_size) {
-    d_mem = (char *)cuda_malloc_async(shared_memory_size, *stream, gpu_index);
+    d_mem = (char *)cuda_malloc_async(shared_memory_size, stream, gpu_index);
     device_batch_fft_ggsw_vector<T, ST, params, NOSM>
         <<<gridSize, blockSize, 0, *stream>>>(dest, src, d_mem);
     checkCudaErrors(cudaGetLastError());
-    cuda_drop_async(d_mem, *stream, gpu_index);
+    cuda_drop_async(d_mem, stream, gpu_index);
   } else {
     device_batch_fft_ggsw_vector<T, ST, params, FULLSM>
         <<<gridSize, blockSize, shared_memory_size, *stream>>>(dest, src,


### PR DESCRIPTION
### Resolves: https://github.com/zama-ai/concrete-core-internal/issues/470

### Description
I also define as default the use of pointers to cudaStream_t for all functions in that file.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
