### PR TITLE
chore(cuda): assert r value is positive in wop pbs

### DIFF
--- a/concrete-cuda/cuda/src/wop_bootstrap.cu
+++ b/concrete-cuda/cuda/src/wop_bootstrap.cu
@@ -300,6 +300,7 @@ void cuda_circuit_bootstrap_vertical_packing_64(
           number_of_inputs <= number_of_sm / 4. / 2. / level_count_bsk));
   switch (polynomial_size) {
   case 256:
+    assert(("Error (GPU WOP PBS): r is negative", number_of_inputs > 8);
     host_circuit_bootstrap_vertical_packing<uint64_t, int64_t, Degree<256>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t *)lwe_array_in, (uint64_t *)lut_vector,
@@ -310,6 +311,7 @@ void cuda_circuit_bootstrap_vertical_packing_64(
         max_shared_memory);
     break;
   case 512:
+    assert(("Error (GPU WOP PBS): r is negative", number_of_inputs > 9);
     host_circuit_bootstrap_vertical_packing<uint64_t, int64_t, Degree<512>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t *)lwe_array_in, (uint64_t *)lut_vector,
@@ -320,6 +322,7 @@ void cuda_circuit_bootstrap_vertical_packing_64(
         max_shared_memory);
     break;
   case 1024:
+    assert(("Error (GPU WOP PBS): r is negative", number_of_inputs > 10);
     host_circuit_bootstrap_vertical_packing<uint64_t, int64_t, Degree<1024>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t *)lwe_array_in, (uint64_t *)lut_vector,
@@ -330,6 +333,7 @@ void cuda_circuit_bootstrap_vertical_packing_64(
         max_shared_memory);
     break;
   case 2048:
+    assert(("Error (GPU WOP PBS): r is negative", number_of_inputs > 11);
     host_circuit_bootstrap_vertical_packing<uint64_t, int64_t, Degree<2048>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t *)lwe_array_in, (uint64_t *)lut_vector,
@@ -340,6 +344,7 @@ void cuda_circuit_bootstrap_vertical_packing_64(
         max_shared_memory);
     break;
   case 4096:
+    assert(("Error (GPU WOP PBS): r is negative", number_of_inputs > 12);
     host_circuit_bootstrap_vertical_packing<uint64_t, int64_t, Degree<4096>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t *)lwe_array_in, (uint64_t *)lut_vector,
@@ -350,6 +355,7 @@ void cuda_circuit_bootstrap_vertical_packing_64(
         max_shared_memory);
     break;
   case 8192:
+    assert(("Error (GPU WOP PBS): r is negative", number_of_inputs > 13);
     host_circuit_bootstrap_vertical_packing<uint64_t, int64_t, Degree<8192>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t *)lwe_array_in, (uint64_t *)lut_vector,
@@ -429,6 +435,7 @@ void cuda_wop_pbs_64(void *v_stream, uint32_t gpu_index, void *lwe_array_out,
           number_of_inputs <= number_of_sm / 4. / 2. / level_count_bsk));
   switch (polynomial_size) {
   case 256:
+    assert(("Error (GPU WOP PBS): r is negative", number_of_inputs * number_of_bits_to_extract > 8);
     host_wop_pbs<uint64_t, int64_t, Degree<256>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t *)lwe_array_in, (uint64_t *)lut_vector,
@@ -441,6 +448,7 @@ void cuda_wop_pbs_64(void *v_stream, uint32_t gpu_index, void *lwe_array_out,
         max_shared_memory);
     break;
   case 512:
+    assert(("Error (GPU WOP PBS): r is negative", number_of_inputs * number_of_bits_to_extract > 9);
     host_wop_pbs<uint64_t, int64_t, Degree<512>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t *)lwe_array_in, (uint64_t *)lut_vector,
@@ -453,6 +461,8 @@ void cuda_wop_pbs_64(void *v_stream, uint32_t gpu_index, void *lwe_array_out,
         max_shared_memory);
     break;
   case 1024:
+    assert(("Error (GPU WOP PBS): r is negative", number_of_inputs * number_of_bits_to_extract > 
+    10);
     host_wop_pbs<uint64_t, int64_t, Degree<1024>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t *)lwe_array_in, (uint64_t *)lut_vector,
@@ -465,6 +475,8 @@ void cuda_wop_pbs_64(void *v_stream, uint32_t gpu_index, void *lwe_array_out,
         max_shared_memory);
     break;
   case 2048:
+    assert(("Error (GPU WOP PBS): r is negative", number_of_inputs * number_of_bits_to_extract >
+                                                  11);
     host_wop_pbs<uint64_t, int64_t, Degree<2048>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t *)lwe_array_in, (uint64_t *)lut_vector,
@@ -477,6 +489,8 @@ void cuda_wop_pbs_64(void *v_stream, uint32_t gpu_index, void *lwe_array_out,
         max_shared_memory);
     break;
   case 4096:
+    assert(("Error (GPU WOP PBS): r is negative", number_of_inputs * number_of_bits_to_extract >
+                                                  12);
     host_wop_pbs<uint64_t, int64_t, Degree<4096>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t *)lwe_array_in, (uint64_t *)lut_vector,
@@ -489,6 +503,8 @@ void cuda_wop_pbs_64(void *v_stream, uint32_t gpu_index, void *lwe_array_out,
         max_shared_memory);
     break;
   case 8192:
+    assert(("Error (GPU WOP PBS): r is negative", number_of_inputs * number_of_bits_to_extract >
+                                                  13);
     host_wop_pbs<uint64_t, int64_t, Degree<8192>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t *)lwe_array_in, (uint64_t *)lut_vector,


### PR DESCRIPTION
### Resolves: `<link_your_issue_here>`

### Description

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
