### PR TITLE
fix(cuda): Debug more complex cases on the CBS+VP private test

### DIFF
--- a/concrete-cuda/cuda/src/vertical_packing.cuh
+++ b/concrete-cuda/cuda/src/vertical_packing.cuh
@@ -276,8 +276,8 @@ void host_cmux_tree(void *v_stream, uint32_t gpu_index, Torus *glwe_array_out,
   int num_lut = (1 << r);
   if (r == 0) {
     // Simply copy the LUTs
-    add_padding_to_lut_async<Torus, params>(
-        glwe_array_out, lut_vector, glwe_dimension, num_lut * tau, stream);
+    add_padding_to_lut_async<Torus, params>(glwe_array_out, lut_vector,
+                                            glwe_dimension, tau, stream);
     checkCudaErrors(cudaStreamSynchronize(*stream));
     return;
   }


### PR DESCRIPTION
### Resolves: https://github.com/zama-ai/concrete-core-internal/issues/493

### Description

* [x] Check for correctness on GPU CBS+VP when tau > 1
* [x] Check for correctness on GPU CBS+VP when tau * p == log2(N) (skipping the CMUX tree)
* [x] Check for correctness on GPU CBS+VP when both a CMUX tree and BR are executed

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [x] The draft release description has been updated
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
