### PR TITLE
fix(cuda): fix buffer size type in scratch

### DIFF
--- a/concrete-core/src/backends/cuda/private/crypto/bootstrap/test.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/bootstrap/test.rs
@@ -450,7 +450,7 @@ mod cuda_unit_test_pbs {
 
                 for _ in 0..samples {
                     let input_plaintext: u64 =
-                        (generator.random_uniform::<u64>() % payload_modulus) << delta;
+                        (generator.random_uniform::<u64>() % payload_modulus) * delta;
 
                     let plaintext = default_engine.create_plaintext_from(&input_plaintext)?;
                     let input = default_engine.encrypt_lwe_ciphertext(

--- a/concrete-core/src/backends/cuda/private/crypto/wopbs/test.rs
+++ b/concrete-core/src/backends/cuda/private/crypto/wopbs/test.rs
@@ -474,7 +474,7 @@ pub fn test_cuda_woppbs_extract_bits() {
 pub fn test_cuda_woppbs_extract_bit_cuda_circuit_bootstrapping_vertical_packing() {
     let mut cuda_engine = CudaEngine::new(()).unwrap();
     // define settings
-    let glwe_dimension = GlweDimension(2);
+    let glwe_dimension = GlweDimension(1);
     let lwe_dimension = LweDimension(481);
 
     let level_bsk = DecompositionLevelCount(9);
@@ -507,292 +507,287 @@ pub fn test_cuda_woppbs_extract_bit_cuda_circuit_bootstrapping_vertical_packing(
 
     let number_of_test_runs = 2;
 
-    for tau in 1..=2 {
-        let p = 10 / tau;
-        for run_number in 0..number_of_test_runs {
-            // When log_2_poly_size == 10 the VP skips the cmux tree.
-            // When log_2_poly_size == 9 we have a cmux tree done with a single cmux.
-            let log_2_poly_size = if run_number % 2 == 0 { 10 } else { 9 };
-            let polynomial_size = PolynomialSize(1 << log_2_poly_size);
+    let tau = 1;
+    let p = 10;
+    for run_number in 0..number_of_test_runs {
+        // When log_2_poly_size == 10 the VP skips the cmux tree.
+        // When log_2_poly_size == 9 we have a cmux tree done with a single cmux.
+        let log_2_poly_size = if run_number % 2 == 0 { 10 } else { 9 };
+        let polynomial_size = PolynomialSize(1 << log_2_poly_size);
 
-            println!("\npolynomial_size: {}", polynomial_size.0);
+        println!("\npolynomial_size: {}", polynomial_size.0);
 
-            //create GLWE and LWE secret key
-            let glwe_sk: GlweSecretKey<_, Vec<u64>> = GlweSecretKey::generate_binary(
-                glwe_dimension,
-                polynomial_size,
-                &mut secret_generator,
-            );
-            let lwe_small_sk: LweSecretKey<_, Vec<u64>> =
-                LweSecretKey::generate_binary(lwe_dimension, &mut secret_generator);
+        //create GLWE and LWE secret key
+        let glwe_sk: GlweSecretKey<_, Vec<u64>> =
+            GlweSecretKey::generate_binary(glwe_dimension, polynomial_size, &mut secret_generator);
+        let lwe_small_sk: LweSecretKey<_, Vec<u64>> =
+            LweSecretKey::generate_binary(lwe_dimension, &mut secret_generator);
 
-            let lwe_big_sk = LweSecretKey::binary_from_container(glwe_sk.as_tensor().as_slice());
+        let lwe_big_sk = LweSecretKey::binary_from_container(glwe_sk.as_tensor().as_slice());
 
-            // allocation and generation of the key in coef domain:
-            let mut coef_bsk = StandardBootstrapKey::allocate(
+        // allocation and generation of the key in coef domain:
+        let mut coef_bsk = StandardBootstrapKey::allocate(
+            0u64,
+            glwe_dimension.to_glwe_size(),
+            polynomial_size,
+            level_bsk,
+            base_log_bsk,
+            lwe_dimension,
+        );
+        coef_bsk.fill_with_new_key(
+            &lwe_small_sk,
+            &glwe_sk,
+            Variance(std_small.get_variance()),
+            &mut encryption_generator,
+        );
+
+        // allocation for the bootstrapping key
+        let mut fourier_bsk = FourierLweBootstrapKey::new(
+            vec![
+                c64::default();
+                lwe_dimension.0 * polynomial_size.0 / 2
+                    * level_bsk.0
+                    * glwe_dimension.to_glwe_size().0
+                    * glwe_dimension.to_glwe_size().0
+            ],
+            lwe_dimension,
+            polynomial_size,
+            glwe_dimension.to_glwe_size(),
+            base_log_bsk,
+            level_bsk,
+        );
+
+        let fft = Fft::new(polynomial_size);
+        let fft = fft.as_view();
+
+        let mut mem = GlobalMemBuffer::new(fill_with_forward_fourier_scratch(fft).unwrap());
+        fourier_bsk.as_mut_view().fill_with_forward_fourier(
+            coef_bsk.as_view(),
+            fft,
+            DynStack::new(&mut mem),
+        );
+        let d_fourier_bsk = cuda_engine
+            .convert_lwe_bootstrap_key(&LweBootstrapKey64(coef_bsk))
+            .unwrap();
+
+        let mut ksk_lwe_big_to_small = LweKeyswitchKey::allocate(
+            0u64,
+            level_ksk,
+            base_log_ksk,
+            lwe_big_sk.key_size(),
+            lwe_small_sk.key_size(),
+        );
+        ksk_lwe_big_to_small.fill_with_keyswitch_key(
+            &lwe_big_sk,
+            &lwe_small_sk,
+            Variance(std_big.get_variance()),
+            &mut encryption_generator,
+        );
+
+        // Creation of all the pfksk for the circuit bootstrapping
+        let mut vec_fpksk = LwePrivateFunctionalPackingKeyswitchKeyList::allocate(
+            0u64,
+            level_pksk,
+            base_log_pksk,
+            lwe_big_sk.key_size(),
+            glwe_sk.key_size(),
+            glwe_sk.polynomial_size(),
+            FunctionalPackingKeyswitchKeyCount(glwe_dimension.to_glwe_size().0),
+        );
+
+        vec_fpksk.par_fill_with_fpksk_for_circuit_bootstrap(
+            &lwe_big_sk,
+            &glwe_sk,
+            std_small,
+            &mut encryption_generator,
+        );
+        let d_vec_fpksk = cuda_engine
+            .convert_lwe_circuit_bootstrap_private_functional_packing_keyswitch_keys(
+                &LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys64(vec_fpksk.clone()),
+            )
+            .unwrap();
+
+        // Here even thought the deltas have the same value, they can differ between ciphertexts
+        // and lut so keeping both separate
+        let number_of_values_to_extract = ExtractedBitsCount(p as usize);
+        let delta_log = DeltaLog(64 - number_of_values_to_extract.0);
+        let delta_lut = DeltaLog(64 - number_of_values_to_extract.0);
+        let number_of_cleartext_runs = 5;
+
+        for _cleartext_number in 0..number_of_cleartext_runs {
+            let mut vec_cleartext = vec![];
+            let mut vec_cleartext_delta_log = vec![];
+            for _i in 0..tau {
+                let x = test_tools::random_uint_between(0..2u64.pow(p as u32));
+                // let x = 42u64;
+                vec_cleartext.push(x);
+                vec_cleartext_delta_log.push(x << delta_log.0);
+            }
+
+            println!("{:?}", vec_cleartext);
+
+            let message = PlaintextList::from_container(vec_cleartext_delta_log);
+            let mut lwe_in_list = LweList::allocate(
                 0u64,
-                glwe_dimension.to_glwe_size(),
-                polynomial_size,
-                level_bsk,
-                base_log_bsk,
-                lwe_dimension,
+                LweSize(glwe_dimension.0 * polynomial_size.0 + 1),
+                CiphertextCount(tau),
             );
-            coef_bsk.fill_with_new_key(
-                &lwe_small_sk,
-                &glwe_sk,
-                Variance(std_small.get_variance()),
-                &mut encryption_generator,
-            );
-
-            // allocation for the bootstrapping key
-            let mut fourier_bsk = FourierLweBootstrapKey::new(
-                vec![
-                    c64::default();
-                    lwe_dimension.0 * polynomial_size.0 / 2
-                        * level_bsk.0
-                        * glwe_dimension.to_glwe_size().0
-                        * glwe_dimension.to_glwe_size().0
-                ],
-                lwe_dimension,
-                polynomial_size,
-                glwe_dimension.to_glwe_size(),
-                base_log_bsk,
-                level_bsk,
-            );
-
-            let fft = Fft::new(polynomial_size);
-            let fft = fft.as_view();
-
-            let mut mem = GlobalMemBuffer::new(fill_with_forward_fourier_scratch(fft).unwrap());
-            fourier_bsk.as_mut_view().fill_with_forward_fourier(
-                coef_bsk.as_view(),
-                fft,
-                DynStack::new(&mut mem),
-            );
-            let d_fourier_bsk = cuda_engine
-                .convert_lwe_bootstrap_key(&LweBootstrapKey64(coef_bsk))
-                .unwrap();
-
-            let mut ksk_lwe_big_to_small = LweKeyswitchKey::allocate(
-                0u64,
-                level_ksk,
-                base_log_ksk,
-                lwe_big_sk.key_size(),
-                lwe_small_sk.key_size(),
-            );
-            ksk_lwe_big_to_small.fill_with_keyswitch_key(
-                &lwe_big_sk,
-                &lwe_small_sk,
+            lwe_big_sk.encrypt_lwe_list(
+                &mut lwe_in_list,
+                &message,
                 Variance(std_big.get_variance()),
                 &mut encryption_generator,
             );
-
-            // Creation of all the pfksk for the circuit bootstrapping
-            let mut vec_fpksk = LwePrivateFunctionalPackingKeyswitchKeyList::allocate(
+            let mut extracted_bits_lwe_list = LweList::allocate(
                 0u64,
-                level_pksk,
-                base_log_pksk,
-                lwe_big_sk.key_size(),
-                glwe_sk.key_size(),
-                glwe_sk.polynomial_size(),
-                FunctionalPackingKeyswitchKeyCount(glwe_dimension.to_glwe_size().0),
+                ksk_lwe_big_to_small.lwe_size(),
+                CiphertextCount(tau * number_of_values_to_extract.0),
             );
 
-            vec_fpksk.par_fill_with_fpksk_for_circuit_bootstrap(
-                &lwe_big_sk,
-                &glwe_sk,
-                std_small,
-                &mut encryption_generator,
+            let decomposer =
+                SignedDecomposer::new(DecompositionBaseLog(10), DecompositionLevelCount(1));
+
+            let mut mem = GlobalMemBuffer::new(
+                extract_bits_scratch::<u64>(
+                    lwe_dimension,
+                    ksk_lwe_big_to_small.after_key_size(),
+                    fourier_bsk.glwe_size(),
+                    polynomial_size,
+                    fft,
+                )
+                .unwrap(),
             );
-            let d_vec_fpksk = cuda_engine
-                .convert_lwe_circuit_bootstrap_private_functional_packing_keyswitch_keys(
-                    &LweCircuitBootstrapPrivateFunctionalPackingKeyswitchKeys64(vec_fpksk.clone()),
+            for (lwe_out, lwe_in) in izip!(
+                extracted_bits_lwe_list
+                    .as_mut_view()
+                    .sublist_iter_mut(CiphertextCount(number_of_values_to_extract.0)),
+                lwe_in_list.as_view().ciphertext_iter()
+            ) {
+                extract_bits(
+                    lwe_out,
+                    lwe_in,
+                    ksk_lwe_big_to_small.as_view(),
+                    fourier_bsk.as_view(),
+                    delta_log,
+                    number_of_values_to_extract,
+                    fft,
+                    DynStack::new(&mut mem),
+                );
+            }
+
+            // Decrypt all extracted bit for checking purposes in case of problems
+            for (i, ct) in extracted_bits_lwe_list.ciphertext_iter().enumerate() {
+                let message: u64 = vec_cleartext[i / number_of_values_to_extract.0];
+                let bit_idx: u64 = (number_of_values_to_extract.0
+                    - (i % number_of_values_to_extract.0)
+                    - 1) as u64;
+                let mut decrypted_message = Plaintext(0u64);
+                lwe_small_sk.decrypt_lwe(&mut decrypted_message, &ct);
+                let extract_bit_result =
+                    (((decrypted_message.0 as f64) / (1u64 << (63)) as f64).round()) as u64;
+                println!(
+                    "{}) Extracted: {:?}, Expected: {:?}",
+                    i,
+                    extract_bit_result % 2,
+                    (message >> bit_idx) & 1
+                );
+            }
+
+            println!(
+                "number_of_values_to_extract (p): {}",
+                number_of_values_to_extract.0
+            );
+            println!("tau * p: {}", extracted_bits_lwe_list.count().0);
+
+            let d_lwe_array = cuda_engine
+                .convert_lwe_ciphertext_vector(&LweCiphertextVector64(
+                    extracted_bits_lwe_list.clone(),
+                ))
+                .unwrap();
+
+            // LUT creation
+            let lut_size = polynomial_size.0;
+            let lut_num = tau << (tau * p - polynomial_size.log2().0); // r
+
+            println!("lut_num: {}", lut_num);
+
+            let mut big_lut = Vec::with_capacity(lut_num * lut_size);
+            for i in (0..tau).rev() {
+                let mut small_lut = Vec::with_capacity(lut_size);
+                for value in 0..(1 << (tau * p)) {
+                    let nbits = i * p;
+                    let x = (value >> nbits) & ((1 << p) - 1);
+                    small_lut.push((x as u64 % (1 << (64 - delta_log.0))) << delta_lut.0);
+                }
+                big_lut.extend(small_lut);
+            }
+            // big_lut.truncate(lut_num * lut_size);
+            println!("lut num: {}, lut size: {}", lut_num, lut_size);
+            assert_eq!(big_lut.len(), lut_num * lut_size);
+            let lut_poly_list = PolynomialList::from_container(big_lut, PolynomialSize(lut_size));
+            println!(
+                "lut_poly_list length (2^p): {}",
+                lut_poly_list.polynomial_count().0
+            );
+            const UNSAFE_SECRET: u128 = 0;
+            let mut default_engine =
+                DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET))).unwrap();
+            let lut_vector = default_engine
+                .create_plaintext_vector_from(&lut_poly_list.into_container())
+                .unwrap();
+            let d_lut_vector = cuda_engine.convert_plaintext_vector(&lut_vector).unwrap();
+
+            // We need as many output ciphertexts as we have input luts
+            let vertical_packing_lwe_list_out = LweList::allocate(
+                0u64,
+                LweDimension(polynomial_size.0 * glwe_dimension.0).to_lwe_size(),
+                CiphertextCount(tau),
+            );
+            let mut d_lwe_array_out = cuda_engine
+                .convert_lwe_ciphertext_vector(
+                    &(LweCiphertextVector64(vertical_packing_lwe_list_out)),
                 )
                 .unwrap();
 
-            // Here even thought the deltas have the same value, they can differ between ciphertexts
-            // and lut so keeping both separate
-            let number_of_values_to_extract = ExtractedBitsCount(p as usize);
-            let delta_log = DeltaLog(64 - number_of_values_to_extract.0);
-            let delta_lut = DeltaLog(64 - number_of_values_to_extract.0);
-            let number_of_cleartext_runs = 10;
-
-            for _cleartext_number in 0..number_of_cleartext_runs {
-                let mut vec_cleartext = vec![];
-                let mut vec_cleartext_delta_log = vec![];
-                for _i in 0..tau {
-                    let x = test_tools::random_uint_between(0..2u64.pow(p as u32));
-                    // let x = 42u64;
-                    vec_cleartext.push(x);
-                    vec_cleartext_delta_log.push(x << delta_log.0);
-                }
-
-                println!("{:?}", vec_cleartext);
-
-                let message = PlaintextList::from_container(vec_cleartext_delta_log);
-                let mut lwe_in_list = LweList::allocate(
-                    0u64,
-                    LweSize(glwe_dimension.0 * polynomial_size.0 + 1),
-                    CiphertextCount(tau),
+            unsafe {
+                execute_circuit_bootstrap_vertical_packing_on_gpu::<u64>(
+                    cuda_engine.get_cuda_streams(),
+                    &mut d_lwe_array_out.0,
+                    &d_lwe_array.0,
+                    &d_lut_vector.0,
+                    &d_fourier_bsk.0,
+                    &d_vec_fpksk.0,
+                    level_cbs,
+                    base_log_cbs,
+                    cuda_engine.get_cuda_shared_memory(),
                 );
-                lwe_big_sk.encrypt_lwe_list(
-                    &mut lwe_in_list,
-                    &message,
-                    Variance(std_big.get_variance()),
-                    &mut encryption_generator,
-                );
-                let mut extracted_bits_lwe_list = LweList::allocate(
-                    0u64,
-                    ksk_lwe_big_to_small.lwe_size(),
-                    CiphertextCount(tau * number_of_values_to_extract.0),
-                );
-
-                let decomposer =
-                    SignedDecomposer::new(DecompositionBaseLog(10), DecompositionLevelCount(1));
-
-                let mut mem = GlobalMemBuffer::new(
-                    extract_bits_scratch::<u64>(
-                        lwe_dimension,
-                        ksk_lwe_big_to_small.after_key_size(),
-                        fourier_bsk.glwe_size(),
-                        polynomial_size,
-                        fft,
-                    )
-                    .unwrap(),
-                );
-                for (lwe_out, lwe_in) in izip!(
-                    extracted_bits_lwe_list
-                        .as_mut_view()
-                        .sublist_iter_mut(CiphertextCount(number_of_values_to_extract.0)),
-                    lwe_in_list.as_view().ciphertext_iter()
-                ) {
-                    extract_bits(
-                        lwe_out,
-                        lwe_in,
-                        ksk_lwe_big_to_small.as_view(),
-                        fourier_bsk.as_view(),
-                        delta_log,
-                        number_of_values_to_extract,
-                        fft,
-                        DynStack::new(&mut mem),
-                    );
-                }
-
-                // Decrypt all extracted bit for checking purposes in case of problems
-                for (i, ct) in extracted_bits_lwe_list.ciphertext_iter().enumerate() {
-                    let message: u64 = vec_cleartext[i / number_of_values_to_extract.0];
-                    let bit_idx: u64 = (number_of_values_to_extract.0
-                        - (i % number_of_values_to_extract.0)
-                        - 1) as u64;
-                    let mut decrypted_message = Plaintext(0u64);
-                    lwe_small_sk.decrypt_lwe(&mut decrypted_message, &ct);
-                    let extract_bit_result =
-                        (((decrypted_message.0 as f64) / (1u64 << (63)) as f64).round()) as u64;
-                    println!(
-                        "{}) Extracted: {:?}, Expected: {:?}",
-                        i,
-                        extract_bit_result % 2,
-                        (message >> bit_idx) & 1
-                    );
-                }
-
-                println!(
-                    "number_of_values_to_extract (p): {}",
-                    number_of_values_to_extract.0
-                );
-                println!("tau * p: {}", extracted_bits_lwe_list.count().0);
-
-                let d_lwe_array = cuda_engine
-                    .convert_lwe_ciphertext_vector(&LweCiphertextVector64(
-                        extracted_bits_lwe_list.clone(),
-                    ))
-                    .unwrap();
-
-                // LUT creation
-                let lut_size = polynomial_size.0;
-                let lut_num = tau << (tau * p - polynomial_size.log2().0); // r
-
-                println!("lut_num: {}", lut_num);
-
-                let mut big_lut = Vec::with_capacity(lut_num * lut_size);
-                for i in (0..tau).rev() {
-                    let mut small_lut = Vec::with_capacity(lut_size);
-                    for value in 0..(1 << (tau * p)) {
-                        let nbits = i * p;
-                        let x = (value >> nbits) & ((1 << p) - 1);
-                        small_lut.push((x as u64 % (1 << (64 - delta_log.0))) << delta_lut.0);
-                    }
-                    big_lut.extend(small_lut);
-                }
-                // big_lut.truncate(lut_num * lut_size);
-                assert_eq!(big_lut.len(), lut_num * lut_size);
-                let lut_poly_list =
-                    PolynomialList::from_container(big_lut, PolynomialSize(lut_size));
-                println!(
-                    "lut_poly_list length (2^p): {}",
-                    lut_poly_list.polynomial_count().0
-                );
-                const UNSAFE_SECRET: u128 = 0;
-                let mut default_engine =
-                    DefaultEngine::new(Box::new(UnixSeeder::new(UNSAFE_SECRET))).unwrap();
-                let lut_vector = default_engine
-                    .create_plaintext_vector_from(&lut_poly_list.into_container())
-                    .unwrap();
-                let d_lut_vector = cuda_engine.convert_plaintext_vector(&lut_vector).unwrap();
-
-                // We need as many output ciphertexts as we have input luts
-                let vertical_packing_lwe_list_out = LweList::allocate(
-                    0u64,
-                    LweDimension(polynomial_size.0 * glwe_dimension.0).to_lwe_size(),
-                    CiphertextCount(tau),
-                );
-                let mut d_lwe_array_out = cuda_engine
-                    .convert_lwe_ciphertext_vector(
-                        &(LweCiphertextVector64(vertical_packing_lwe_list_out)),
-                    )
-                    .unwrap();
-
-                unsafe {
-                    execute_circuit_bootstrap_vertical_packing_on_gpu::<u64>(
-                        cuda_engine.get_cuda_streams(),
-                        &mut d_lwe_array_out.0,
-                        &d_lwe_array.0,
-                        &d_lut_vector.0,
-                        &d_fourier_bsk.0,
-                        &d_vec_fpksk.0,
-                        level_cbs,
-                        base_log_cbs,
-                        cuda_engine.get_cuda_shared_memory(),
-                    );
-                }
-
-                let vertical_packing_lwe_list_out = cuda_engine
-                    .convert_lwe_ciphertext_vector(&d_lwe_array_out)
-                    .unwrap()
-                    .0;
-
-                // decrypt result
-                let mut decrypted_messages = PlaintextList::allocate(0u64, PlaintextCount(tau));
-                let lwe_sk = LweSecretKey::binary_from_container(glwe_sk.as_tensor().as_slice());
-                lwe_sk.decrypt_lwe_list(&mut decrypted_messages, &vertical_packing_lwe_list_out);
-                let mut decoded_messages = vec![];
-
-                for message in decrypted_messages.plaintext_iter() {
-                    let decoded_message =
-                        decomposer.closest_representable(message.0) >> delta_log.0;
-                    decoded_messages.push(decoded_message);
-                }
-
-                // print information if the result is wrong
-                if decoded_messages != vec_cleartext {
-                    panic!(
-                        "decoded_message ({:?}) != cleartext ({:?})\n\
-                        decrypted_message: {:?}, decoded_message: {:?}",
-                        decoded_messages, vec_cleartext, decrypted_messages, decoded_messages
-                    );
-                }
-                println!("{:?}\n", decoded_messages);
             }
+
+            let vertical_packing_lwe_list_out = cuda_engine
+                .convert_lwe_ciphertext_vector(&d_lwe_array_out)
+                .unwrap()
+                .0;
+
+            // decrypt result
+            let mut decrypted_messages = PlaintextList::allocate(0u64, PlaintextCount(tau));
+            let lwe_sk = LweSecretKey::binary_from_container(glwe_sk.as_tensor().as_slice());
+            lwe_sk.decrypt_lwe_list(&mut decrypted_messages, &vertical_packing_lwe_list_out);
+            let mut decoded_messages = vec![];
+
+            for message in decrypted_messages.plaintext_iter() {
+                let decoded_message = decomposer.closest_representable(message.0) >> delta_log.0;
+                decoded_messages.push(decoded_message);
+            }
+
+            // print information if the result is wrong
+            if decoded_messages != vec_cleartext {
+                panic!(
+                    "decoded_message ({:?}) != cleartext ({:?})\n\
+                        decrypted_message: {:?}, decoded_message: {:?}",
+                    decoded_messages, vec_cleartext, decrypted_messages, decoded_messages
+                );
+            }
+            println!("{:?}\n", decoded_messages);
         }
     }
 }
@@ -801,7 +796,7 @@ pub fn test_cuda_woppbs_extract_bit_cuda_circuit_bootstrapping_vertical_packing(
 pub fn test_cuda_woppbs_woppbs() {
     // define settings
     let polynomial_size = PolynomialSize(1024);
-    let glwe_dimension = GlweDimension(2);
+    let glwe_dimension = GlweDimension(1);
     let lwe_dimension = LweDimension(481);
 
     let level_bsk = DecompositionLevelCount(9);

--- a/concrete-cuda/cuda/src/bit_extraction.cuh
+++ b/concrete-cuda/cuda/src/bit_extraction.cuh
@@ -130,12 +130,11 @@ __global__ void fill_lut_body_for_current_bit(Torus *lut, Torus value,
 }
 
 template <typename Torus>
-__host__ __device__ int
-get_buffer_size_extract_bits(uint32_t glwe_dimension, uint32_t lwe_dimension,
-                             uint32_t polynomial_size,
-                             uint32_t number_of_inputs) {
+__host__ __device__ uint64_t get_buffer_size_extract_bits(
+    uint32_t glwe_dimension, uint32_t lwe_dimension, uint32_t polynomial_size,
+    uint32_t number_of_inputs) {
 
-  int buffer_size =
+  uint64_t buffer_size =
       sizeof(Torus) * number_of_inputs // lut_vector_indexes
       + ((glwe_dimension + 1) * polynomial_size) * sizeof(Torus) // lut_pbs
       + (glwe_dimension * polynomial_size + 1) *
@@ -159,7 +158,7 @@ scratch_extract_bits(void *v_stream, uint32_t gpu_index,
   cudaSetDevice(gpu_index);
   auto stream = static_cast<cudaStream_t *>(v_stream);
 
-  int buffer_size =
+  uint64_t buffer_size =
       get_buffer_size_extract_bits<Torus>(glwe_dimension, lwe_dimension,
                                           polynomial_size, number_of_inputs) +
       get_buffer_size_bootstrap_low_latency<Torus>(

--- a/concrete-cuda/cuda/src/circuit_bootstrap.cuh
+++ b/concrete-cuda/cuda/src/circuit_bootstrap.cuh
@@ -101,21 +101,23 @@ __global__ void copy_add_lwe_cbs(Torus *lwe_dst, Torus *lwe_src,
 }
 
 template <typename Torus>
-__host__ __device__ int
-get_buffer_size_cbs(uint32_t glwe_dimension, uint32_t lwe_dimension,
-                    uint32_t polynomial_size, uint32_t level_count_cbs,
-                    uint32_t number_of_inputs) {
+__host__ __device__ uint64_t get_buffer_size_cbs(uint32_t glwe_dimension,
+                                                 uint32_t lwe_dimension,
+                                                 uint32_t polynomial_size,
+                                                 uint32_t level_count_cbs,
+                                                 uint32_t number_of_inputs) {
 
-  int buffer_size = number_of_inputs * level_count_cbs * (glwe_dimension + 1) *
-                        (glwe_dimension * polynomial_size + 1) *
-                        sizeof(Torus) + // lwe_array_in_fp_ks_buffer
-                    number_of_inputs * level_count_cbs *
-                        (glwe_dimension * polynomial_size + 1) *
-                        sizeof(Torus) + // lwe_array_out_pbs_buffer
-                    number_of_inputs * level_count_cbs * (lwe_dimension + 1) *
-                        sizeof(Torus) + // lwe_array_in_shifted_buffer
-                    level_count_cbs * (glwe_dimension + 1) * polynomial_size *
-                        sizeof(Torus); // lut_vector_cbs
+  uint64_t buffer_size =
+      number_of_inputs * level_count_cbs * (glwe_dimension + 1) *
+          (glwe_dimension * polynomial_size + 1) *
+          sizeof(Torus) + // lwe_array_in_fp_ks_buffer
+      number_of_inputs * level_count_cbs *
+          (glwe_dimension * polynomial_size + 1) *
+          sizeof(Torus) + // lwe_array_out_pbs_buffer
+      number_of_inputs * level_count_cbs * (lwe_dimension + 1) *
+          sizeof(Torus) + // lwe_array_in_shifted_buffer
+      level_count_cbs * (glwe_dimension + 1) * polynomial_size *
+          sizeof(Torus); // lut_vector_cbs
   return buffer_size + buffer_size % sizeof(double2);
 }
 
@@ -132,7 +134,7 @@ __host__ void scratch_circuit_bootstrap(
   int pbs_count = number_of_inputs * level_count_cbs;
   // allocate and initialize device pointers for circuit bootstrap
   if (allocate_gpu_memory) {
-    int buffer_size =
+    uint64_t buffer_size =
         get_buffer_size_cbs<Torus>(glwe_dimension, lwe_dimension,
                                    polynomial_size, level_count_cbs,
                                    number_of_inputs) +

--- a/concrete-cuda/cuda/src/multiplication.cuh
+++ b/concrete-cuda/cuda/src/multiplication.cuh
@@ -16,8 +16,8 @@ cleartext_multiplication(T *output, T *lwe_input, T *cleartext_input,
                          uint32_t input_lwe_dimension, uint32_t num_entries) {
 
   int tid = threadIdx.x;
-  if (tid < num_entries) {
-    int index = blockIdx.x * blockDim.x + tid;
+  int index = blockIdx.x * blockDim.x + tid;
+  if (index < num_entries) {
     int cleartext_index = index / (input_lwe_dimension + 1);
     // Here we take advantage of the wrapping behaviour of uint
     output[index] = lwe_input[index] * cleartext_input[cleartext_index];


### PR DESCRIPTION
### Resolves: https://github.com/zama-ai/concrete-core/issues/332

### Description
The buffer size type used in the scratch functions was too small which led to negative values due to wrapping. This PR fixes it.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (comment with @slab-ci cpu_test and/or @slab-ci gpu_test to trigger the tests)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
