### PR TITLE
chore(cuda): replace synchronous copies with async ones in the private cuda backend

### DIFF
--- a/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_discarding_bootstrap.rs
+++ b/concrete-core/src/backends/cuda/implementation/engines/cuda_engine/lwe_ciphertext_discarding_bootstrap.rs
@@ -131,8 +131,8 @@ impl
         bsk: &CudaFourierLweBootstrapKey32,
     ) {
         let stream = self.streams.first().unwrap();
-        let mut test_vector_indexes = stream.malloc::<u32>(1);
-        stream.copy_to_gpu(&mut test_vector_indexes, &[0]);
+        let mut test_vector_indexes = stream.malloc_async::<u32>(1);
+        stream.copy_to_gpu_async(&mut test_vector_indexes, &[0]);
 
         stream.discard_bootstrap_low_latency_lwe_ciphertext_vector::<u32>(
             &mut output.0.d_vec,
@@ -266,8 +266,8 @@ impl
         bsk: &CudaFourierLweBootstrapKey64,
     ) {
         let stream = self.streams.first().unwrap();
-        let mut test_vector_indexes = stream.malloc::<u64>(1);
-        stream.copy_to_gpu(&mut test_vector_indexes, &[0]);
+        let mut test_vector_indexes = stream.malloc_async::<u64>(1);
+        stream.copy_to_gpu_async(&mut test_vector_indexes, &[0]);
 
         stream.discard_bootstrap_low_latency_lwe_ciphertext_vector::<u64>(
             &mut output.0.d_vec,

--- a/concrete-core/src/backends/cuda/private/crypto/bootstrap/mod.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/bootstrap/mod.rs
@@ -59,8 +59,8 @@ where
         input.key_size().0 * input.glwe_size().0 * input.glwe_size().0 * input.level_count().0;
     let alloc_size = total_polynomials * input.polynomial_size().0;
     for stream in streams.iter() {
-        let mut d_vec = stream.malloc::<f64>(alloc_size as u32);
         let input_slice = input.as_tensor().as_slice();
+        let mut d_vec = stream.malloc::<f64>(alloc_size as u32);
         stream.convert_lwe_bootstrap_key::<T>(
             &mut d_vec,
             input_slice,
@@ -107,8 +107,8 @@ pub(crate) unsafe fn execute_lwe_ciphertext_vector_low_latency_bootstrap_on_gpu<
         for (i, ind) in test_vector_indexes.iter_mut().enumerate() {
             *ind = <usize as CastInto<T>>::cast_into(i);
         }
-        let mut d_test_vector_indexes = stream.malloc::<T>(samples.0 as u32);
-        stream.copy_to_gpu(&mut d_test_vector_indexes, &test_vector_indexes);
+        let mut d_test_vector_indexes = stream.malloc_async::<T>(samples.0 as u32);
+        stream.copy_to_gpu_async::<T>(&mut d_test_vector_indexes, &test_vector_indexes);
 
         stream.discard_bootstrap_low_latency_lwe_ciphertext_vector::<T>(
             output.d_vecs.get_mut(gpu_index).unwrap(),
@@ -161,8 +161,8 @@ pub(crate) unsafe fn execute_lwe_ciphertext_vector_amortized_bootstrap_on_gpu<
         for (i, ind) in test_vector_indexes.iter_mut().enumerate() {
             *ind = <usize as CastInto<T>>::cast_into(i);
         }
-        let mut d_test_vector_indexes = stream.malloc::<T>(samples.0 as u32);
-        stream.copy_to_gpu(&mut d_test_vector_indexes, &test_vector_indexes);
+        let mut d_test_vector_indexes = stream.malloc_async::<T>(samples.0 as u32);
+        stream.copy_to_gpu_async::<T>(&mut d_test_vector_indexes, &test_vector_indexes);
 
         stream.discard_bootstrap_amortized_lwe_ciphertext_vector::<T>(
             output.d_vecs.get_mut(gpu_index).unwrap(),

--- a/concrete-core/src/backends/cuda/private/crypto/bootstrap/test.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/bootstrap/test.rs
@@ -66,8 +66,6 @@ mod cuda_unit_test_pbs {
         let lwe_dimension = LweDimension(500);
         let glwe_dimension = GlweDimension(1);
         let polynomial_sizes = vec![
-            PolynomialSize(256),
-            PolynomialSize(512),
             PolynomialSize(1024),
             PolynomialSize(2048),
             PolynomialSize(4096),

--- a/concrete-core/src/backends/cuda/private/crypto/wopbs/test.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/wopbs/test.rs
@@ -156,10 +156,14 @@ pub fn test_cuda_woppbs_cmux_tree() {
         // Copy to Device
         unsafe {
             let mut d_concatenated_luts = stream.malloc::<u64>(h_concatenated_luts.len() as u32);
-            stream.copy_to_gpu::<u64>(&mut d_concatenated_luts, h_concatenated_luts.as_slice());
+            stream
+                .copy_to_gpu_async::<u64>(&mut d_concatenated_luts, h_concatenated_luts.as_slice());
 
             let mut d_concatenated_mtree = stream.malloc::<u64>(h_concatenated_ggsw.len() as u32);
-            stream.copy_to_gpu::<u64>(&mut d_concatenated_mtree, h_concatenated_ggsw.as_slice());
+            stream.copy_to_gpu_async::<u64>(
+                &mut d_concatenated_mtree,
+                h_concatenated_ggsw.as_slice(),
+            );
 
             let mut d_results = stream.malloc::<u64>((tau * glwe_size) as u32);
             let mut cmux_tree_buffer: *mut i8 = std::ptr::null_mut();
@@ -196,7 +200,7 @@ pub fn test_cuda_woppbs_cmux_tree() {
                 &mut cmux_tree_buffer as *mut *mut i8,
             );
             cuda_synchronize_device(gpu_index.0 as u32);
-            stream.copy_to_cpu::<u64>(&mut h_results, &d_results);
+            stream.copy_to_cpu_async::<u64>(&mut h_results, &d_results);
         }
 
         assert_eq!(h_results.len(), tau * glwe_size);
@@ -381,9 +385,10 @@ pub fn test_cuda_woppbs_extract_bits() {
         */
 
         unsafe {
-            stream.copy_to_gpu::<u64>(&mut d_ksk, &mut h_ksk);
+            stream.copy_to_gpu_async::<u64>(&mut d_ksk, &mut h_ksk);
             //println!("rust_lwe_array_in: {:?}", lwe_array_in);
-            stream.copy_to_gpu::<u64>(&mut d_lwe_array_in, &mut lwe_array_in.tensor.as_slice());
+            stream
+                .copy_to_gpu_async::<u64>(&mut d_lwe_array_in, &mut lwe_array_in.tensor.as_slice());
 
             now = Instant::now();
             let mut bit_extract_buffer: *mut i8 = std::ptr::null_mut();
@@ -430,7 +435,7 @@ pub fn test_cuda_woppbs_extract_bits() {
             println!("elapsed: {:?}", elapsed);
 
             let mut h_result = vec![0u64; (lwe_dimension.0 + 1) * number_values_to_extract.0];
-            stream.copy_to_cpu::<u64>(&mut h_result, &d_lwe_array_out);
+            stream.copy_to_cpu_async::<u64>(&mut h_result, &d_lwe_array_out);
 
             cuda_synchronize_device(gpu_index.0 as u32);
 
@@ -1316,9 +1321,9 @@ fn test_cuda_woppbs_circuit_bootstrapping_binary() {
 
     unsafe {
         // fill device lwe input with same ciphertext
-        stream.copy_to_gpu::<u64>(&mut d_lwe_array_in, &mut lwe_in.tensor.as_slice());
-        stream.copy_to_gpu::<u64>(&mut d_lut_vector_indexes, &mut h_lut_vector_indexes);
-        stream.copy_to_gpu::<u64>(&mut d_fp_ksk_array, &mut h_fp_ksk_array);
+        stream.copy_to_gpu_async::<u64>(&mut d_lwe_array_in, &mut lwe_in.tensor.as_slice());
+        stream.copy_to_gpu_async::<u64>(&mut d_lut_vector_indexes, &mut h_lut_vector_indexes);
+        stream.copy_to_gpu_async::<u64>(&mut d_fp_ksk_array, &mut h_fp_ksk_array);
     }
 
     unsafe {

--- a/concrete-cuda/cuda/src/wop_bootstrap.cu
+++ b/concrete-cuda/cuda/src/wop_bootstrap.cu
@@ -511,7 +511,9 @@ void cuda_wop_pbs_64(void *v_stream, uint32_t gpu_index, void *lwe_array_out,
  */
 void cleanup_cuda_wop_pbs(void *v_stream, uint32_t gpu_index,
                           int8_t **wop_pbs_buffer) {
-  cleanup_wop_pbs(v_stream, gpu_index, wop_pbs_buffer);
+  auto stream = static_cast<cudaStream_t *>(v_stream);
+  // Free memory
+  cuda_drop_async(*wop_pbs_buffer, stream, gpu_index);
 }
 
 /*
@@ -521,6 +523,7 @@ void cleanup_cuda_wop_pbs(void *v_stream, uint32_t gpu_index,
 void cleanup_cuda_circuit_bootstrap_vertical_packing(void *v_stream,
                                                      uint32_t gpu_index,
                                                      int8_t **cbs_vp_buffer) {
-  cleanup_circuit_bootstrap_vertical_packing(v_stream, gpu_index,
-                                             cbs_vp_buffer);
+  auto stream = static_cast<cudaStream_t *>(v_stream);
+  // Free memory
+  cuda_drop_async(*cbs_vp_buffer, stream, gpu_index);
 }

--- a/concrete-cuda/cuda/src/wop_bootstrap.cuh
+++ b/concrete-cuda/cuda/src/wop_bootstrap.cuh
@@ -104,21 +104,6 @@ __host__ void scratch_circuit_bootstrap_vertical_packing(
       level_count_cbs, mbr_size, tau, max_shared_memory, false);
 }
 
-/*
- * Cleanup functions free the necessary data on the GPU and on the CPU.
- * Data that lives on the CPU is prefixed with `h_`. This cleanup function thus
- * frees the data for the circuit bootstrap and vertical packing on GPU
- * contained in cbs_vp_buffer
- */
-__host__ void
-cleanup_circuit_bootstrap_vertical_packing(void *v_stream, uint32_t gpu_index,
-                                           int8_t **cbs_vp_buffer) {
-
-  auto stream = static_cast<cudaStream_t *>(v_stream);
-  // Free memory
-  cuda_drop_async(*cbs_vp_buffer, stream, gpu_index);
-}
-
 // number_of_inputs is the total number of LWE ciphertexts passed to CBS + VP,
 // i.e. tau * p where tau is the number of LUTs (the original number of LWEs
 // before bit extraction) and p is the number of extracted bits
@@ -267,17 +252,6 @@ scratch_wop_pbs(void *v_stream, uint32_t gpu_index, int8_t **wop_pbs_buffer,
       lwe_dimension, polynomial_size, level_count_cbs,
       number_of_inputs * number_of_bits_to_extract, number_of_inputs,
       max_shared_memory, false);
-}
-
-/*
- * Cleanup functions free the necessary data on the GPU and on the CPU.
- * Data that lives on the CPU is prefixed with `h_`. This cleanup function thus
- * frees the data for the wop PBS on GPU in wop_pbs_buffer
- */
-__host__ void cleanup_wop_pbs(void *v_stream, uint32_t gpu_index,
-                              int8_t **wop_pbs_buffer) {
-  auto stream = static_cast<cudaStream_t *>(v_stream);
-  cuda_drop_async(*wop_pbs_buffer, stream, gpu_index);
 }
 
 template <typename Torus, typename STorus, class params>


### PR DESCRIPTION
### Resolves
https://github.com/zama-ai/concrete-core-internal/issues/513
as a follow up to a discussion in https://github.com/zama-ai/concrete-core/issues/332

### Description

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
