### PR TITLE
fix(cuda): fix pbs buffer size for amortized PBS

### DIFF
--- a/concrete-cuda/cuda/src/bootstrap_amortized.cuh
+++ b/concrete-cuda/cuda/src/bootstrap_amortized.cuh
@@ -217,8 +217,9 @@ get_buffer_size_full_sm_bootstrap_amortized(uint32_t polynomial_size,
                                             uint32_t glwe_dimension) {
   return sizeof(Torus) * polynomial_size * (glwe_dimension + 1) + // accumulator
          sizeof(Torus) * polynomial_size *
-             (glwe_dimension + 1) +              // accumulator rotated
-         sizeof(double2) * polynomial_size / 2 + // accumulator fft
+             (glwe_dimension + 1) + // accumulator rotated
+         sizeof(double2) * polynomial_size / 2 *
+             (glwe_dimension + 1) + // accumulator fft
          sizeof(double2) * polynomial_size / 2 *
              (glwe_dimension + 1); // calculate buffer fft
 }
@@ -227,7 +228,8 @@ template <typename Torus>
 __host__ __device__ int
 get_buffer_size_partial_sm_bootstrap_amortized(uint32_t polynomial_size,
                                                uint32_t glwe_dimension) {
-  return sizeof(double2) * polynomial_size / 2; // calculate buffer fft
+  return sizeof(double2) * polynomial_size / 2 *
+         (glwe_dimension + 1); // calculate buffer fft
 }
 
 template <typename Torus>


### PR DESCRIPTION
### Resolves: 
https://github.com/zama-ai/concrete-core-internal/issues/516

### Description

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
