### PR TITLE
fix(cuda): fix cleanup functions: it is necessary to sync the stream before freeing memory

### DIFF
--- a/concrete-cuda/cuda/src/bit_extraction.cu
+++ b/concrete-cuda/cuda/src/bit_extraction.cu
@@ -315,6 +315,7 @@ void cuda_extract_bits_64(void *v_stream, uint32_t gpu_index,
 void cleanup_cuda_extract_bits(void *v_stream, uint32_t gpu_index,
                                int8_t **bit_extract_buffer) {
   auto stream = static_cast<cudaStream_t *>(v_stream);
+  check_cuda_error(cudaStreamSynchronize(*stream));
   // Free memory
   cuda_drop_async(*bit_extract_buffer, stream, gpu_index);
 }

--- a/concrete-cuda/cuda/src/bootstrap_amortized.cu
+++ b/concrete-cuda/cuda/src/bootstrap_amortized.cu
@@ -317,6 +317,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_64(
 void cleanup_cuda_bootstrap_amortized(void *v_stream, uint32_t gpu_index,
                                       int8_t **pbs_buffer) {
   auto stream = static_cast<cudaStream_t *>(v_stream);
+  check_cuda_error(cudaStreamSynchronize(*stream));
   // Free memory
   cuda_drop_async(*pbs_buffer, stream, gpu_index);
 }

--- a/concrete-cuda/cuda/src/bootstrap_low_latency.cu
+++ b/concrete-cuda/cuda/src/bootstrap_low_latency.cu
@@ -360,6 +360,7 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
 void cleanup_cuda_bootstrap_low_latency(void *v_stream, uint32_t gpu_index,
                                         int8_t **pbs_buffer) {
   auto stream = static_cast<cudaStream_t *>(v_stream);
+  check_cuda_error(cudaStreamSynchronize(*stream));
   // Free memory
   cuda_drop_async(*pbs_buffer, stream, gpu_index);
 }

--- a/concrete-cuda/cuda/src/circuit_bootstrap.cu
+++ b/concrete-cuda/cuda/src/circuit_bootstrap.cu
@@ -282,6 +282,7 @@ void cuda_circuit_bootstrap_64(
 void cleanup_cuda_circuit_bootstrap(void *v_stream, uint32_t gpu_index,
                                     int8_t **cbs_buffer) {
   auto stream = static_cast<cudaStream_t *>(v_stream);
+  check_cuda_error(cudaStreamSynchronize(*stream));
   // Free memory
   cuda_drop_async(*cbs_buffer, stream, gpu_index);
 }

--- a/concrete-cuda/cuda/src/vertical_packing.cu
+++ b/concrete-cuda/cuda/src/vertical_packing.cu
@@ -235,6 +235,7 @@ void cuda_cmux_tree_64(void *v_stream, uint32_t gpu_index, void *glwe_array_out,
 void cleanup_cuda_cmux_tree(void *v_stream, uint32_t gpu_index,
                             int8_t **cmux_tree_buffer) {
   auto stream = static_cast<cudaStream_t *>(v_stream);
+  check_cuda_error(cudaStreamSynchronize(*stream));
   // Free memory
   cuda_drop_async(*cmux_tree_buffer, stream, gpu_index);
 }
@@ -394,6 +395,7 @@ void cleanup_cuda_blind_rotation_sample_extraction(void *v_stream,
                                                    uint32_t gpu_index,
                                                    int8_t **br_se_buffer) {
   auto stream = static_cast<cudaStream_t *>(v_stream);
+  check_cuda_error(cudaStreamSynchronize(*stream));
   // Free memory
   cuda_drop_async(*br_se_buffer, stream, gpu_index);
 }

--- a/concrete-cuda/cuda/src/wop_bootstrap.cu
+++ b/concrete-cuda/cuda/src/wop_bootstrap.cu
@@ -461,7 +461,10 @@ void cuda_wop_pbs_64(void *v_stream, uint32_t gpu_index, void *lwe_array_out,
  */
 void cleanup_cuda_wop_pbs(void *v_stream, uint32_t gpu_index,
                           int8_t **wop_pbs_buffer) {
-  cleanup_wop_pbs(v_stream, gpu_index, wop_pbs_buffer);
+  auto stream = static_cast<cudaStream_t *>(v_stream);
+  check_cuda_error(cudaStreamSynchronize(*stream));
+  // Free memory
+  cuda_drop_async(*wop_pbs_buffer, stream, gpu_index);
 }
 
 /*
@@ -471,6 +474,8 @@ void cleanup_cuda_wop_pbs(void *v_stream, uint32_t gpu_index,
 void cleanup_cuda_circuit_bootstrap_vertical_packing(void *v_stream,
                                                      uint32_t gpu_index,
                                                      int8_t **cbs_vp_buffer) {
-  cleanup_circuit_bootstrap_vertical_packing(v_stream, gpu_index,
-                                             cbs_vp_buffer);
+  auto stream = static_cast<cudaStream_t *>(v_stream);
+  check_cuda_error(cudaStreamSynchronize(*stream));
+  // Free memory
+  cuda_drop_async(*cbs_vp_buffer, stream, gpu_index);
 }

--- a/concrete-cuda/cuda/src/wop_bootstrap.cuh
+++ b/concrete-cuda/cuda/src/wop_bootstrap.cuh
@@ -104,21 +104,6 @@ __host__ void scratch_circuit_bootstrap_vertical_packing(
       level_count_cbs, mbr_size, tau, max_shared_memory, false);
 }
 
-/*
- * Cleanup functions free the necessary data on the GPU and on the CPU.
- * Data that lives on the CPU is prefixed with `h_`. This cleanup function thus
- * frees the data for the circuit bootstrap and vertical packing on GPU
- * contained in cbs_vp_buffer
- */
-__host__ void
-cleanup_circuit_bootstrap_vertical_packing(void *v_stream, uint32_t gpu_index,
-                                           int8_t **cbs_vp_buffer) {
-
-  auto stream = static_cast<cudaStream_t *>(v_stream);
-  // Free memory
-  cuda_drop_async(*cbs_vp_buffer, stream, gpu_index);
-}
-
 // number_of_inputs is the total number of LWE ciphertexts passed to CBS + VP,
 // i.e. tau * p where tau is the number of LUTs (the original number of LWEs
 // before bit extraction) and p is the number of extracted bits
@@ -267,17 +252,6 @@ scratch_wop_pbs(void *v_stream, uint32_t gpu_index, int8_t **wop_pbs_buffer,
       lwe_dimension, polynomial_size, level_count_cbs,
       number_of_inputs * number_of_bits_to_extract, number_of_inputs,
       max_shared_memory, false);
-}
-
-/*
- * Cleanup functions free the necessary data on the GPU and on the CPU.
- * Data that lives on the CPU is prefixed with `h_`. This cleanup function thus
- * frees the data for the wop PBS on GPU in wop_pbs_buffer
- */
-__host__ void cleanup_wop_pbs(void *v_stream, uint32_t gpu_index,
-                              int8_t **wop_pbs_buffer) {
-  auto stream = static_cast<cudaStream_t *>(v_stream);
-  cuda_drop_async(*wop_pbs_buffer, stream, gpu_index);
 }
 
 template <typename Torus, typename STorus, class params>


### PR DESCRIPTION
### Resolves: https://github.com/zama-ai/concrete-core-internal/issues/516

### Description

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
