### PR TITLE
chore(cuda): Add checks to validate inputs passed to the scratch functions

### DIFF
--- a/concrete-cuda/cuda/src/bootstrap_amortized.cu
+++ b/concrete-cuda/cuda/src/bootstrap_amortized.cu
@@ -1,6 +1,27 @@
 #include "bootstrap_amortized.cuh"
 
 /*
+ * Runs standard checks to validate the inputs
+ */
+void checks_fast_bootstrap_amortized(int nbits, int polynomial_size) {
+  assert(
+      ("Error (GPU amortized PBS): polynomial size should be one of 256, 512, "
+       "1024, 2048, 4096, 8192",
+       polynomial_size == 256 || polynomial_size == 512 ||
+           polynomial_size == 1024 || polynomial_size == 2048 ||
+           polynomial_size == 4096 || polynomial_size == 8192));
+}
+
+/*
+ * Runs standard checks to validate the inputs
+ */
+void checks_bootstrap_amortized(int nbits, int base_log, int polynomial_size) {
+  assert(("Error (GPU amortized PBS): base log should be <= nbits",
+          base_log <= nbits));
+  checks_fast_bootstrap_amortized(nbits, polynomial_size);
+}
+
+/*
  * This scratch function allocates the necessary amount of data on the GPU for
  * the amortized PBS on 32 bits inputs, into `pbs_buffer`. It also
  * configures SM options on the GPU in case FULLSM or PARTIALSM mode is going to
@@ -13,6 +34,7 @@ void scratch_cuda_bootstrap_amortized_32(void *v_stream, uint32_t gpu_index,
                                          uint32_t input_lwe_ciphertext_count,
                                          uint32_t max_shared_memory,
                                          bool allocate_gpu_memory) {
+  checks_fast_bootstrap_amortized(32, polynomial_size);
 
   switch (polynomial_size) {
   case 256:
@@ -63,6 +85,7 @@ void scratch_cuda_bootstrap_amortized_64(void *v_stream, uint32_t gpu_index,
                                          uint32_t input_lwe_ciphertext_count,
                                          uint32_t max_shared_memory,
                                          bool allocate_gpu_memory) {
+  checks_fast_bootstrap_amortized(64, polynomial_size);
 
   switch (polynomial_size) {
   case 256:
@@ -111,14 +134,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_32(
     uint32_t num_samples, uint32_t num_lut_vectors, uint32_t lwe_idx,
     uint32_t max_shared_memory) {
 
-  assert(
-      ("Error (GPU amortized PBS): base log should be <= 32", base_log <= 32));
-  assert(
-      ("Error (GPU amortized PBS): polynomial size should be one of 256, 512, "
-       "1024, 2048, 4096, 8192",
-       polynomial_size == 256 || polynomial_size == 512 ||
-           polynomial_size == 1024 || polynomial_size == 2048 ||
-           polynomial_size == 4096 || polynomial_size == 8192));
+  checks_bootstrap_amortized(32, base_log, polynomial_size);
 
   switch (polynomial_size) {
   case 256:
@@ -247,14 +263,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_64(
     uint32_t num_samples, uint32_t num_lut_vectors, uint32_t lwe_idx,
     uint32_t max_shared_memory) {
 
-  assert(
-      ("Error (GPU amortized PBS): base log should be <= 64", base_log <= 64));
-  assert(
-      ("Error (GPU amortized PBS): polynomial size should be one of 256, 512, "
-       "1024, 2048, 4096, 8192",
-       polynomial_size == 256 || polynomial_size == 512 ||
-           polynomial_size == 1024 || polynomial_size == 2048 ||
-           polynomial_size == 4096 || polynomial_size == 8192));
+  checks_bootstrap_amortized(64, base_log, polynomial_size);
 
   switch (polynomial_size) {
   case 256:


### PR DESCRIPTION
### Resolves: https://github.com/zama-ai/concrete-core-internal/issues/517

### Description

This commit moves all asserts from `host_*` methods to a single function and inserts it also in the scratch functions.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
