### PR TITLE
chore(cuda): Improves VP parallelization and refactors CMUX Tree to match the CPU version

### DIFF
--- a/concrete-core/src/backends/cuda/private/wopbs/mod.rs
+++ b/concrete-core/src/backends/cuda/private/wopbs/mod.rs
@@ -61,7 +61,7 @@ pub fn cuda_vertical_packing(
     let mut d_result_br = stream.malloc::<u64>(glwe_size as u32);
 
     if tree_lut.len() == (1 << r) {
-        assert_eq!(h_concatenated_luts_glwe.len(), (1 << r) * glwe_size);
+        assert_eq!(h_concatenated_luts_glwe.len(), (1 << r) * polynomial_size.0);
         let mut d_result_cmux = stream.malloc::<u64>(glwe_size as u32);
 
         // split the vec of GGSW in two, the msb GGSW is for the CMux tree and the lsb GGSW is for
@@ -110,6 +110,7 @@ pub fn cuda_vertical_packing(
                 base_log.0 as u32,
                 level.0 as u32,
                 cmux_ggsw.len() as u32,
+                1,
                 stream.get_max_shared_memory().unwrap() as u32,
             );
         }
@@ -131,11 +132,6 @@ pub fn cuda_vertical_packing(
             );
         }
     } else {
-        assert_eq!(
-            glwe_size * tree_lut.len(),
-            h_concatenated_luts_glwe.as_slice().len()
-        );
-
         // mbr GGSWs
         let mut h_concatenated_br_ggsw = vec![];
         for ggsw in vec_ggsw.iter() {

--- a/concrete-cuda/cuda/include/bootstrap.h
+++ b/concrete-cuda/cuda/include/bootstrap.h
@@ -50,13 +50,13 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
 void cuda_cmux_tree_32(void *v_stream, uint32_t gpu_index, void *glwe_array_out,
                        void *ggsw_in, void *lut_vector, uint32_t glwe_dimension,
                        uint32_t polynomial_size, uint32_t base_log,
-                       uint32_t level_count, uint32_t r,
+                       uint32_t level_count, uint32_t r, uint32_t tau,
                        uint32_t max_shared_memory);
 
 void cuda_cmux_tree_64(void *v_stream, uint32_t gpu_index, void *glwe_array_out,
                        void *ggsw_in, void *lut_vector, uint32_t glwe_dimension,
                        uint32_t polynomial_size, uint32_t base_log,
-                       uint32_t level_count, uint32_t r,
+                       uint32_t level_count, uint32_t r, uint32_t tau,
                        uint32_t max_shared_memory);
 
 void cuda_blind_rotate_and_sample_extraction_64(

--- a/concrete-cuda/cuda/src/bootstrap_wop.cu
+++ b/concrete-cuda/cuda/src/bootstrap_wop.cu
@@ -3,7 +3,7 @@
 void cuda_cmux_tree_32(void *v_stream, uint32_t gpu_index, void *glwe_array_out,
                        void *ggsw_in, void *lut_vector, uint32_t glwe_dimension,
                        uint32_t polynomial_size, uint32_t base_log,
-                       uint32_t level_count, uint32_t r,
+                       uint32_t level_count, uint32_t r, uint32_t tau,
                        uint32_t max_shared_memory) {
 
   assert(("Error (GPU Cmux tree): base log should be <= 32", base_log <= 32));
@@ -24,31 +24,31 @@ void cuda_cmux_tree_32(void *v_stream, uint32_t gpu_index, void *glwe_array_out,
     host_cmux_tree<uint32_t, int32_t, Degree<512>>(
         v_stream, gpu_index, (uint32_t *)glwe_array_out, (uint32_t *)ggsw_in,
         (uint32_t *)lut_vector, glwe_dimension, polynomial_size, base_log,
-        level_count, r, max_shared_memory);
+        level_count, r, tau, max_shared_memory);
     break;
   case 1024:
     host_cmux_tree<uint32_t, int32_t, Degree<1024>>(
         v_stream, gpu_index, (uint32_t *)glwe_array_out, (uint32_t *)ggsw_in,
         (uint32_t *)lut_vector, glwe_dimension, polynomial_size, base_log,
-        level_count, r, max_shared_memory);
+        level_count, r, tau, max_shared_memory);
     break;
   case 2048:
     host_cmux_tree<uint32_t, int32_t, Degree<2048>>(
         v_stream, gpu_index, (uint32_t *)glwe_array_out, (uint32_t *)ggsw_in,
         (uint32_t *)lut_vector, glwe_dimension, polynomial_size, base_log,
-        level_count, r, max_shared_memory);
+        level_count, r, tau, max_shared_memory);
     break;
   case 4096:
     host_cmux_tree<uint32_t, int32_t, Degree<4096>>(
         v_stream, gpu_index, (uint32_t *)glwe_array_out, (uint32_t *)ggsw_in,
         (uint32_t *)lut_vector, glwe_dimension, polynomial_size, base_log,
-        level_count, r, max_shared_memory);
+        level_count, r, tau, max_shared_memory);
     break;
   case 8192:
     host_cmux_tree<uint32_t, int32_t, Degree<8192>>(
         v_stream, gpu_index, (uint32_t *)glwe_array_out, (uint32_t *)ggsw_in,
         (uint32_t *)lut_vector, glwe_dimension, polynomial_size, base_log,
-        level_count, r, max_shared_memory);
+        level_count, r, tau, max_shared_memory);
     break;
   default:
     break;
@@ -58,7 +58,7 @@ void cuda_cmux_tree_32(void *v_stream, uint32_t gpu_index, void *glwe_array_out,
 void cuda_cmux_tree_64(void *v_stream, uint32_t gpu_index, void *glwe_array_out,
                        void *ggsw_in, void *lut_vector, uint32_t glwe_dimension,
                        uint32_t polynomial_size, uint32_t base_log,
-                       uint32_t level_count, uint32_t r,
+                       uint32_t level_count, uint32_t r, uint32_t tau,
                        uint32_t max_shared_memory) {
 
   assert(("Error (GPU Cmux tree): base log should be <= 64", base_log <= 64));
@@ -79,31 +79,31 @@ void cuda_cmux_tree_64(void *v_stream, uint32_t gpu_index, void *glwe_array_out,
     host_cmux_tree<uint64_t, int64_t, Degree<512>>(
         v_stream, gpu_index, (uint64_t *)glwe_array_out, (uint64_t *)ggsw_in,
         (uint64_t *)lut_vector, glwe_dimension, polynomial_size, base_log,
-        level_count, r, max_shared_memory);
+        level_count, r, tau, max_shared_memory);
     break;
   case 1024:
     host_cmux_tree<uint64_t, int64_t, Degree<1024>>(
         v_stream, gpu_index, (uint64_t *)glwe_array_out, (uint64_t *)ggsw_in,
         (uint64_t *)lut_vector, glwe_dimension, polynomial_size, base_log,
-        level_count, r, max_shared_memory);
+        level_count, r, tau, max_shared_memory);
     break;
   case 2048:
     host_cmux_tree<uint64_t, int64_t, Degree<2048>>(
         v_stream, gpu_index, (uint64_t *)glwe_array_out, (uint64_t *)ggsw_in,
         (uint64_t *)lut_vector, glwe_dimension, polynomial_size, base_log,
-        level_count, r, max_shared_memory);
+        level_count, r, tau, max_shared_memory);
     break;
   case 4096:
     host_cmux_tree<uint64_t, int64_t, Degree<4096>>(
         v_stream, gpu_index, (uint64_t *)glwe_array_out, (uint64_t *)ggsw_in,
         (uint64_t *)lut_vector, glwe_dimension, polynomial_size, base_log,
-        level_count, r, max_shared_memory);
+        level_count, r, tau, max_shared_memory);
     break;
   case 8192:
     host_cmux_tree<uint64_t, int64_t, Degree<8192>>(
         v_stream, gpu_index, (uint64_t *)glwe_array_out, (uint64_t *)ggsw_in,
         (uint64_t *)lut_vector, glwe_dimension, polynomial_size, base_log,
-        level_count, r, max_shared_memory);
+        level_count, r, tau, max_shared_memory);
     break;
   default:
     break;

--- a/concrete-cuda/src/cuda_bind.rs
+++ b/concrete-cuda/src/cuda_bind.rs
@@ -200,6 +200,7 @@ extern "C" {
         base_log: u32,
         level_count: u32,
         r: u32,
+        tau: u32,
         max_shared_memory: u32,
     );
 
@@ -214,6 +215,7 @@ extern "C" {
         base_log: u32,
         level_count: u32,
         r: u32,
+        tau: u32,
         max_shared_memory: u32,
     );
 


### PR DESCRIPTION
### Resolves: https://github.com/zama-ai/concrete-core-internal/issues/488

### Description
LUTs are initially trivially encrypted, thus only bodies are handled. However, inside the CMUX Tree we need the zeroed mask to keep correctness of the computation.

* Implements add_padding_to_lut_async() to insert zeroed polynomials paddings . This is also done in the CPU implementation, and in the GPU case we can make use of asynchronous copies within the device to reorganize the array.
* Refactors the CMUX tree to run different trees through the y-axis of the grid.
* Refactors the CBS+VP implementation to use the tau parameters of the blind rotation host function.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
