### PR TITLE
chore(cuda): Reduces shared memory consumption in the amortized PBS and improves loop unrolling.

### DIFF
--- a/concrete-cuda/cuda/src/vertical_packing.cuh
+++ b/concrete-cuda/cuda/src/vertical_packing.cuh
@@ -75,11 +75,12 @@ cmux(Torus *glwe_array_out, Torus *glwe_array_in, double2 *ggsw_in,
   // The polynomial multiplications happens at the block level
   // and each thread handles two or more coefficients
   int pos = threadIdx.x;
-  for (int j = 0; j < (glwe_dim + 1) * params::opt / 2; j++) {
-    res_fft[pos].x = 0;
-    res_fft[pos].y = 0;
-    pos += params::degree / params::opt;
-  }
+  for (int i = 0; i < (glwe_dim + 1); i++)
+    for (int j = 0; j < params::opt / 2; j++) {
+      res_fft[pos].x = 0;
+      res_fft[pos].y = 0;
+      pos += params::degree / params::opt;
+    }
 
   synchronize_threads_in_block();
   GadgetMatrix<Torus, params> gadget(base_log, level_count, glwe_sub,
@@ -124,10 +125,11 @@ cmux(Torus *glwe_array_out, Torus *glwe_array_in, double2 *ggsw_in,
   Torus *mb = &glwe_array_out[output_idx * (glwe_dim + 1) * polynomial_size];
 
   int tid = threadIdx.x;
-  for (int i = 0; i < (glwe_dim + 1) * params::opt; i++) {
-    mb[tid] = m0[tid];
-    tid += params::degree / params::opt;
-  }
+  for (int i = 0; i < (glwe_dim + 1); i++)
+    for (int j = 0; j < params::opt; j++) {
+      mb[tid] = m0[tid];
+      tid += params::degree / params::opt;
+    }
 
   for (int i = 0; i < (glwe_dim + 1); i++) {
     auto res_fft_slice = res_fft + i * params::degree / 2;
@@ -425,10 +427,11 @@ __global__ void device_blind_rotation_and_sample_extraction(
   // Input LUT
   auto mi = &glwe_in[blockIdx.x * (glwe_dim + 1) * polynomial_size];
   int tid = threadIdx.x;
-  for (int i = 0; i < (glwe_dim + 1) * params::opt; i++) {
-    accumulator_c0[tid] = mi[tid];
-    tid += params::degree / params::opt;
-  }
+  for (int i = 0; i < (glwe_dim + 1); i++)
+    for (int j = 0; j < params::opt; j++) {
+      accumulator_c0[tid] = mi[tid];
+      tid += params::degree / params::opt;
+    }
 
   int monomial_degree = 0;
   for (int i = mbr_size - 1; i >= 0; i--) {


### PR DESCRIPTION
### Resolves: https://github.com/zama-ai/concrete-core-internal/issues/519

### Description
By using the new `decompose_and_compress_next_polynomial()` we can shrink again the size of `accumulator_fft` to store a single polynomial. Moreover, this PR also replaces loops of the form

```
for (int i = 0; i < (glwe_dim+1) * params::opt; i++){
   ...
}
```

by
```
for (int i = 0; i < (glwe_dim+1); i++)
   for (int j = 0; j < params::opt; j++){
   ...
   }
```

so the compiler is capable of unrolling the inner loop.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
