### PR TITLE
refactor(csprng): upgrade aes to 0.8.2 generator_soft -> generator_fallback

### DIFF
--- a/concrete-core-fixture/Cargo.toml
+++ b/concrete-core-fixture/Cargo.toml
@@ -11,7 +11,7 @@ concrete-core = { path = "../concrete-core", features = [
 ] }
 concrete-csprng = { path = "../concrete-csprng", features = [
     "seeder_unix",
-    "generator_soft",
+    "generator_fallback",
 ] }
 concrete-npe = { path = "../concrete-npe" }
 concrete-cuda = { path = "../concrete-cuda", optional = true }

--- a/concrete-core/Cargo.toml
+++ b/concrete-core/Cargo.toml
@@ -18,7 +18,7 @@ kolmogorov_smirnov = "1.1.0"
 criterion = "0.3"
 
 [dependencies]
-concrete-csprng = { version = "0.2.1", path = "../concrete-csprng" }
+concrete-csprng = { version = "0.3.0", path = "../concrete-csprng" }
 concrete-cuda = { version = "0.1.1", path = "../concrete-cuda", optional = true }
 serde = { version = "1.0", optional = true }
 lazy_static = "1.4.0"
@@ -41,7 +41,7 @@ harness = false
 default = ["backend_default", "seeder_unix"]
 
 # A pure-rust backend. Included by default in the build.
-backend_default = ["concrete-csprng/generator_soft"]
+backend_default = ["concrete-csprng/generator_fallback"]
 
 # An accelerated backend, using the `concrete-fft` library.
 backend_fft = ["concrete-fft"]

--- a/concrete-csprng/Cargo.toml
+++ b/concrete-csprng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concrete-csprng"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 authors = ["D. Ligier", "J.B. Orfila", "A. Péré", "S. Tap", "Zama team"]
 license = "BSD-3-Clause-Clear"
@@ -12,7 +12,7 @@ readme = "README.md"
 keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
 
 [dependencies]
-aes-soft = "0.6.4"
+aes = "0.8.2"
 rayon = { version = "1.5.0", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -27,7 +27,7 @@ parallel = ["rayon"]
 seeder_x86_64_rdseed = []
 seeder_unix = []
 generator_x86_64_aesni = []
-generator_soft = []
+generator_fallback = []
 generator_aarch64_aes = []
 
 x86_64 = [
@@ -35,14 +35,14 @@ x86_64 = [
     "seeder_x86_64_rdseed",
     "seeder_unix",
     "generator_x86_64_aesni",
-    "generator_soft",
+    "generator_fallback",
 ]
 x86_64-cuda = ["x86_64"]
 aarch64 = [
     "parallel",
     "seeder_unix",
     "generator_aarch64_aes",
-    "generator_soft",
+    "generator_fallback",
 ]
 
 [[bench]]
@@ -54,4 +54,4 @@ required-features = ["seeder_x86_64_rdseed", "generator_x86_64_aesni"]
 [[bin]]
 name = "generate"
 path = "src/main.rs"
-required-features = ["seeder_unix", "generator_soft"]
+required-features = ["seeder_unix", "generator_fallback"]

--- a/concrete-csprng/src/generators/implem/mod.rs
+++ b/concrete-csprng/src/generators/implem/mod.rs
@@ -8,7 +8,7 @@ mod aarch64;
 #[cfg(feature = "generator_aarch64_aes")]
 pub use aarch64::*;
 
-#[cfg(feature = "generator_soft")]
+#[cfg(feature = "generator_fallback")]
 mod soft;
-#[cfg(feature = "generator_soft")]
+#[cfg(feature = "generator_fallback")]
 pub use soft::*;

--- a/concrete-csprng/src/generators/implem/soft/block_cipher.rs
+++ b/concrete-csprng/src/generators/implem/soft/block_cipher.rs
@@ -1,9 +1,9 @@
 use crate::generators::aes_ctr::{
     AesBlockCipher, AesIndex, AesKey, AES_CALLS_PER_BATCH, BYTES_PER_AES_CALL, BYTES_PER_BATCH,
 };
-use aes_soft::cipher::generic_array::GenericArray;
-use aes_soft::cipher::{BlockCipher, NewBlockCipher};
-use aes_soft::Aes128;
+use aes::cipher::generic_array::GenericArray;
+use aes::cipher::{BlockEncrypt, KeyInit};
+use aes::Aes128;
 
 #[derive(Clone)]
 pub struct SoftwareBlockCipher {

--- a/concrete-csprng/src/lib.rs
+++ b/concrete-csprng/src/lib.rs
@@ -1,5 +1,8 @@
 #![deny(rustdoc::broken_intra_doc_links)]
-#![cfg_attr(target_arch = "aarch64", feature(stdsimd))]
+#![cfg_attr(
+    all(feature = "generator_aarch64_aes", target_arch = "aarch64"),
+    feature(stdsimd)
+)]
 //! Cryptographically secure pseudo random number generator.
 //!
 //! Welcome to the `concrete-csprng` documentation.

--- a/concrete-csprng/src/main.rs
+++ b/concrete-csprng/src/main.rs
@@ -7,7 +7,7 @@ use concrete_csprng::generators::NeonAesRandomGenerator as ActivatedRandomGenera
 #[cfg(all(
     not(feature = "generator_x86_64_aesni"),
     not(feature = "generator_aarch64_aes"),
-    feature = "generator_soft"
+    feature = "generator_fallback"
 ))]
 use concrete_csprng::generators::SoftwareRandomGenerator as ActivatedRandomGenerator;
 


### PR DESCRIPTION
### Resolves:

closes https://github.com/zama-ai/concrete-core-internal/issues/353

### Description

- updated csprng code so that nightly is not always necessary on M1 macs (if using the fallback generator coming from aes e.g.)
- bumped version as the feature name change is a breaking change

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
